### PR TITLE
Uniformize reduction definitions

### DIFF
--- a/theories/DeclarativeInstance.v
+++ b/theories/DeclarativeInstance.v
@@ -309,9 +309,10 @@ Section Boundaries.
     induction 1 ; now eauto using boundary_ty_ctx, boundary_tm_conv_ctx.
   Qed.
 
-  Definition boundary_ored_tm_l {Γ t u A} : 
-    [ Γ |- t ⇒ u : A] ->
-    [ Γ |- t : A ].
+
+  Definition boundary_ored_l {Γ t u K} : 
+    [ Γ |- t ⇒ u ∈ K ] ->
+    match K with istype => [ Γ |- t ] | isterm A => [ Γ |- t : A ] end.
   Proof.
     induction 1.
     all: econstructor ; eauto.
@@ -319,13 +320,18 @@ Section Boundaries.
     econstructor; now eapply boundary_tm_ctx.
   Qed.
 
+  Definition boundary_ored_tm_l {Γ t u A} : 
+    [ Γ |- t ⇒ u : A] ->
+    [ Γ |- t : A ].
+  Proof.
+  apply @boundary_ored_l with (K := isterm A).
+  Qed.
+
   Definition boundary_ored_ty_l {Γ A B} : 
     [ Γ |- A ⇒ B ] ->
     [ Γ |- A ].
   Proof.
-    destruct 1.
-    econstructor.
-    now eapply boundary_ored_tm_l.
+  apply @boundary_ored_l with (K := istype).
   Qed.
 
   Definition boundary_red_tm_l {Γ t u A} : 
@@ -353,13 +359,20 @@ End Boundaries.
 
 (** ** Inclusion of the various reductions in conversion *)
 
+Definition RedConv {Γ} {t u : term} {K} :
+  [Γ |- t ⇒ u ∈ K] -> 
+  match K with istype => [Γ |- t ≅ u] | isterm A => [Γ |- t ≅ u : A] end.
+Proof.
+induction 1.
+1,4,5: now econstructor.
+all: econstructor; tea; now econstructor.
+Qed.
+
 Definition RedConvTe {Γ} {t u A : term} :
     [Γ |- t ⇒ u : A] -> 
     [Γ |- t ≅ u : A].
 Proof.
-    induction 1.
-    1,4,5: now econstructor.
-    all: econstructor; tea; now econstructor.
+apply @RedConv with (K := isterm A).
 Qed.
 
 Definition RedConvTeC {Γ} {t u A : term} :
@@ -376,8 +389,7 @@ Definition RedConvTy {Γ} {A B : term} :
     [Γ |- A ⇒ B] -> 
     [Γ |- A ≅ B].
 Proof.
-  destruct 1.
-  now econstructor ; eapply RedConvTe.
+apply @RedConv with (K := istype).
 Qed.
 
 Definition RedConvTyC {Γ} {A B : term} :
@@ -401,11 +413,12 @@ Qed.
 
 (** ** Weakenings of reduction *)
 
-Lemma oredtmdecl_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
-[|- Δ ] -> [Γ |- t ⇒ u : A] -> [Δ |- t⟨ρ⟩ ⇒ u⟨ρ⟩ : A⟨ρ⟩].
+Lemma oreddecl_wk {Γ Δ t u K} (ρ : Δ ≤ Γ) :
+  [|- Δ ] -> [Γ |- t ⇒ u ∈ K] ->
+  match K with istype => [Δ |- t⟨ρ⟩ ⇒ u⟨ρ⟩] | isterm A => [Δ |- t⟨ρ⟩ ⇒ u⟨ρ⟩ : A⟨ρ⟩] end.
 Proof.
   intros ? red.
-  induction red as [? ? ? ? ? ? Ht Ha | | | | |]; refold.
+  induction red as [? ? ? ? ? ? Ht Ha | | | | | |]; refold.
   - cbn in *.
     eapply oredtm_meta_conv.
     1: econstructor.
@@ -463,6 +476,13 @@ Proof.
   - econstructor.
     1: eassumption.
     now eapply typing_wk.
+  - now econstructor.
+Qed.
+
+Lemma oredtmdecl_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
+  [|- Δ ] -> [Γ |- t ⇒ u : A] -> [Δ |- t⟨ρ⟩ ⇒ u⟨ρ⟩ : A⟨ρ⟩].
+Proof.
+apply @oreddecl_wk with (K := isterm A).
 Qed.
 
 Lemma redtmdecl_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
@@ -478,11 +498,7 @@ Qed.
 Lemma oredtydecl_wk {Γ Δ A B} (ρ : Δ ≤ Γ) :
   [|- Δ ] -> [Γ |- A ⇒ B] -> [Δ |- A⟨ρ⟩ ⇒ B⟨ρ⟩].
 Proof.
-  intros ? red.
-  destruct red.
-  constructor.
-  change U with (U⟨ρ⟩).
-  now apply oredtmdecl_wk.
+apply @oreddecl_wk with (K := istype).
 Qed.
 
 Lemma redtydecl_wk {Γ Δ A B} (ρ : Δ ≤ Γ) :

--- a/theories/DeclarativeInstance.v
+++ b/theories/DeclarativeInstance.v
@@ -334,18 +334,26 @@ Section Boundaries.
   apply @boundary_ored_l with (K := istype).
   Qed.
 
+  Definition boundary_red_l {Γ t u K} : 
+    [ Γ |- t ⇒* u ∈ K] ->
+    match K with istype => [ Γ |- t ] | isterm A => [ Γ |- t : A ] end.
+  Proof.
+    induction 1; eauto.
+    now eapply boundary_ored_l.
+  Qed.
+
   Definition boundary_red_tm_l {Γ t u A} : 
     [ Γ |- t ⇒* u : A] ->
     [ Γ |- t : A ].
   Proof.
-    induction 1 ; eauto using boundary_ored_tm_l.
+    apply @boundary_red_l with (K := isterm A).
   Qed.
 
   Definition boundary_red_ty_l {Γ A B} : 
     [ Γ |- A ⇒* B ] ->
     [ Γ |- A ].
   Proof.
-    induction 1 ; eauto using boundary_ored_ty_l.
+    apply @boundary_red_l with (K := istype).
   Qed.
 
 End Boundaries.
@@ -375,14 +383,21 @@ Proof.
 apply @RedConv with (K := isterm A).
 Qed.
 
+Definition RedConvC {Γ} {t u : term} {K} :
+    [Γ |- t ⇒* u ∈ K] -> 
+    match K with istype => [Γ |- t ≅ u] | isterm A => [Γ |- t ≅ u : A] end.
+Proof.
+  induction 1.
+  - destruct K; now constructor.
+  - now eapply RedConv.
+  - destruct K; [now eapply TypeTrans|now eapply TermTrans].
+Qed.
+
 Definition RedConvTeC {Γ} {t u A : term} :
     [Γ |- t ⇒* u : A] -> 
     [Γ |- t ≅ u : A].
 Proof.
-  induction 1.
-  - now constructor.
-  - now eapply RedConvTe.
-  - now eapply TermTrans.
+apply @RedConvC with (K := isterm A).
 Qed.
 
 Definition RedConvTy {Γ} {A B : term} :
@@ -396,10 +411,7 @@ Definition RedConvTyC {Γ} {A B : term} :
     [Γ |- A ⇒* B] -> 
     [Γ |- A ≅ B].
 Proof.
-  induction 1.
-  - now constructor.
-  - now eapply RedConvTy.
-  - now eapply TypeTrans.
+apply @RedConvC with (K := istype).
 Qed.
 
 Lemma oredtm_meta_conv (Γ : context) (t u u' A A' : term) :

--- a/theories/Notations.v
+++ b/theories/Notations.v
@@ -133,6 +133,8 @@ Reserved Notation "[ t ⇒* t' ]" (at level 0, t, t' at level 50).
 Reserved Notation "[ Γ |- A ⇒ B ]" (at level 0, Γ, A, B at level 50).
 (** Term or type t one-step weak-head reduces to term or type type u as class A in Γ *)
 Reserved Notation "[ Γ |- t ⇒ u ∈ A ]" (at level 0, Γ, t, u, A at level 50).
+(** Term or type t multi-step weak-head reduces to term or type type u as class A in Γ *)
+Reserved Notation "[ Γ |- t ⇒* u ∈ A ]" (at level 0, Γ, t, u, A at level 50).
 (** Term t one-step weak-head reduces to term u at type A in Γ *)
 Notation "[ Γ |- t ⇒ u : A ]" := (osred_tm Γ A t u) (at level 0, Γ, t, u, A at level 50, only parsing) : typing_scope.
 Notation "[ Γ |-[ ta  ] t ⇒ u : A ]" := (osred_tm (ta:=ta) Γ A t u) (at level 0, ta,Γ, t, u, A at level 50) : typing_scope.

--- a/theories/Notations.v
+++ b/theories/Notations.v
@@ -10,6 +10,7 @@ ideally wisely in cases where there is only one instance at hand. The tagged one
 and can be used in input when disambiguation is desired. *)
 
 Variant tag := | de | al | bn | bni.
+Inductive class := istype | isterm : term -> class.
 
 Declare Scope typing_scope.
 Delimit Scope typing_scope with ty.
@@ -52,11 +53,13 @@ Notation "[ Γ |- A ]" := (wf_type Γ A)
   (at level 0, Γ, A at level 50, only parsing) : typing_scope.
 Notation "[ Γ |-[ ta  ] A ]" := (wf_type (ta := ta) Γ A)
   (at level 0, ta, Γ, A at level 50) : typing_scope.
+
 (** The term t has type A in Γ *)
 Notation "[ Γ |- t : A ]" := (typing Γ A t)
   (at level 0, Γ, t, A at level 50, only parsing) : typing_scope.
 Notation "[ Γ |-[ ta  ] t : A ]" :=
   (typing (ta := ta) Γ A t) (at level 0, ta, Γ, t, A at level 50) : typing_scope.
+
 Notation "Nf[ Γ |- A ]" := (type_nf Γ A)
   (at level 0, Γ, A at level 50, only parsing) : typing_scope.
 Notation "Nf[ Γ |-[ ta  ] A ]" := (type_nf (ta := ta) Γ A)
@@ -128,6 +131,8 @@ Reserved Notation "[ t ⇒* t' ]" (at level 0, t, t' at level 50).
 
 (** Type A one-step weak-head reduces to type B in Γ *)
 Reserved Notation "[ Γ |- A ⇒ B ]" (at level 0, Γ, A, B at level 50).
+(** Term or type t one-step weak-head reduces to term or type type u as class A in Γ *)
+Reserved Notation "[ Γ |- t ⇒ u ∈ A ]" (at level 0, Γ, t, u, A at level 50).
 (** Term t one-step weak-head reduces to term u at type A in Γ *)
 Notation "[ Γ |- t ⇒ u : A ]" := (osred_tm Γ A t u) (at level 0, Γ, t, u, A at level 50, only parsing) : typing_scope.
 Notation "[ Γ |-[ ta  ] t ⇒ u : A ]" := (osred_tm (ta:=ta) Γ A t u) (at level 0, ta,Γ, t, u, A at level 50) : typing_scope.

--- a/theories/UntypedReduction.v
+++ b/theories/UntypedReduction.v
@@ -5,22 +5,25 @@ From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakenin
 
 (** ** Reductions *)
 
-(** *** One-step reduction *)
+(** *** One-step reduction. *)
 
 Inductive OneRedAlg : term -> term -> Type :=
-    | termBetaAlg {na A t u} :
-      [ tApp (tLambda na A t) u ⇒ t[u..] ]
-    | termRedAppAlg {t t' u} :
-      [ t ⇒ t' ] ->
-      [ tApp t u ⇒ tApp t' u ]
-    | termRedNatElimAlg {P hz hs n n'} :
-        [n ⇒ n'] ->
-        [tNatElim P hz hs n ⇒ tNatElim P hz hs n']        
-    | termRedNatElimZeroAlg {P hz hs} :
-      [tNatElim P hz hs tZero ⇒ hz]
-    | termRedNatElimSuccAlg {P hz hs n} :
-      [tNatElim P hz hs (tSucc n) ⇒ tApp (tApp hs n) (tNatElim P hz hs n) ]
-  where "[ t ⇒ t' ]" := (OneRedAlg t t') : typing_scope.
+| BRed {na} {A a t} :
+    [ tApp (tLambda na A t) a ⇒ t[a..] ]
+| appSubst {t u a} :
+    [ t ⇒ u ] ->
+    [ tApp t a ⇒ tApp u a ]
+| natElimSubst {P hz hs n n'} :
+    [ n ⇒ n' ] ->
+    [ tNatElim P hz hs n ⇒ tNatElim P hz hs n' ]
+| natElimZero {P hz hs} :
+    [ tNatElim P hz hs tZero ⇒ hz ]
+| natElimSucc {P hz hs n} :
+    [ tNatElim P hz hs (tSucc n) ⇒ tApp (tApp hs n) (tNatElim P hz hs n) ]
+
+where "[ t ⇒ t' ]" := (OneRedAlg t t') : typing_scope.
+
+(* Keep in sync with OneRedTermDecl! *)
 
 (** *** Multi-step reduction *)
 


### PR DESCRIPTION
We make several uniformization steps.
- Untyped reduction now has (a subset of the) same constructors as typed reduction.
- Typed reduction (one and multi-step) is defined as a single inductive parameterized by a class istype / isterm A.