### PR TITLE
Cleanups

### DIFF
--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -15,7 +15,7 @@ Section AlgoConvConv.
   Lemma in_ctx_conv_r Γ' Γ n decl :
   [|-[de] Γ' ≅ Γ] ->
   in_ctx Γ n decl ->
-  ∑ decl', (in_ctx Γ' n decl') × ([Γ' |-[de] decl'.(decl_type) ≅ decl.(decl_type)]).
+  ∑ decl', (in_ctx Γ' n decl') × ([Γ' |-[de] decl' ≅ decl]).
   Proof.
   intros Hconv Hin.
   induction Hin in Γ', Hconv |- *.
@@ -27,8 +27,7 @@ Section AlgoConvConv.
     eapply typing_wk ; tea.
     econstructor.
     all: now boundary.
-  - destruct d as [? d].
-    edestruct IHHin as [[? d'] []].
+  - edestruct IHHin as [d'' [??]].
     1: eassumption.
     cbn in *.
     econstructor ; split.
@@ -43,7 +42,7 @@ Section AlgoConvConv.
   Lemma in_ctx_conv_l Γ' Γ n decl' :
   [|-[de] Γ' ≅ Γ] ->
   in_ctx Γ' n decl' ->
-  ∑ decl, (in_ctx Γ n decl) × ([Γ' |-[de] decl'.(decl_type) ≅ decl.(decl_type)]).
+  ∑ decl, (in_ctx Γ n decl) × ([Γ' |-[de] decl' ≅ decl]).
   Proof.
     intros ? Hin.
     eapply in_ctx_conv_r in Hin as [? []].
@@ -80,7 +79,7 @@ Section AlgoConvConv.
       1: now econstructor.
       eassumption.
     - intros * ? IHm Ht [IHt []%boundary] **.
-      edestruct IHm as [[? [? (?&?&?&[HconvP HconvA])%red_ty_compl_prod_r]] ?] ; tea.
+      edestruct IHm as [[? [? (?&?&[HconvP HconvA])%red_ty_compl_prod_r]] ?] ; tea.
       eapply redty_red, red_whnf in HconvP as ->.
       2: gen_typing.
       eexists ; split.
@@ -130,7 +129,7 @@ Section AlgoConvConv.
         all: econstructor ; tea.
         econstructor.
         all: gen_typing.
-    - intros * ? ? ? IHf ? ? ? * ? (?&?&?&[HconvP])%red_ty_compl_prod_l ?.
+    - intros * ? ? ? IHf ? ? ? * ? (?&?&[HconvP])%red_ty_compl_prod_l ?.
       eapply redty_red, red_whnf in HconvP as ->.
       2: gen_typing.
       econstructor ; tea.
@@ -266,7 +265,7 @@ Section Symmetry.
       now eapply stability.
     - intros * ? IHm ? [IHt Hwft]  **.
       edestruct IHm as [[? [IHm' Hconv]] []] ; tea ; clear IHm.
-      eapply red_ty_compl_prod_l in Hconv as (?&?&?&[Hred]).
+      eapply red_ty_compl_prod_l in Hconv as (?&?&[Hred]).
       eapply redty_red, red_whnf in Hred as ->.
       2: now eapply algo_conv_wh in IHm' as [] ; gen_typing.
       eexists ; split.
@@ -629,7 +628,7 @@ Admitted.
       + now econstructor.
       + eassumption.
   - intros *
-    [? ? ? ? ? ? Hf (?&?&?&[])%red_ty_compl_prod_r]
+    [? ? ? ? ? ? Hf (?&?&[])%red_ty_compl_prod_r]
     [? ? ? ? Ht].
     econstructor ; tea.
     + eapply conv_sound in Hf as [Hf] ; tea.
@@ -720,7 +719,7 @@ Module IntermediateTypingProperties.
       2-3: econstructor.
       1-3: assumption.
       do 2 econstructor.
-    - intros * ? ? [] [].
+    - intros * ?  [] [].
       split ; tea.
       + now econstructor.
       + econstructor ; tea.
@@ -755,7 +754,7 @@ Admitted.
         4: eassumption.
         all: now etransitivity. 
     - gen_typing.
-    - intros * ? ? [] [].
+    - intros * ? [] [].
       split ; tea.
       + now econstructor.
       + econstructor ; tea.

--- a/theories/AlgorithmicTypingProperties.v
+++ b/theories/AlgorithmicTypingProperties.v
@@ -71,7 +71,7 @@ Module AlgorithmicTypingProperties.
     - now intros * [].
     - intros * [] ; constructor; tea; now econstructor.
     - intros_bn.
-      + eapply red_ty_compl_prod_r in bun_inf_conv_conv0 as (?&?&?&[]).
+      + eapply red_ty_compl_prod_r in bun_inf_conv_conv0 as (?&?&[]).
         econstructor ; tea.
         1: econstructor.
         * econstructor ; tea.
@@ -162,7 +162,7 @@ Module AlgorithmicTypingProperties.
       + econstructor ; tea.
         2: econstructor.
         all: boundary.
-    - intros * [? ? ? (?&?&?&[])%red_ty_compl_prod_r] [].
+    - intros * [? ? ? (?&?&[])%red_ty_compl_prod_r] [].
       esplit ; tea.
       + do 2 econstructor ; tea.
         1: now eapply (redty_red (ta := de)).

--- a/theories/AutoSubst/Ast.v
+++ b/theories/AutoSubst/Ast.v
@@ -8,8 +8,8 @@ Module Core.
 Inductive term : Type :=
   | tRel : nat -> term
   | tSort : sort -> term
-  | tProd : aname -> term -> term -> term
-  | tLambda : aname -> term -> term -> term
+  | tProd : term -> term -> term
+  | tLambda : term -> term -> term
   | tApp : term -> term -> term
   | tNat : term
   | tZero : term
@@ -22,24 +22,18 @@ Proof.
 exact (eq_trans eq_refl (ap (fun x => tSort x) H0)).
 Qed.
 
-Lemma congr_tProd {s0 : aname} {s1 : term} {s2 : term} {t0 : aname}
-  {t1 : term} {t2 : term} (H0 : s0 = t0) (H1 : s1 = t1) (H2 : s2 = t2) :
-  tProd s0 s1 s2 = tProd t0 t1 t2.
+Lemma congr_tProd {s0 : term} {s1 : term} {t0 : term} {t1 : term}
+  (H0 : s0 = t0) (H1 : s1 = t1) : tProd s0 s1 = tProd t0 t1.
 Proof.
-exact (eq_trans
-         (eq_trans (eq_trans eq_refl (ap (fun x => tProd x s1 s2) H0))
-            (ap (fun x => tProd t0 x s2) H1))
-         (ap (fun x => tProd t0 t1 x) H2)).
+exact (eq_trans (eq_trans eq_refl (ap (fun x => tProd x s1) H0))
+         (ap (fun x => tProd t0 x) H1)).
 Qed.
 
-Lemma congr_tLambda {s0 : aname} {s1 : term} {s2 : term} {t0 : aname}
-  {t1 : term} {t2 : term} (H0 : s0 = t0) (H1 : s1 = t1) (H2 : s2 = t2) :
-  tLambda s0 s1 s2 = tLambda t0 t1 t2.
+Lemma congr_tLambda {s0 : term} {s1 : term} {t0 : term} {t1 : term}
+  (H0 : s0 = t0) (H1 : s1 = t1) : tLambda s0 s1 = tLambda t0 t1.
 Proof.
-exact (eq_trans
-         (eq_trans (eq_trans eq_refl (ap (fun x => tLambda x s1 s2) H0))
-            (ap (fun x => tLambda t0 x s2) H1))
-         (ap (fun x => tLambda t0 t1 x) H2)).
+exact (eq_trans (eq_trans eq_refl (ap (fun x => tLambda x s1) H0))
+         (ap (fun x => tLambda t0 x) H1)).
 Qed.
 
 Lemma congr_tApp {s0 : term} {s1 : term} {t0 : term} {t1 : term}
@@ -88,11 +82,10 @@ Fixpoint ren_term (xi_term : nat -> nat) (s : term) {struct s} : term :=
   match s with
   | tRel s0 => tRel (xi_term s0)
   | tSort s0 => tSort s0
-  | tProd s0 s1 s2 =>
-      tProd s0 (ren_term xi_term s1) (ren_term (upRen_term_term xi_term) s2)
-  | tLambda s0 s1 s2 =>
-      tLambda s0 (ren_term xi_term s1)
-        (ren_term (upRen_term_term xi_term) s2)
+  | tProd s0 s1 =>
+      tProd (ren_term xi_term s0) (ren_term (upRen_term_term xi_term) s1)
+  | tLambda s0 s1 =>
+      tLambda (ren_term xi_term s0) (ren_term (upRen_term_term xi_term) s1)
   | tApp s0 s1 => tApp (ren_term xi_term s0) (ren_term xi_term s1)
   | tNat => tNat
   | tZero => tZero
@@ -112,12 +105,12 @@ term :=
   match s with
   | tRel s0 => sigma_term s0
   | tSort s0 => tSort s0
-  | tProd s0 s1 s2 =>
-      tProd s0 (subst_term sigma_term s1)
-        (subst_term (up_term_term sigma_term) s2)
-  | tLambda s0 s1 s2 =>
-      tLambda s0 (subst_term sigma_term s1)
-        (subst_term (up_term_term sigma_term) s2)
+  | tProd s0 s1 =>
+      tProd (subst_term sigma_term s0)
+        (subst_term (up_term_term sigma_term) s1)
+  | tLambda s0 s1 =>
+      tLambda (subst_term sigma_term s0)
+        (subst_term (up_term_term sigma_term) s1)
   | tApp s0 s1 => tApp (subst_term sigma_term s0) (subst_term sigma_term s1)
   | tNat => tNat
   | tZero => tZero
@@ -145,12 +138,12 @@ subst_term sigma_term s = s :=
   match s with
   | tRel s0 => Eq_term s0
   | tSort s0 => congr_tSort (eq_refl s0)
-  | tProd s0 s1 s2 =>
-      congr_tProd (eq_refl s0) (idSubst_term sigma_term Eq_term s1)
-        (idSubst_term (up_term_term sigma_term) (upId_term_term _ Eq_term) s2)
-  | tLambda s0 s1 s2 =>
-      congr_tLambda (eq_refl s0) (idSubst_term sigma_term Eq_term s1)
-        (idSubst_term (up_term_term sigma_term) (upId_term_term _ Eq_term) s2)
+  | tProd s0 s1 =>
+      congr_tProd (idSubst_term sigma_term Eq_term s0)
+        (idSubst_term (up_term_term sigma_term) (upId_term_term _ Eq_term) s1)
+  | tLambda s0 s1 =>
+      congr_tLambda (idSubst_term sigma_term Eq_term s0)
+        (idSubst_term (up_term_term sigma_term) (upId_term_term _ Eq_term) s1)
   | tApp s0 s1 =>
       congr_tApp (idSubst_term sigma_term Eq_term s0)
         (idSubst_term sigma_term Eq_term s1)
@@ -181,14 +174,14 @@ ren_term xi_term s = ren_term zeta_term s :=
   match s with
   | tRel s0 => ap (tRel) (Eq_term s0)
   | tSort s0 => congr_tSort (eq_refl s0)
-  | tProd s0 s1 s2 =>
-      congr_tProd (eq_refl s0) (extRen_term xi_term zeta_term Eq_term s1)
+  | tProd s0 s1 =>
+      congr_tProd (extRen_term xi_term zeta_term Eq_term s0)
         (extRen_term (upRen_term_term xi_term) (upRen_term_term zeta_term)
-           (upExtRen_term_term _ _ Eq_term) s2)
-  | tLambda s0 s1 s2 =>
-      congr_tLambda (eq_refl s0) (extRen_term xi_term zeta_term Eq_term s1)
+           (upExtRen_term_term _ _ Eq_term) s1)
+  | tLambda s0 s1 =>
+      congr_tLambda (extRen_term xi_term zeta_term Eq_term s0)
         (extRen_term (upRen_term_term xi_term) (upRen_term_term zeta_term)
-           (upExtRen_term_term _ _ Eq_term) s2)
+           (upExtRen_term_term _ _ Eq_term) s1)
   | tApp s0 s1 =>
       congr_tApp (extRen_term xi_term zeta_term Eq_term s0)
         (extRen_term xi_term zeta_term Eq_term s1)
@@ -221,14 +214,14 @@ subst_term sigma_term s = subst_term tau_term s :=
   match s with
   | tRel s0 => Eq_term s0
   | tSort s0 => congr_tSort (eq_refl s0)
-  | tProd s0 s1 s2 =>
-      congr_tProd (eq_refl s0) (ext_term sigma_term tau_term Eq_term s1)
+  | tProd s0 s1 =>
+      congr_tProd (ext_term sigma_term tau_term Eq_term s0)
         (ext_term (up_term_term sigma_term) (up_term_term tau_term)
-           (upExt_term_term _ _ Eq_term) s2)
-  | tLambda s0 s1 s2 =>
-      congr_tLambda (eq_refl s0) (ext_term sigma_term tau_term Eq_term s1)
+           (upExt_term_term _ _ Eq_term) s1)
+  | tLambda s0 s1 =>
+      congr_tLambda (ext_term sigma_term tau_term Eq_term s0)
         (ext_term (up_term_term sigma_term) (up_term_term tau_term)
-           (upExt_term_term _ _ Eq_term) s2)
+           (upExt_term_term _ _ Eq_term) s1)
   | tApp s0 s1 =>
       congr_tApp (ext_term sigma_term tau_term Eq_term s0)
         (ext_term sigma_term tau_term Eq_term s1)
@@ -260,18 +253,16 @@ Fixpoint compRenRen_term (xi_term : nat -> nat) (zeta_term : nat -> nat)
   match s with
   | tRel s0 => ap (tRel) (Eq_term s0)
   | tSort s0 => congr_tSort (eq_refl s0)
-  | tProd s0 s1 s2 =>
-      congr_tProd (eq_refl s0)
-        (compRenRen_term xi_term zeta_term rho_term Eq_term s1)
+  | tProd s0 s1 =>
+      congr_tProd (compRenRen_term xi_term zeta_term rho_term Eq_term s0)
         (compRenRen_term (upRen_term_term xi_term)
            (upRen_term_term zeta_term) (upRen_term_term rho_term)
-           (up_ren_ren _ _ _ Eq_term) s2)
-  | tLambda s0 s1 s2 =>
-      congr_tLambda (eq_refl s0)
-        (compRenRen_term xi_term zeta_term rho_term Eq_term s1)
+           (up_ren_ren _ _ _ Eq_term) s1)
+  | tLambda s0 s1 =>
+      congr_tLambda (compRenRen_term xi_term zeta_term rho_term Eq_term s0)
         (compRenRen_term (upRen_term_term xi_term)
            (upRen_term_term zeta_term) (upRen_term_term rho_term)
-           (up_ren_ren _ _ _ Eq_term) s2)
+           (up_ren_ren _ _ _ Eq_term) s1)
   | tApp s0 s1 =>
       congr_tApp (compRenRen_term xi_term zeta_term rho_term Eq_term s0)
         (compRenRen_term xi_term zeta_term rho_term Eq_term s1)
@@ -309,18 +300,17 @@ subst_term tau_term (ren_term xi_term s) = subst_term theta_term s :=
   match s with
   | tRel s0 => Eq_term s0
   | tSort s0 => congr_tSort (eq_refl s0)
-  | tProd s0 s1 s2 =>
-      congr_tProd (eq_refl s0)
-        (compRenSubst_term xi_term tau_term theta_term Eq_term s1)
+  | tProd s0 s1 =>
+      congr_tProd (compRenSubst_term xi_term tau_term theta_term Eq_term s0)
         (compRenSubst_term (upRen_term_term xi_term) (up_term_term tau_term)
            (up_term_term theta_term) (up_ren_subst_term_term _ _ _ Eq_term)
-           s2)
-  | tLambda s0 s1 s2 =>
-      congr_tLambda (eq_refl s0)
-        (compRenSubst_term xi_term tau_term theta_term Eq_term s1)
+           s1)
+  | tLambda s0 s1 =>
+      congr_tLambda
+        (compRenSubst_term xi_term tau_term theta_term Eq_term s0)
         (compRenSubst_term (upRen_term_term xi_term) (up_term_term tau_term)
            (up_term_term theta_term) (up_ren_subst_term_term _ _ _ Eq_term)
-           s2)
+           s1)
   | tApp s0 s1 =>
       congr_tApp (compRenSubst_term xi_term tau_term theta_term Eq_term s0)
         (compRenSubst_term xi_term tau_term theta_term Eq_term s1)
@@ -367,18 +357,18 @@ ren_term zeta_term (subst_term sigma_term s) = subst_term theta_term s :=
   match s with
   | tRel s0 => Eq_term s0
   | tSort s0 => congr_tSort (eq_refl s0)
-  | tProd s0 s1 s2 =>
-      congr_tProd (eq_refl s0)
-        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s1)
+  | tProd s0 s1 =>
+      congr_tProd
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s0)
         (compSubstRen_term (up_term_term sigma_term)
            (upRen_term_term zeta_term) (up_term_term theta_term)
-           (up_subst_ren_term_term _ _ _ Eq_term) s2)
-  | tLambda s0 s1 s2 =>
-      congr_tLambda (eq_refl s0)
-        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s1)
+           (up_subst_ren_term_term _ _ _ Eq_term) s1)
+  | tLambda s0 s1 =>
+      congr_tLambda
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s0)
         (compSubstRen_term (up_term_term sigma_term)
            (upRen_term_term zeta_term) (up_term_term theta_term)
-           (up_subst_ren_term_term _ _ _ Eq_term) s2)
+           (up_subst_ren_term_term _ _ _ Eq_term) s1)
   | tApp s0 s1 =>
       congr_tApp
         (compSubstRen_term sigma_term zeta_term theta_term Eq_term s0)
@@ -430,18 +420,18 @@ subst_term tau_term (subst_term sigma_term s) = subst_term theta_term s :=
   match s with
   | tRel s0 => Eq_term s0
   | tSort s0 => congr_tSort (eq_refl s0)
-  | tProd s0 s1 s2 =>
-      congr_tProd (eq_refl s0)
-        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s1)
+  | tProd s0 s1 =>
+      congr_tProd
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s0)
         (compSubstSubst_term (up_term_term sigma_term)
            (up_term_term tau_term) (up_term_term theta_term)
-           (up_subst_subst_term_term _ _ _ Eq_term) s2)
-  | tLambda s0 s1 s2 =>
-      congr_tLambda (eq_refl s0)
-        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s1)
+           (up_subst_subst_term_term _ _ _ Eq_term) s1)
+  | tLambda s0 s1 =>
+      congr_tLambda
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s0)
         (compSubstSubst_term (up_term_term sigma_term)
            (up_term_term tau_term) (up_term_term theta_term)
-           (up_subst_subst_term_term _ _ _ Eq_term) s2)
+           (up_subst_subst_term_term _ _ _ Eq_term) s1)
   | tApp s0 s1 =>
       congr_tApp
         (compSubstSubst_term sigma_term tau_term theta_term Eq_term s0)
@@ -545,16 +535,14 @@ Fixpoint rinst_inst_term (xi_term : nat -> nat) (sigma_term : nat -> term)
   match s with
   | tRel s0 => Eq_term s0
   | tSort s0 => congr_tSort (eq_refl s0)
-  | tProd s0 s1 s2 =>
-      congr_tProd (eq_refl s0)
-        (rinst_inst_term xi_term sigma_term Eq_term s1)
+  | tProd s0 s1 =>
+      congr_tProd (rinst_inst_term xi_term sigma_term Eq_term s0)
         (rinst_inst_term (upRen_term_term xi_term) (up_term_term sigma_term)
-           (rinstInst_up_term_term _ _ Eq_term) s2)
-  | tLambda s0 s1 s2 =>
-      congr_tLambda (eq_refl s0)
-        (rinst_inst_term xi_term sigma_term Eq_term s1)
+           (rinstInst_up_term_term _ _ Eq_term) s1)
+  | tLambda s0 s1 =>
+      congr_tLambda (rinst_inst_term xi_term sigma_term Eq_term s0)
         (rinst_inst_term (upRen_term_term xi_term) (up_term_term sigma_term)
-           (rinstInst_up_term_term _ _ Eq_term) s2)
+           (rinstInst_up_term_term _ _ Eq_term) s1)
   | tApp s0 s1 =>
       congr_tApp (rinst_inst_term xi_term sigma_term Eq_term s0)
         (rinst_inst_term xi_term sigma_term Eq_term s1)
@@ -764,14 +752,12 @@ Fixpoint allfv_term (p_term : nat -> Prop) (s : term) {struct s} : Prop :=
   match s with
   | tRel s0 => p_term s0
   | tSort s0 => and True True
-  | tProd s0 s1 s2 =>
-      and True
-        (and (allfv_term p_term s1)
-           (and (allfv_term (upAllfv_term_term p_term) s2) True))
-  | tLambda s0 s1 s2 =>
-      and True
-        (and (allfv_term p_term s1)
-           (and (allfv_term (upAllfv_term_term p_term) s2) True))
+  | tProd s0 s1 =>
+      and (allfv_term p_term s0)
+        (and (allfv_term (upAllfv_term_term p_term) s1) True)
+  | tLambda s0 s1 =>
+      and (allfv_term p_term s0)
+        (and (allfv_term (upAllfv_term_term p_term) s1) True)
   | tApp s0 s1 =>
       and (allfv_term p_term s0) (and (allfv_term p_term s1) True)
   | tNat => True
@@ -797,18 +783,16 @@ Fixpoint allfvTriv_term (p_term : nat -> Prop) (H_term : forall x, p_term x)
   match s with
   | tRel s0 => H_term s0
   | tSort s0 => conj I I
-  | tProd s0 s1 s2 =>
-      conj I
-        (conj (allfvTriv_term p_term H_term s1)
-           (conj
-              (allfvTriv_term (upAllfv_term_term p_term)
-                 (upAllfvTriv_term_term H_term) s2) I))
-  | tLambda s0 s1 s2 =>
-      conj I
-        (conj (allfvTriv_term p_term H_term s1)
-           (conj
-              (allfvTriv_term (upAllfv_term_term p_term)
-                 (upAllfvTriv_term_term H_term) s2) I))
+  | tProd s0 s1 =>
+      conj (allfvTriv_term p_term H_term s0)
+        (conj
+           (allfvTriv_term (upAllfv_term_term p_term)
+              (upAllfvTriv_term_term H_term) s1) I)
+  | tLambda s0 s1 =>
+      conj (allfvTriv_term p_term H_term s0)
+        (conj
+           (allfvTriv_term (upAllfv_term_term p_term)
+              (upAllfvTriv_term_term H_term) s1) I)
   | tApp s0 s1 =>
       conj (allfvTriv_term p_term H_term s0)
         (conj (allfvTriv_term p_term H_term s1) I)
@@ -840,48 +824,36 @@ allfv_term p_term s -> allfv_term q_term s :=
   match s with
   | tRel s0 => fun HP => H_term s0 HP
   | tSort s0 => fun HP => conj I I
-  | tProd s0 s1 s2 =>
+  | tProd s0 s1 =>
       fun HP =>
-      conj I
+      conj
+        (allfvImpl_term p_term q_term H_term s0
+           match HP with
+           | conj HP _ => HP
+           end)
         (conj
-           (allfvImpl_term p_term q_term H_term s1
+           (allfvImpl_term (upAllfv_term_term p_term)
+              (upAllfv_term_term q_term) (upAllfvImpl_term_term H_term) s1
               match HP with
               | conj _ HP => match HP with
                              | conj HP _ => HP
                              end
-              end)
-           (conj
-              (allfvImpl_term (upAllfv_term_term p_term)
-                 (upAllfv_term_term q_term) (upAllfvImpl_term_term H_term) s2
-                 match HP with
-                 | conj _ HP =>
-                     match HP with
-                     | conj _ HP => match HP with
-                                    | conj HP _ => HP
-                                    end
-                     end
-                 end) I))
-  | tLambda s0 s1 s2 =>
+              end) I)
+  | tLambda s0 s1 =>
       fun HP =>
-      conj I
+      conj
+        (allfvImpl_term p_term q_term H_term s0
+           match HP with
+           | conj HP _ => HP
+           end)
         (conj
-           (allfvImpl_term p_term q_term H_term s1
+           (allfvImpl_term (upAllfv_term_term p_term)
+              (upAllfv_term_term q_term) (upAllfvImpl_term_term H_term) s1
               match HP with
               | conj _ HP => match HP with
                              | conj HP _ => HP
                              end
-              end)
-           (conj
-              (allfvImpl_term (upAllfv_term_term p_term)
-                 (upAllfv_term_term q_term) (upAllfvImpl_term_term H_term) s2
-                 match HP with
-                 | conj _ HP =>
-                     match HP with
-                     | conj _ HP => match HP with
-                                    | conj HP _ => HP
-                                    end
-                     end
-                 end) I))
+              end) I)
   | tApp s0 s1 =>
       fun HP =>
       conj
@@ -964,50 +936,36 @@ allfv_term (funcomp p_term xi_term) s :=
   match s with
   | tRel s0 => fun H => H
   | tSort s0 => fun H => conj I I
-  | tProd s0 s1 s2 =>
+  | tProd s0 s1 =>
       fun H =>
-      conj I
+      conj
+        (allfvRenL_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
         (conj
-           (allfvRenL_term p_term xi_term s1
-              match H with
-              | conj _ H => match H with
-                            | conj H _ => H
-                            end
-              end)
-           (conj
-              (allfvImpl_term _ _ (upAllfvRenL_term_term p_term xi_term) s2
-                 (allfvRenL_term (upAllfv_term_term p_term)
-                    (upRen_term_term xi_term) s2
-                    match H with
-                    | conj _ H =>
-                        match H with
-                        | conj _ H => match H with
-                                      | conj H _ => H
-                                      end
-                        end
-                    end)) I))
-  | tLambda s0 s1 s2 =>
+           (allfvImpl_term _ _ (upAllfvRenL_term_term p_term xi_term) s1
+              (allfvRenL_term (upAllfv_term_term p_term)
+                 (upRen_term_term xi_term) s1
+                 match H with
+                 | conj _ H => match H with
+                               | conj H _ => H
+                               end
+                 end)) I)
+  | tLambda s0 s1 =>
       fun H =>
-      conj I
+      conj
+        (allfvRenL_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
         (conj
-           (allfvRenL_term p_term xi_term s1
-              match H with
-              | conj _ H => match H with
-                            | conj H _ => H
-                            end
-              end)
-           (conj
-              (allfvImpl_term _ _ (upAllfvRenL_term_term p_term xi_term) s2
-                 (allfvRenL_term (upAllfv_term_term p_term)
-                    (upRen_term_term xi_term) s2
-                    match H with
-                    | conj _ H =>
-                        match H with
-                        | conj _ H => match H with
-                                      | conj H _ => H
-                                      end
-                        end
-                    end)) I))
+           (allfvImpl_term _ _ (upAllfvRenL_term_term p_term xi_term) s1
+              (allfvRenL_term (upAllfv_term_term p_term)
+                 (upRen_term_term xi_term) s1
+                 match H with
+                 | conj _ H => match H with
+                               | conj H _ => H
+                               end
+                 end)) I)
   | tApp s0 s1 =>
       fun H =>
       conj
@@ -1087,52 +1045,36 @@ allfv_term p_term (ren_term xi_term s) :=
   match s with
   | tRel s0 => fun H => H
   | tSort s0 => fun H => conj I I
-  | tProd s0 s1 s2 =>
+  | tProd s0 s1 =>
       fun H =>
-      conj I
+      conj
+        (allfvRenR_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
         (conj
-           (allfvRenR_term p_term xi_term s1
-              match H with
-              | conj _ H => match H with
-                            | conj H _ => H
-                            end
-              end)
-           (conj
-              (allfvRenR_term (upAllfv_term_term p_term)
-                 (upRen_term_term xi_term) s2
-                 (allfvImpl_term _ _ (upAllfvRenR_term_term p_term xi_term)
-                    s2
-                    match H with
-                    | conj _ H =>
-                        match H with
-                        | conj _ H => match H with
-                                      | conj H _ => H
-                                      end
-                        end
-                    end)) I))
-  | tLambda s0 s1 s2 =>
+           (allfvRenR_term (upAllfv_term_term p_term)
+              (upRen_term_term xi_term) s1
+              (allfvImpl_term _ _ (upAllfvRenR_term_term p_term xi_term) s1
+                 match H with
+                 | conj _ H => match H with
+                               | conj H _ => H
+                               end
+                 end)) I)
+  | tLambda s0 s1 =>
       fun H =>
-      conj I
+      conj
+        (allfvRenR_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
         (conj
-           (allfvRenR_term p_term xi_term s1
-              match H with
-              | conj _ H => match H with
-                            | conj H _ => H
-                            end
-              end)
-           (conj
-              (allfvRenR_term (upAllfv_term_term p_term)
-                 (upRen_term_term xi_term) s2
-                 (allfvImpl_term _ _ (upAllfvRenR_term_term p_term xi_term)
-                    s2
-                    match H with
-                    | conj _ H =>
-                        match H with
-                        | conj _ H => match H with
-                                      | conj H _ => H
-                                      end
-                        end
-                    end)) I))
+           (allfvRenR_term (upAllfv_term_term p_term)
+              (upRen_term_term xi_term) s1
+              (allfvImpl_term _ _ (upAllfvRenR_term_term p_term xi_term) s1
+                 match H with
+                 | conj _ H => match H with
+                               | conj H _ => H
+                               end
+                 end)) I)
   | tApp s0 s1 =>
       fun H =>
       conj

--- a/theories/AutoSubst/Extra.v
+++ b/theories/AutoSubst/Extra.v
@@ -49,9 +49,9 @@ Arguments ren1 {_ _ _}%type_scope {Ren1} _ !_/.
 Arguments Ren_term _ _ /.
 Arguments Ren1_subst {_ _ _} _ _/.
 
-Notation arr A B := (tProd anDummy A B⟨↑⟩).
-Notation comp A f g := (tLambda anDummy A (tApp f⟨↑⟩ (tApp g⟨↑⟩ (tRel 0)))).
-Notation idterm A  := (tLambda anDummy A (tRel 0)).
+Notation arr A B := (tProd A B⟨↑⟩).
+Notation comp A f g := (tLambda A (tApp f⟨↑⟩ (tApp g⟨↑⟩ (tRel 0)))).
+Notation idterm A  := (tLambda A (tRel 0)).
 
 Lemma arr_ren1 {A B} : forall ρ, (arr A B)⟨ρ⟩ = arr A⟨ρ⟩ B⟨ρ⟩.
 Proof.

--- a/theories/AutoSubst/PiUniv.sig
+++ b/theories/AutoSubst/PiUniv.sig
@@ -1,11 +1,10 @@
 sort : Type
-aname : Type
 term : Type
 
 tSort : sort -> term
 
-tProd : aname -> term -> (bind term in term) -> term
-tLambda : aname -> term -> (bind term in term) -> term
+tProd : term -> (bind term in term) -> term
+tLambda : term -> (bind term in term) -> term
 tApp : term -> term -> term
 
 tNat : term

--- a/theories/BasicAst.v
+++ b/theories/BasicAst.v
@@ -2,11 +2,5 @@
 From Coq Require Import String Bool.
 From LogRel.AutoSubst Require Import core unscoped.
 
-Record aname := { nNamed : string }.
-
-Definition anDummy := {| nNamed := "" |}.
-
-Definition eq_binder_annot (a a' : aname) := True.
-
 Inductive sort :=
   | set : sort.

--- a/theories/BundledAlgorithmicTyping.v
+++ b/theories/BundledAlgorithmicTyping.v
@@ -324,11 +324,11 @@ Section BundledConv.
       | ?T => (pre_cond T)
     end.
 
-  (* Eval cbn beta in ltac:(let T := strong_step (forall (Γ : context) (na na' : aname) (A B A' B' : term),
+  (* Eval cbn beta in ltac:(let T := strong_step (forall (Γ : context) (na' : aname) (A B A' B' : term),
     [Γ |-[ al ] A ≅ A'] ->
     PTyEq Γ A A' ->
-    [Γ,, vass na A |-[ al ] B ≅ B'] ->
-    PTyEq (Γ,, vass na A) B B' -> PTyRedEq Γ (tProd na A B) (tProd na' A' B')) in exact T).
+    [Γ,, A |-[ al ] B ≅ B'] ->
+    PTyEq (Γ,, A) B B' -> PTyRedEq Γ (tProd A B) (tProd na' A' B')) in exact T).
   *)
 
   #[local] Ltac weak_concl concl :=
@@ -384,7 +384,7 @@ Section BundledConv.
       now econstructor.
     - intros * ? IHA ? IHB ? HP HP'.
       eapply prod_ty_inv in HP as [], HP' as [? HB'].
-      assert [Γ,, vass na A |-[de] B'].
+      assert [Γ,, A |-[de] B'].
       { eapply stability ; tea.
         econstructor.
         1: now eapply ctx_refl.
@@ -430,8 +430,8 @@ Section BundledConv.
     - intros * ? IHm ? IHt ? Htym Htyn.
       pose proof Htym as [? Htym'].
       pose proof Htyn as [? Htyn'].
-      eapply termGen' in Htym' as [? [(?&?&?&[-> Htym' ]) ?]].
-      eapply termGen' in Htyn' as [? [(?&?&?&[-> Htyn' ]) ?]].
+      eapply termGen' in Htym' as [? [[? [? [-> Htym']]] ?]].
+      eapply termGen' in Htyn' as [? [[? [? [-> Htyn']]] ?]].
       edestruct IHm as [? [IHmc IHm' IHn']].
       1: easy.
       1-2: now econstructor.
@@ -444,13 +444,13 @@ Section BundledConv.
       split.
       + econstructor ; gen_typing.
       + intros ? Happ.
-        eapply termGen' in Happ as [? [(?&?&?&[-> Htym']) ?]].
+        eapply termGen' in Happ as [? [(?&?&[-> Htym']) ?]].
         eapply IHm', prod_ty_inj in Htym' as [].
         etransitivity ; [..|eassumption].
         eapply typing_subst1 ; tea.
         now econstructor.
       + intros ? Happ.
-        eapply termGen' in Happ as [? [(?&?&?&[-> Htyn']) ?]].
+        eapply termGen' in Happ as [? [(?&?&[-> Htyn']) ?]].
         eapply IHn', prod_ty_inj in Htyn' as [HA ?].
         etransitivity ; [..|eassumption].
         eapply typing_subst1.
@@ -499,7 +499,7 @@ Section BundledConv.
       pose proof (Htyd' := Hty').
       eapply termGen' in Htyd as [? [[->] _]].
       eapply termGen' in Htyd' as [? [[->] _]].
-      assert [Γ,, vass na A |-[de] B' : U].
+      assert [Γ,, A |-[de] B' : U].
       { eapply stability ; tea.
         econstructor.
         1: now eapply ctx_refl.

--- a/theories/Context.v
+++ b/theories/Context.v
@@ -6,71 +6,19 @@ From LogRel Require Import Utils BasicAst.
 Set Primitive Projections.
 
 (** ** Context declaration *)
+(** Context: list of declarations *)
+(** Terms use de Bruijn indices to refer to context entries.*)
 
-(** The name is just a printing annotation: terms use de Bruijn indices to refer to context entries.*)
+Definition context := list term.
 
-Record context_decl := mkdecl {
-  decl_name : aname ;
-  decl_type : term
-}.
-
-Definition map_decl (f : term -> term) : context_decl -> context_decl :=
-  fun d => {| decl_name := d.(decl_name) ; decl_type := f d.(decl_type) |}.
-
-Lemma map_decl_id (f : term -> term) : f =1 id -> map_decl f =1 id.
-Proof.
-  intros Hf [a t].
-  cbv.
-  f_equal.
-  now apply Hf.
-Qed.
-
-Lemma compose_map_decl f g x :
-  map_decl f (map_decl g x) = map_decl (g >> f) x.
-Proof.
-  destruct x; reflexivity.
-Qed.
-
-Lemma map_decl_ext f g x : (forall x, f x = g x) -> map_decl f x = map_decl g x.
-Proof.
-  intros H; destruct x; rewrite /map_decl /=; f_equal; auto.
-Qed.
-
-#[global] Instance map_decl_proper : Proper (`=1` ==> Logic.eq ==> Logic.eq) map_decl.
-Proof.
-  intros f g Hfg x y ->. now apply map_decl_ext.
-Qed.
-
-#[global] Instance map_decl_pointwise : Proper (`=1` ==> `=1`) map_decl.
-Proof. intros f g Hfg x. rewrite /map_decl.
-  destruct x => /=. f_equal.
-  now rewrite Hfg.
-Qed.
-
-Arguments map_decl _ !_/.
-
-#[global] Instance Ren_decl : (Ren1 (nat -> nat) context_decl context_decl) :=
-  fun ρ t => map_decl (ren_term ρ) t.
-
-Arguments Ren_decl _ !_/.
-
-Ltac fold_ren_decl := change Ren_decl with ren1 in *.
-Smpl Add fold_ren_decl : refold.
-
-Definition vass a A := {| decl_name := a ; decl_type := A |}.
-
-(** ** Context: list of declarations *)
-
-Definition context := list context_decl.
-
-Notation "'ε'" := (@nil context_decl).
-Notation " Γ ,, d " := (@cons context_decl d Γ) (at level 20, d at next level).
-Notation " Γ ,,, Δ " := (@app context_decl Δ Γ) (at level 25, Δ at next level, left associativity).
+Notation "'ε'" := (@nil term).
+Notation " Γ ,, d " := (@cons term d Γ) (at level 20, d at next level).
+Notation " Γ ,,, Δ " := (@app term Δ Γ) (at level 25, Δ at next level, left associativity).
 
 (** States that a definition, correctly weakened, is in a context. *)
-Inductive in_ctx : context -> nat -> context_decl -> Type :=
+Inductive in_ctx : context -> nat -> term -> Type :=
   | in_here (Γ : context) d : in_ctx (Γ,,d) 0 (d⟨↑⟩)
-  | in_there (Γ : context) d d' n : in_ctx Γ n d -> in_ctx (Γ,,d') (S n) (map_decl (ren_term shift) d).
+  | in_there (Γ : context) d d' n : in_ctx Γ n d -> in_ctx (Γ,,d') (S n) (ren_term shift d).
 
 Lemma in_ctx_inj Γ n decl decl' :
   in_ctx Γ n decl -> in_ctx Γ n decl' -> decl = decl'.

--- a/theories/DeclarativeInstance.v
+++ b/theories/DeclarativeInstance.v
@@ -430,7 +430,7 @@ Lemma oreddecl_wk {Γ Δ t u K} (ρ : Δ ≤ Γ) :
   match K with istype => [Δ |- t⟨ρ⟩ ⇒ u⟨ρ⟩] | isterm A => [Δ |- t⟨ρ⟩ ⇒ u⟨ρ⟩ : A⟨ρ⟩] end.
 Proof.
   intros ? red.
-  induction red as [? ? ? ? ? ? Ht Ha | | | | | |]; refold.
+  induction red as [| | | | | |]; refold.
   - cbn in *.
     eapply oredtm_meta_conv.
     1: econstructor.

--- a/theories/DeclarativeInstance.v
+++ b/theories/DeclarativeInstance.v
@@ -19,16 +19,16 @@ this implication. *)
 
 Definition termGenData (Γ : context) (t T : term) : Type :=
   match t with
-    | tRel n => ∑ decl, [× T = decl.(decl_type), [|- Γ]& in_ctx Γ n decl]
-    | tProd na A B =>  [× T = U, [Γ |- A : U] & [Γ,, vass na A |- B : U]]
-    | tLambda na A t => ∑ B, [× T = tProd na A B, [Γ |- A] & [Γ,, vass na A |- t : B]]
-    | tApp f a => ∑ na A B, [× T = B[a..], [Γ |- f : tProd na A B] & [Γ |- a : A]]
+    | tRel n => ∑ decl, [× T = decl, [|- Γ]& in_ctx Γ n decl]
+    | tProd A B =>  [× T = U, [Γ |- A : U] & [Γ,, A |- B : U]]
+    | tLambda A t => ∑ B, [× T = tProd A B, [Γ |- A] & [Γ,, A |- t : B]]
+    | tApp f a => ∑ A B, [× T = B[a..], [Γ |- f : tProd A B] & [Γ |- a : A]]
     | tSort _ => False
     | tNat => T = U
     | tZero => T = tNat
     | tSucc n => T = tNat × [Γ |- n : tNat]
-    | tNatElim P hz hs n =>
-      ∑ nN, [× T = P[n..], [Γ,, vass nN tNat |- P], [Γ |- hz : P[tZero..]], [Γ |- hs : elimSuccHypTy nN P] & [Γ |- n : tNat]]
+    |  tNatElim P hz hs n =>
+      [× T = P[n..], [Γ,, tNat |- P], [Γ |- hz : P[tZero..]], [Γ |- hs : elimSuccHypTy P] & [Γ |- n : tNat]]
   end.
 
 Ltac prod_splitter :=
@@ -58,9 +58,9 @@ Proof.
     * prod_splitter; tea; right; now eapply TypeTrans.
 Qed.
 
-Lemma prod_ty_inv Γ na A B :
-  [Γ |- tProd na A B] ->
-  [Γ |- A] × [Γ,, vass na A |- B].
+Lemma prod_ty_inv Γ A B :
+  [Γ |- tProd A B] ->
+  [Γ |- A] × [Γ,, A |- B].
 Proof.
   intros Hty.
   inversion Hty ; subst ; clear Hty.
@@ -71,7 +71,7 @@ Qed.
 
 (** ** Stability by weakening *)
 
-Lemma subst_ren_wk_up {Γ Δ P nA A} {ρ : Γ ≤ Δ}: forall n, P[n..]⟨ρ⟩ = P⟨wk_up nA A ρ⟩[n⟨ρ⟩..].
+Lemma subst_ren_wk_up {Γ Δ P A} {ρ : Γ ≤ Δ}: forall n, P[n..]⟨ρ⟩ = P⟨wk_up A ρ⟩[n⟨ρ⟩..].
 Proof. intros; now bsimpl. Qed.
 
 
@@ -97,10 +97,10 @@ Section TypingWk.
     - trivial.
     - intros ? ? IH.
       now econstructor.
-    - intros Γ na A B HA IHA HB IHB Δ ρ HΔ.
+    - intros Γ A B HA IHA HB IHB Δ ρ HΔ.
       econstructor ; fold ren_term.
       1: now eapply IHA.
-      eapply IHB with (ρ := wk_up _ _ ρ).
+      eapply IHB with (ρ := wk_up _ ρ).
       now constructor.
     - intros; now constructor.
     - intros * _ IHA ? * ?.
@@ -115,14 +115,14 @@ Section TypingWk.
       cbn.
       econstructor.
       1: now eapply IHA.
-      eapply IHB with (ρ := wk_up _ _ ρ).
+      eapply IHB with (ρ := wk_up _ ρ).
       econstructor ; tea.
       econstructor.
       now eapply IHA.
     - intros * _ IHA _ IHt ? ρ ?.
       econstructor.
       1: now eapply IHA.
-      eapply IHt with (ρ := wk_up _ _ ρ).
+      eapply IHt with (ρ := wk_up _ ρ).
       econstructor ; tea.
       now eapply IHA.
     - intros * _ IHf _ IHu ? ρ ?.
@@ -151,12 +151,12 @@ Section TypingWk.
       econstructor.
       1: now eapply IHt.
       now eapply IHAB.
-    - intros Γ ? ? A A' B B' _ IHA _ IHAA' _ IHBB' ? ρ ?.
+    - intros Γ A A' B B' _ IHA _ IHAA' _ IHBB' ? ρ ?.
       cbn.
       econstructor.
       + now eapply IHA.
       + now eapply IHAA'.
-      + eapply IHBB' with (ρ := wk_up _ _ ρ).
+      + eapply IHBB' with (ρ := wk_up _ ρ).
         econstructor ; tea.
         now eapply IHA.
     - intros * _ IHA ? ρ ?.
@@ -171,26 +171,26 @@ Section TypingWk.
       eapply TypeTrans.
       + now eapply IHA.
       + now eapply IHB.
-    - intros Γ ? u t A B _ IHA _ IHt _ IHu ? ρ ?.
+    - intros Γ u t A B _ IHA _ IHt _ IHu ? ρ ?.
       cbn.
       eapply convtm_meta_conv.
       1: econstructor.
       + now eapply IHA.
-      + eapply IHt with (ρ := wk_up _ _ ρ).
+      + eapply IHt with (ρ := wk_up _ ρ).
         econstructor ; tea.
         now eapply IHA.
       + now eapply IHu.
       + now asimpl.
       + now asimpl. 
-    - intros Γ ? ? A A' B B' _ IHA _ IHAA' _ IHBB' ? ρ ?.
+    - intros Γ A A' B B' _ IHA _ IHAA' _ IHBB' ? ρ ?.
       cbn.
       econstructor.
       + now eapply IHA.
       + now eapply IHAA'.
-      + eapply IHBB' with (ρ := wk_up _ _ ρ).
+      + eapply IHBB' with (ρ := wk_up _ ρ).
         pose (IHA _ ρ H).
         econstructor; tea; now econstructor.
-    - intros Γ ? u u' f f' A B _ IHf _ IHu ? ρ ?.
+    - intros Γ u u' f f' A B _ IHf _ IHu ? ρ ?.
       cbn.
       red in IHf.
       cbn in IHf.
@@ -200,15 +200,15 @@ Section TypingWk.
       + now eapply IHu.
       + now asimpl.
       + now asimpl.
-    - intros Γ ? ? f f' A B _ IHA _ IHf _ IHg _ IHe ? ρ ?.
+    - intros Γ f f' A B _ IHA _ IHf _ IHg _ IHe ? ρ ?.
       cbn.
       econstructor.
       1-3: easy.
-      specialize (IHe _ (wk_up _ _ ρ)).
+      specialize (IHe _ (wk_up _ ρ)).
       cbn in IHe.
-      bsimpl.
       repeat rewrite renRen_term in IHe.
       cbn in * ; refold.
+      bsimpl.
       eapply IHe.
       econstructor ; tea.
       now eapply IHA.
@@ -271,12 +271,12 @@ by substitution and injectivity of type constructors, which we get from the logi
 Section Boundaries.
   Import DeclarativeTypingData.
 
-  Definition boundary_ctx_ctx {Γ na A} : [|- Γ,, vass na A] -> [|- Γ].
+  Definition boundary_ctx_ctx {Γ A} : [|- Γ,, A] -> [|- Γ].
   Proof.
     now inversion 1.
   Qed.
 
-  Definition boundary_ctx_tip {Γ na A} : [|- Γ,, vass na A] -> [Γ |- A].
+  Definition boundary_ctx_tip {Γ A} : [|- Γ,, A] -> [Γ |- A].
   Proof.
     now inversion 1.
   Qed.
@@ -435,7 +435,7 @@ Proof.
     eapply oredtm_meta_conv.
     1: econstructor.
     + now eapply typing_wk.
-    + eapply typing_wk with (ρ := wk_up _ _ ρ) ; tea.
+    + eapply typing_wk with (ρ := wk_up _ ρ) ; tea.
       econstructor ; tea.
       now eapply typing_wk.
     + now eapply typing_wk.
@@ -449,9 +449,9 @@ Proof.
     + now asimpl.
     + reflexivity.
   - cbn. erewrite subst_ren_wk_up.
-    eapply (@natElimSubst _ nN); tea.
+    eapply natElimSubst; tea.
     * erewrite <- wk_up_ren_on.
-      refine (fst (snd typing_wk) _ _ w _ (wk_up _ _ ρ) _). 
+      refine (fst (snd typing_wk) _ _ w _ (wk_up _ ρ) _). 
       constructor; tea; now constructor.
     * eapply typing_meta_conv.
       1: now eapply typing_wk.
@@ -461,9 +461,9 @@ Proof.
       unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
     Unshelve. all: tea.
   - cbn. erewrite subst_ren_wk_up.
-    eapply (@natElimZero _ nN); tea.
+    eapply natElimZero; tea.
     * erewrite <- wk_up_ren_on.
-      refine (fst (snd typing_wk) _ _ w _ (wk_up _ _ ρ) _). 
+      refine (fst (snd typing_wk) _ _ w _ (wk_up _ ρ) _). 
       constructor; tea; now constructor.
     * eapply typing_meta_conv.
       1: now eapply typing_wk.
@@ -473,9 +473,9 @@ Proof.
       unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
     Unshelve. all: tea.
   - cbn. erewrite subst_ren_wk_up.
-    eapply (@natElimSucc _ nN).
+    eapply natElimSucc.
     * erewrite <- wk_up_ren_on.
-      refine (fst (snd typing_wk) _ _ w _ (wk_up _ _ ρ) _). 
+      refine (fst (snd typing_wk) _ _ w _ (wk_up _ ρ) _). 
       constructor; tea; now constructor.
     * eapply typing_meta_conv.
       1: now eapply typing_wk.
@@ -525,13 +525,13 @@ Qed.
 
 (** ** Derived rules for multi-step reduction *)
 
-Lemma redtmdecl_app Γ na A B f f' t :
-  [ Γ |- f ⇒* f' : tProd na A B ] ->
+Lemma redtmdecl_app Γ A B f f' t :
+  [ Γ |- f ⇒* f' : tProd A B ] ->
   [ Γ |- t : A ] ->
   [ Γ |- tApp f t ⇒* tApp f' t : B[t..] ].
 Proof.
   intros Hf ?.
-  remember (tProd na A B) as T in *.
+  remember (tProd A B) as T in *.
   induction Hf.
   + subst.
     now do 2 econstructor.

--- a/theories/DeclarativeTyping.v
+++ b/theories/DeclarativeTyping.v
@@ -11,8 +11,8 @@ or typing, done in a declarative fashion. For instance, we _demand_ that convers
 be transitive by adding a corresponding rule. *)
 
 (** ** Definitions *)
-Definition elimSuccHypTy nN' P :=
-  tProd nN' tNat (arr P P[tSucc (tRel 0)]⇑).
+Definition elimSuccHypTy P :=
+  tProd tNat (arr P P[tSucc (tRel 0)]⇑).
 
 Section Definitions.
 
@@ -27,19 +27,19 @@ Section Definitions.
   (** **** Context well-formation *)
   Inductive WfContextDecl : context -> Type :=
       | connil : [ |- ε ]
-      | concons {Γ na A} : 
+      | concons {Γ A} : 
           [ |- Γ ] -> 
           [ Γ |- A ] -> 
-          [ |-  Γ ,, vass na A]
+          [ |-  Γ ,, A]
   (** **** Type well-formation *)
   with WfTypeDecl  : context -> term -> Type :=
       | wfTypeU {Γ} : 
           [ |- Γ ] -> 
           [ Γ |- U ] 
-      | wfTypeProd {Γ} {na : aname} {A B} : 
+      | wfTypeProd {Γ} {A B} : 
           [ Γ |- A ] -> 
-          [Γ ,, (vass na A) |- B ] -> 
-          [ Γ |- tProd na A B ]
+          [Γ ,, (A) |- B ] -> 
+          [ Γ |- tProd A B ]
       | wfTypeNat {Γ} : 
           [|- Γ] ->
           [Γ |- tNat]
@@ -51,17 +51,17 @@ Section Definitions.
       | wfVar {Γ} {n decl} :
           [   |- Γ ] ->
           in_ctx Γ n decl ->
-          [ Γ |- tRel n : decl.(decl_type) ]
-      | wfTermProd {Γ} {na} {A B} :
+          [ Γ |- tRel n : decl ]
+      | wfTermProd {Γ} {A B} :
           [ Γ |- A : U] -> 
-          [Γ ,, (vass na A) |- B : U ] ->
-          [ Γ |- tProd na A B : U ]
-      | wfTermLam {Γ} {na} {A B t} :
+          [Γ ,, (A) |- B : U ] ->
+          [ Γ |- tProd A B : U ]
+      | wfTermLam {Γ} {A B t} :
           [ Γ |- A ] ->        
-          [ Γ ,, vass na A |- t : B ] -> 
-          [ Γ |- tLambda na A t : tProd na A B]
-      | wfTermApp {Γ} {na} {f a A B} :
-          [ Γ |- f : tProd na A B ] -> 
+          [ Γ ,, A |- t : B ] -> 
+          [ Γ |- tLambda A t : tProd A B]
+      | wfTermApp {Γ} {f a A B} :
+          [ Γ |- f : tProd A B ] -> 
           [ Γ |- a : A ] -> 
           [ Γ |- tApp f a : B[a..] ]
       | wfTermNat {Γ} :
@@ -73,10 +73,10 @@ Section Definitions.
       | wfTermSucc {Γ n} :
           [Γ |- n : tNat] ->
           [Γ |- tSucc n : tNat]
-      | wfTermNatElim {Γ nN P hz hs n} :
-        [Γ ,, vass nN tNat |- P ] ->
+      | wfTermNatElim {Γ P hz hs n} :
+        [Γ ,, tNat |- P ] ->
         [Γ |- hz : P[tZero..]] ->
-        [Γ |- hs : elimSuccHypTy nN P] ->
+        [Γ |- hs : elimSuccHypTy P] ->
         [Γ |- n : tNat] ->
         [Γ |- tNatElim P hz hs n : P[n..]]
       | wfTermConv {Γ} {t A B} :
@@ -85,11 +85,11 @@ Section Definitions.
           [ Γ |- t : B ]
   (** **** Conversion of types *)
   with ConvTypeDecl : context -> term -> term  -> Type :=  
-      | TypePiCong {Γ} {na nb} {A B C D} :
+      | TypePiCong {Γ} {A B C D} :
           [ Γ |- A] ->
           [ Γ |- A ≅ B] ->
-          [ Γ ,, vass na A |- C ≅ D] ->
-          [ Γ |- tProd na A C ≅ tProd nb B D]
+          [ Γ ,, A |- C ≅ D] ->
+          [ Γ |- tProd A C ≅ tProd B D]
       | TypeRefl {Γ} {A} : 
           [ Γ |- A ] ->
           [ Γ |- A ≅ A]
@@ -105,44 +105,44 @@ Section Definitions.
           [ Γ |- A ≅ C]
   (** **** Conversion of terms *)
   with ConvTermDecl : context -> term -> term -> term -> Type :=
-      | TermBRed {Γ} {na} {a t A B} :
+      | TermBRed {Γ} {a t A B} :
               [ Γ |- A ] ->
-              [ Γ ,, vass na A |- t : B ] ->
+              [ Γ ,, A |- t : B ] ->
               [ Γ |- a : A ] ->
-              [ Γ |- tApp (tLambda na A t) a ≅ t[a..] : B[a..] ]
-      | TermPiCong {Γ} {na nb } {A B C D} :
+              [ Γ |- tApp (tLambda A t) a ≅ t[a..] : B[a..] ]
+      | TermPiCong {Γ} {A B C D} :
           [ Γ |- A : U] ->
           [ Γ |- A ≅ B : U ] ->
-          [ Γ ,, vass na A |- C ≅ D : U ] ->
-          [ Γ |- tProd na A C ≅ tProd nb B D : U ]
-      | TermAppCong {Γ} {na} {a b f g A B} :
-          [ Γ |- f ≅ g : tProd na A B ] ->
+          [ Γ ,, A |- C ≅ D : U ] ->
+          [ Γ |- tProd A C ≅ tProd B D : U ]
+      | TermAppCong {Γ} {a b f g A B} :
+          [ Γ |- f ≅ g : tProd A B ] ->
           [ Γ |- a ≅ b : A ] ->
           [ Γ |- tApp f a ≅ tApp g b : B[a..] ]
-      | TermFunExt {Γ} {na nb} {f g A B} :
+      | TermFunExt {Γ} {f g A B} :
           [ Γ |- A ] ->
-          [ Γ |- f : tProd na A B ] ->
-          [ Γ |- g : tProd nb A B ] ->
-          [ Γ ,, vass na A |- eta_expand f ≅ eta_expand g : B ] ->
-          [ Γ |- f ≅ g : tProd na A B ]
+          [ Γ |- f : tProd A B ] ->
+          [ Γ |- g : tProd A B ] ->
+          [ Γ ,, A |- eta_expand f ≅ eta_expand g : B ] ->
+          [ Γ |- f ≅ g : tProd A B ]
       | TermSuccCong {Γ} {n n'} :
           [Γ |- n ≅ n' : tNat] ->
           [Γ |- tSucc n ≅ tSucc n' : tNat]
-      | TermNatElimCong {Γ nN P P' hz hz' hs hs' n n'} :
-          [Γ ,, vass nN tNat |- P ≅ P'] ->
+      | TermNatElimCong {Γ P P' hz hz' hs hs' n n'} :
+          [Γ ,, tNat |- P ≅ P'] ->
           [Γ |- hz ≅ hz' : P[tZero..]] ->
-          [Γ |- hs ≅ hs' : elimSuccHypTy nN P] ->
+          [Γ |- hs ≅ hs' : elimSuccHypTy P] ->
           [Γ |- n ≅ n' : tNat] ->
           [Γ |- tNatElim P hz hs n ≅ tNatElim P' hz' hs' n' : P[n..]]        
-      | TermNatElimZero {Γ nN P hz hs} :
-          [Γ ,, vass nN tNat |- P ] ->
+      | TermNatElimZero {Γ P hz hs} :
+          [Γ ,, tNat |- P ] ->
           [Γ |- hz : P[tZero..]] ->
-          [Γ |- hs : elimSuccHypTy nN P] ->
+          [Γ |- hs : elimSuccHypTy P] ->
           [Γ |- tNatElim P hz hs tZero ≅ hz : P[tZero..]]
-      | TermNatElimSucc {Γ nN P hz hs n} :
-          [Γ ,, vass nN tNat |- P ] ->
+      | TermNatElimSucc {Γ P hz hs n} :
+          [Γ ,, tNat |- P ] ->
           [Γ |- hz : P[tZero..]] ->
-          [Γ |- hs : elimSuccHypTy nN P] ->
+          [Γ |- hs : elimSuccHypTy P] ->
           [Γ |- n : tNat] ->
           [Γ |- tNatElim P hz hs (tSucc n) ≅ tApp (tApp hs n) (tNatElim P hz hs n) : P[(tSucc n)..]]
       | TermRefl {Γ} {t A} :
@@ -172,30 +172,30 @@ Section Definitions.
   Local Coercion isterm : term >-> class.
 
   Inductive OneRedDecl (Γ : context) : class -> term -> term -> Type :=
-  | BRed {na} {A B : term} {a t} :
+  | BRed {A B : term} {a t} :
       [ Γ |- A ] -> 
-      [ Γ ,, vass na A |- t : B ] ->
+      [ Γ ,, A |- t : B ] ->
       [ Γ |- a : A ] ->
-      [ Γ |- tApp (tLambda na A t) a ⇒ t[a..] : B[a..] ]
-  | appSubst {na A B t u a} :
-      [ Γ |- t ⇒ u : tProd na A B] ->
+      [ Γ |- tApp (tLambda A t) a ⇒ t[a..] : B[a..] ]
+  | appSubst {A B t u a} :
+      [ Γ |- t ⇒ u : tProd A B] ->
       [ Γ |- a : A ] ->
       [ Γ |- tApp t a ⇒ tApp u a : B[a..] ]
-  | natElimSubst {nN P hz hs n n'} :
-      [Γ ,, vass nN tNat |- P] ->
+  | natElimSubst {P hz hs n n'} :
+      [Γ ,, tNat |- P] ->
       [Γ |- hz : P[tZero..]] ->
-      [Γ |- hs : elimSuccHypTy nN P] ->
+      [Γ |- hs : elimSuccHypTy P] ->
       [Γ |- n ⇒ n' : tNat] ->
-      [Γ |- tNatElim P hz hs n ⇒ tNatElim P hz hs n' : P[n..]]
-  | natElimZero {nN P hz hs} :
-      [Γ ,, vass nN tNat |- P ] ->
+      [Γ |- tNatElim P hz hs n ⇒ tNatElim P hz hs n' : P[n..]]        
+  | natElimZero {P hz hs} :
+      [Γ ,, tNat |- P ] ->
       [Γ |- hz : P[tZero..]] ->
-      [Γ |- hs : elimSuccHypTy nN P] ->
+      [Γ |- hs : elimSuccHypTy P] ->
       [Γ |- tNatElim P hz hs tZero ⇒ hz : P[tZero..]]
-  | natElimSucc {nN P hz hs n} :
-      [Γ ,, vass nN tNat |- P ] ->
+  | natElimSucc {P hz hs n} :
+      [Γ ,, tNat |- P ] ->
       [Γ |- hz : P[tZero..]] ->
-      [Γ |- hs : elimSuccHypTy nN P] ->
+      [Γ |- hs : elimSuccHypTy P] ->
       [Γ |- n : tNat] ->
       [Γ |- tNatElim P hz hs (tSucc n) ⇒ tApp (tApp hs n) (tNatElim P hz hs n) : P[(tSucc n)..]]
   | termRedConv {A B : term} {t u} :

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -797,6 +797,34 @@ Section GenericConsequences.
     eapply redtm_one_step; gen_typing.
   Qed.
 
+  Lemma rtc_osredtm_redtm {Γ A x y} :
+    reflTransClos (osred_tm Γ A) x y ->
+    [Γ |- y : A] ->
+    [Γ |- x ⇒* y : A].
+  Proof.
+    intros r ?; induction r.
+    + now eapply redtm_refl.
+    + intros. etransitivity.
+      2: now eapply IHr.
+      now eapply redtm_one_step.
+  Qed.
+
+  Lemma rtc_osredtm_redtmwf {Γ A x y} :
+    reflTransClos (osred_tm Γ A) x y ->
+    [Γ |- y : A] ->
+    [Γ |- x :⇒*: y : A].
+  Proof.
+    intros reds yty.
+    pose proof (rtc_osredtm_redtm reds yty).
+    constructor; tea; gen_typing.
+  Qed.
+
+  Lemma osredtm_ty_src {Γ t u A} : [Γ |- t ⇒ u : A] -> [Γ |- t : A].
+  Proof.
+    intros ?%redtm_one_step; gen_typing.
+  Qed.
+
+
   (** *** Derived typing, reduction and conversion judgements *)
 
   Lemma ty_var0 {Γ A} : 

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -276,13 +276,12 @@ Module PiRedTy.
     `{WfContext ta} `{WfType ta} `{ConvType ta} `{RedType ta}
     {Γ : context} {A : term}
   : Type (* @ max(Set, i+1) *) := {
-    na : aname ;
     dom : term ;
     cod : term ;
-    red : [Γ |- A :⇒*: tProd na dom cod];
+    red : [Γ |- A :⇒*: tProd dom cod];
     domTy : [Γ |- dom];
-    codTy : [Γ ,, vass na dom |- cod];
-    eq : [Γ |- tProd na dom cod ≅ tProd na dom cod];
+    codTy : [Γ ,, dom |- cod];
+    eq : [Γ |- tProd dom cod ≅ tProd dom cod];
     domRed {Δ} (ρ : Δ ≤ Γ) : [ |- Δ ] -> LRPack@{i} Δ dom⟨ρ⟩ ;
     codRed {Δ} {a} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
         [ (domRed ρ h) |  Δ ||- a : dom⟨ρ⟩] ->
@@ -326,11 +325,10 @@ Module PiRedTyEq.
     `{WfType ta} `{ConvType ta} `{RedType ta}
     {Γ : context} {A B : term} {ΠA : PiRedTy Γ A}
   : Type := {
-    na : aname ;
     dom : term;
     cod : term;
-    red : [Γ |- B :⇒*: tProd na dom cod];
-    eq  : [Γ |- tProd ΠA.(PiRedTy.na) ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ≅ tProd na dom cod ];
+    red : [Γ |- B :⇒*: tProd dom cod];
+    eq  : [Γ |- tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ≅ tProd dom cod ];
     domRed {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
       [ (ΠA.(PiRedTy.domRed) ρ h) | Δ ||- ΠA.(PiRedTy.dom)⟨ρ⟩ ≅ dom⟨ρ⟩ ];
     codRed {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
@@ -353,10 +351,10 @@ Module PiRedTm.
     {Γ : context} {t A : term} {ΠA : PiRedTy Γ A}
   : Type := {
     nf : term;
-    red : [ Γ |- t :⇒*: nf : tProd ΠA.(PiRedTy.na) ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
+    red : [ Γ |- t :⇒*: nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
     isfun : isFun nf;
-    isnf  : Nf[Γ |- nf : tProd ΠA.(PiRedTy.na) ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod)];
-    refl : [ Γ |- nf ≅ nf : tProd ΠA.(PiRedTy.na) ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
+    isnf  : Nf[Γ |- nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod)];
+    refl : [ Γ |- nf ≅ nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
     app {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
       (ha : [ (ΠA.(PiRedTy.domRed) ρ h) | Δ ||- a : ΠA.(PiRedTy.dom)⟨ρ⟩ ])
       : [(ΠA.(PiRedTy.codRed) ρ h ha) | Δ ||- tApp nf⟨ρ⟩ a : ΠA.(PiRedTy.cod)[a .: (ρ >> tRel)]] ;
@@ -383,7 +381,7 @@ Module PiRedTmEq.
   : Type := {
     redL : [ Γ ||-Π t : A | ΠA ] ;
     redR : [ Γ ||-Π u : A | ΠA ] ;
-    eq : [ Γ |- redL.(PiRedTm.nf) ≅ redR.(PiRedTm.nf) : tProd ΠA.(PiRedTy.na) ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
+    eq : [ Γ |- redL.(PiRedTm.nf) ≅ redR.(PiRedTm.nf) : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
     eqApp {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
       (ha : [(ΠA.(PiRedTy.domRed) ρ h) | Δ ||- a : ΠA.(PiRedTy.dom)⟨ρ⟩ ] )
       : [ ( ΠA.(PiRedTy.codRed) ρ h ha) | Δ ||-
@@ -716,13 +714,12 @@ Section PiRedTyPack.
 
   Record PiRedTyPack@{i j k l} {Γ : context} {A : term} {l : TypeLevel} 
     : Type@{l} := {
-      na : aname ;
       dom : term ;
       cod : term ;
-      red : [Γ |- A :⇒*: tProd na dom cod];
+      red : [Γ |- A :⇒*: tProd dom cod];
       domTy : [Γ |- dom];
-      codTy : [Γ ,, vass na dom |- cod];
-      eq : [Γ |- tProd na dom cod ≅ tProd na dom cod];
+      codTy : [Γ ,, dom |- cod];
+      eq : [Γ |- tProd dom cod ≅ tProd dom cod];
       domRed {Δ} (ρ : Δ ≤ Γ) : [ |- Δ ] -> [ LogRel@{i j k l} l | Δ ||- dom⟨ρ⟩ ] ;
       codRed {Δ} {a} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
           [ (domRed ρ h) |  Δ ||- a : dom⟨ρ⟩] ->
@@ -743,8 +740,8 @@ Section PiRedTyPack.
     (ΠAad : PiRedTyAdequate (LogRel@{i j k l} l) ΠA) 
     : PiRedTyPack@{i j k l} Γ A l.
   Proof.
-    destruct ΠA as [na dom cod]; destruct ΠAad; cbn in *.
-    unshelve econstructor; [eassumption| exact dom| exact cod|..].
+    destruct ΠA as [dom cod]; destruct ΠAad; cbn in *.
+    unshelve econstructor; [exact dom| exact cod|..].
     3-6: assumption.
     * intros; econstructor; now unshelve apply domAd.
     * intros; econstructor; now unshelve apply codAd.
@@ -754,8 +751,8 @@ Section PiRedTyPack.
   Definition toPiRedTy@{i j k l} {Γ A l} (ΠA : PiRedTyPack@{i j k l} Γ A l) :
     PiRedTy@{k} Γ A.
   Proof.
-    destruct ΠA as [na dom cod ???? domRed codRed codExt].
-    unshelve econstructor; [assumption|exact dom|exact cod|..].
+    destruct ΠA as [dom cod ???? domRed codRed codExt].
+    unshelve econstructor; [exact dom|exact cod|..].
     3-6: assumption.
     * intros; now eapply domRed.
     * intros; now eapply codRed.
@@ -765,7 +762,7 @@ Section PiRedTyPack.
   Definition toPiRedTyAd@{i j k l} {Γ A l} (ΠA : PiRedTyPack@{i j k l} Γ A l) :
     PiRedTyAdequate (LogRel@{i j k l} l) (toPiRedTy ΠA).
   Proof.
-    destruct ΠA as [na dom cod ???? domRed codRed ?].
+    destruct ΠA as [dom cod ???? domRed codRed ?].
     unshelve econstructor; cbn; intros; [eapply domRed|eapply codRed].
   Defined.  
 
@@ -788,11 +785,11 @@ Section PiRedTyPack.
     LRbuild (LRPi (LogRelRec l) _ (toPiRedTyAd ΠA)).
 
   Definition prod@{i j k l} {l Γ A} (ΠA : PiRedTyPack@{i j k l} Γ A l) : term :=
-    tProd (na ΠA) (dom ΠA) (cod ΠA).
+    tProd (dom ΠA) (cod ΠA).
 
   Lemma whne_noΠ `{!RedTypeProperties} {Γ A} : [Γ ||-Πd A] -> whne A -> False.
   Proof.
-    intros [??? r] h.
+    intros [?? r] h.
     pose proof (UntypedReduction.red_whne _ _ (redtywf_red r) h).
     subst; inversion h.
   Qed.

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -792,8 +792,8 @@ Section PiRedTyPack.
 
   Lemma whne_noΠ `{!RedTypeProperties} {Γ A} : [Γ ||-Πd A] -> whne A -> False.
   Proof.
-    intros [??? [?? r]] h.
-    pose proof (UntypedReduction.red_whne _ _ (redty_red r) h).
+    intros [??? r] h.
+    pose proof (UntypedReduction.red_whne _ _ (redtywf_red r) h).
     subst; inversion h.
   Qed.
 

--- a/theories/LogicalRelation/Application.v
+++ b/theories/LogicalRelation/Application.v
@@ -15,10 +15,10 @@ Context `{GenericTypingProperties}.
 Set Printing Primitive Projection Parameters.
 
 Section AppTerm.
-  Context {Γ t u nF F G l l' l''}
-    (hΠ : [Γ ||-Π<l> tProd nF F G])
+  Context {Γ t u F G l l' l''}
+    (hΠ : [Γ ||-Π<l> tProd F G])
     {RF : [Γ ||-<l'> F]}
-    (Rt : [Γ ||-<l> t : tProd nF F G | LRPi' (normRedΠ0 hΠ)])
+    (Rt : [Γ ||-<l> t : tProd F G | LRPi' (normRedΠ0 hΠ)])
     (Ru : [Γ ||-<l'> u : F | RF])
     (RGu : [Γ ||-<l''> G[u..]]).
 
@@ -46,10 +46,10 @@ Section AppTerm.
 
 End AppTerm.
 
-Lemma appTerm {Γ t u nF F G l}
-  (RΠ : [Γ ||-<l> tProd nF F G])
+Lemma appTerm {Γ t u F G l}
+  (RΠ : [Γ ||-<l> tProd F G])
   {RF : [Γ ||-<l> F]}
-  (Rt : [Γ ||-<l> t : tProd nF F G | RΠ])
+  (Rt : [Γ ||-<l> t : tProd F G | RΠ])
   (Ru : [Γ ||-<l> u : F | RF])
   (RGu : [Γ ||-<l> G[u..]]) : 
   [Γ ||-<l> tApp t u : G[u..]| RGu].
@@ -57,14 +57,15 @@ Proof.
   unshelve eapply appTerm0.
   7:irrelevance.
   3: exact (invLRΠ RΠ).
-  all: eassumption.
+  all: tea.
+  irrelevance.
 Qed.
 
 
-Lemma appcongTerm {Γ t t' u u' nF F G l l'}
-  (RΠ : [Γ ||-<l> tProd nF F G]) 
+Lemma appcongTerm {Γ t t' u u' F G l l'}
+  (RΠ : [Γ ||-<l> tProd F G]) 
   {RF : [Γ ||-<l'> F]}
-  (Rtt' : [Γ ||-<l> t ≅ t' : tProd nF F G | RΠ])
+  (Rtt' : [Γ ||-<l> t ≅ t' : tProd F G | RΠ])
   (Ru : [Γ ||-<l'> u : F | RF])
   (Ru' : [Γ ||-<l'> u' : F | RF])
   (Ruu' : [Γ ||-<l'> u ≅ u' : F | RF ])
@@ -73,11 +74,11 @@ Lemma appcongTerm {Γ t t' u u' nF F G l l'}
     [Γ ||-<l'> tApp t u ≅ tApp t' u' : G[u..] | RGu].
 Proof.
   set (hΠ := invLRΠ RΠ); pose (RΠ' := LRPi' (normRedΠ0 hΠ)).
-  assert [Γ ||-<l> t ≅ t' : tProd nF F G | RΠ'] as [Rt Rt' ? eqApp] by irrelevance.
+  assert [Γ ||-<l> t ≅ t' : tProd F G | RΠ'] as [Rt Rt' ? eqApp] by irrelevance.
   set (h := invLRΠ _) in hΠ.
   epose proof (e := redtywf_whnf (PiRedTyPack.red h) whnf_tProd); 
   symmetry in e; injection e; clear e; 
-  destruct h as [??????? domRed codRed codExt] ; clear RΠ Rtt'; 
+  destruct h as [?????? domRed codRed codExt] ; clear RΠ Rtt'; 
   intros; cbn in *; subst. 
   assert (wfΓ : [|-Γ]) by gen_typing.
   assert [Γ ||-<l> u' : F⟨@wk_id Γ⟩ | domRed _ (@wk_id Γ) wfΓ] by irrelevance.

--- a/theories/LogicalRelation/Induction.v
+++ b/theories/LogicalRelation/Induction.v
@@ -232,12 +232,12 @@ Section Inversions.
         1-3: inv_whne.
         now eexists.
     - intros ??? PiA _ _ A' red whA.
-      enough (∑ na dom cod, A' = tProd na cod dom) as (?&?&?&->).
+      enough (∑ dom cod, A' = tProd cod dom) as (?&?&->).
       + dependent inversion whA ; subst.
         2: exfalso ; gen_typing.
         assumption.
-      + destruct PiA as [??? redA].
-        do 3 eexists.
+      + destruct PiA as [?? redA].
+        do 2 eexists.
         eapply whred_det.
         1-3: gen_typing.
         eapply redty_red, redA.
@@ -262,7 +262,7 @@ Section Inversions.
     now unshelve eapply  (invLR _ redIdAlg (NeType _)).
   Qed.
 
-  Lemma invLRΠ {Γ l na dom cod} : [Γ ||-<l> tProd na dom cod] -> [Γ ||-Π<l> tProd na dom cod].
+  Lemma invLRΠ {Γ l dom cod} : [Γ ||-<l> tProd dom cod] -> [Γ ||-Π<l> tProd dom cod].
   Proof.
     intros.
     now unshelve eapply  (invLR _ redIdAlg ProdType).

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -295,8 +295,8 @@ Proof.
   - destruct lrA' as [| | ? A' ΠA' HAad'|] ; try solve [destruct s] ; clear s.
     pose (PA := PiRedTyPack.pack ΠA HAad).
     pose (PA' := PiRedTyPack.pack ΠA' HAad').
-    destruct he as [na0 dom0 cod0 ?? domRed codRed], ΠA' as [na1 dom1 cod1];
-    assert (tProd na0 dom0 cod0 = tProd na1 dom1 cod1) as ePi
+    destruct he as [dom0 cod0 ?? domRed codRed], ΠA' as [dom1 cod1];
+    assert (tProd dom0 cod0 = tProd dom1 cod1) as ePi
     by (eapply whredty_det ; gen_typing).
     inversion ePi ; subst ; clear ePi.
     eapply (ΠIrrelevanceLRPack PA PA').
@@ -323,7 +323,7 @@ Proof.
   - eapply LRne_. exact neA.
   - cbn in *. eapply LRPi'. unshelve econstructor.
     6: eassumption.
-    3,4,5: tea.
+    4,5,6: tea.
     + exact IHdom.
     + intros Δ a ρ tΔ ra. eapply IHcod.
       destruct (LRIrrelevantPreds IH Δ (dom⟨ρ⟩) (dom⟨ρ⟩)

--- a/theories/LogicalRelation/Neutral.v
+++ b/theories/LogicalRelation/Neutral.v
@@ -37,7 +37,7 @@ Proof.
   clear l Γ K h.
   - intros ??? [??? r] ne; pose proof (redtywf_whne r  ne); subst; inversion ne.
   - intros; assumption.
-  - intros ??? [??? red] ?? ne ; cbn in *.
+  - intros ??? [?? red] ?? ne ; cbn in *.
     rewrite (redtywf_whne red ne) in ne.
     inversion ne.
   - intros ??? [red] ne.
@@ -62,38 +62,37 @@ Proof.
   all: cbn; assumption.
 Qed.
 
-Lemma ty_app_ren {Γ Δ A f a na dom cod} (ρ : Δ ≤ Γ) :
-  [Γ |- f : A] -> [Γ |- A ≅ tProd na dom cod] -> [Δ |- a : dom⟨ρ⟩] -> [Δ |- tApp f⟨ρ⟩ a : cod[a .: ρ >> tRel]].
+Lemma ty_app_ren {Γ Δ A f a dom cod} (ρ : Δ ≤ Γ) :
+  [Γ |- f : A] -> [Γ |- A ≅ tProd dom cod] -> [Δ |- a : dom⟨ρ⟩] -> [Δ |- tApp f⟨ρ⟩ a : cod[a .: ρ >> tRel]].
 Proof.
   intros.
-  replace (cod[a .: ρ >> tRel]) with (cod⟨wk_up na dom ρ⟩[a..]) by (now bsimpl).
-  unshelve eapply ty_app. 1,4: eassumption.
-  replace (tProd _ _ _) with (tProd na dom cod)⟨ρ⟩ by now bsimpl.
+  replace (cod[a .: ρ >> tRel]) with (cod⟨wk_up dom ρ⟩[a..]) by (now bsimpl).
+  unshelve eapply ty_app. 3: eassumption.
+  replace (tProd _ _) with (tProd dom cod)⟨ρ⟩ by now bsimpl.
   gen_typing.
 Qed.
 
-Lemma convneu_app_ren {Γ Δ A f g a b na dom cod} (ρ : Δ ≤ Γ) :
+Lemma convneu_app_ren {Γ Δ A f g a b dom cod} (ρ : Δ ≤ Γ) :
   [Γ |- f ~ g : A] ->
-  [Γ |- A ≅ tProd na dom cod] ->
+  [Γ |- A ≅ tProd dom cod] ->
   [Δ |- a ≅ b : dom⟨ρ⟩] ->
   [Δ |- tApp f⟨ρ⟩ a ~ tApp g⟨ρ⟩ b : cod[a .: ρ >> tRel]].
 Proof.
   intros.
-  replace (cod[a .: ρ >> tRel]) with (cod⟨wk_up na dom ρ⟩[a..]) by (now bsimpl).
-  unshelve eapply convneu_app. 1,4: eassumption.
-  replace (tProd _ _ _) with (tProd na dom cod)⟨ρ⟩ by now bsimpl.
+  replace (cod[a .: ρ >> tRel]) with (cod⟨wk_up dom ρ⟩[a..]) by (now bsimpl).
+  unshelve eapply convneu_app. 3: eassumption.
+  replace (tProd _ _) with (tProd dom cod)⟨ρ⟩ by now bsimpl.
   gen_typing.
 Qed.
 
-Lemma neu_app_ren {Γ Δ A n a na dom cod} (ρ : Δ ≤ Γ) :
+Lemma neu_app_ren {Γ Δ A n a dom cod} (ρ : Δ ≤ Γ) :
   [|- Δ] ->
-  Ne[Γ |- n : A] -> [Γ |- A ≅ tProd na dom cod] -> Nf[Δ |- a : dom⟨ρ⟩] -> Ne[Δ |- tApp n⟨ρ⟩ a : cod[a .: ρ >> tRel]].
+  Ne[Γ |- n : A] -> [Γ |- A ≅ tProd dom cod] -> Nf[Δ |- a : dom⟨ρ⟩] -> Ne[Δ |- tApp n⟨ρ⟩ a : cod[a .: ρ >> tRel]].
 Proof.
   intros.
-  replace (cod[a .: ρ >> tRel]) with (cod⟨wk_up na dom ρ⟩[a..]) by (now bsimpl).
+  replace (cod[a .: ρ >> tRel]) with (cod⟨wk_up dom ρ⟩[a..]) by (now bsimpl).
   eapply tm_ne_app; [|eassumption].
-  instantiate (1 := na).
-  change (Ne[Δ |- n⟨ρ⟩ : (tProd na dom cod)⟨ρ⟩]).
+  change (Ne[Δ |- n⟨ρ⟩ : (tProd dom cod)⟨ρ⟩]).
   eapply tm_ne_conv; [|now eapply convty_wk].
   now eapply tm_ne_wk.
 Qed.
@@ -169,9 +168,9 @@ Lemma complete_Pi : forall l Γ A (RA : [Γ ||-Π< l > A]),
   complete (LRPi' RA).
 Proof.
 intros l Γ A ΠA0 ihdom ihcod; split.
-- set (ΠA := ΠA0); destruct ΠA0 as [na dom cod].
+- set (ΠA := ΠA0); destruct ΠA0 as [dom cod].
   simpl in ihdom, ihcod.
-  assert [Γ |- A ≅ tProd na dom cod] by gen_typing.
+  assert [Γ |- A ≅ tProd dom cod] by gen_typing.
   unshelve refine ( let funred : forall n, Ne[Γ |- n : A] -> [Γ |- n : A] -> [Γ |- n ~ n : A] -> [Γ ||-Π n : A | PiRedTyPack.toPiRedTy ΠA] := _ in _).
   {
     intros. exists n; cbn.
@@ -217,8 +216,8 @@ intros l Γ A ΠA0 ihdom ihcod; split.
     + eapply convneu_app_ren. 1,2: eassumption.
     eapply escapeEqTerm; eapply LREqTermRefl_; eassumption.
 - intros a [a' Hr Ha].
-  destruct ΠA0 as [na dom codom]; simpl in *.
-  assert ([Γ |- tProd na dom codom ≅ A ]) by gen_typing.
+  destruct ΠA0 as [dom codom]; simpl in *.
+  assert ([Γ |- tProd dom codom ≅ A ]) by gen_typing.
   eapply tm_nf_conv; [|eassumption].
   eapply tm_nf_red; [now apply tmr_wf_red|].
   assumption.
@@ -279,13 +278,13 @@ Proof.
   intros; now eapply completeness.
 Qed.
 
-Lemma var0 {l Γ A A'} nA (RA : [Γ ,, vass nA A ||-<l> A']) :
+Lemma var0 {l Γ A A'} (RA : [Γ ,, A ||-<l> A']) :
   A⟨↑⟩ = A' ->
   [Γ |- A] ->
-  [Γ ,, vass nA A ||-<l> tRel 0 : A' | RA].
+  [Γ ,, A ||-<l> tRel 0 : A' | RA].
 Proof.
   intros <- HA.
-  assert [Γ ,, vass nA A |- tRel 0 : A⟨↑⟩]
+  assert [Γ ,, A |- tRel 0 : A⟨↑⟩]
   by (escape; eapply (ty_var (wfc_wft EscRA) (in_here _ _))).
   eapply neuTerm; tea.
   - now eapply tm_ne_rel.
@@ -315,17 +314,17 @@ induction HRA.
   - specialize (IHdom _ wk_id tΓ (PiRedTy.domRed _ _ tΓ) tΓ).
     rewrite wk_id_ren_on in IHdom; apply IHdom.
   - destruct ΠA ; destruct HAad ; cbn in *.
-    pose (Δ := Γ ,, vass na dom).
+    pose (Δ := Γ ,, dom).
     assert (tΔ : wf_context Δ) by (now apply wfc_cons).
-    unshelve epose (rdom := _ : [ Γ ,, vass na dom ||-< l > dom⟨@wk1 Γ na dom⟩ ]).
-    { econstructor. exact (domAd (Γ,, vass na dom) (@wk1 Γ na dom) tΔ). }
-    specialize (IHcodom _ (tRel 0) (wk1 na dom) tΔ).
-    replace cod with (cod[tRel 0 .: @wk1 Γ na dom >> tRel]).
+    unshelve epose (rdom := _ : [ Γ ,, dom ||-< l > dom⟨@wk1 Γ dom⟩ ]).
+    { econstructor. exact (domAd (Γ,, dom) (@wk1 Γ dom) tΔ). }
+    specialize (IHcodom _ (tRel 0) (wk1 dom) tΔ).
+    replace cod with (cod[tRel 0 .: @wk1 Γ dom >> tRel]).
     eapply IHcodom.
-    * change ([ Γ ,, vass na dom ||-< l > tRel 0 : dom⟨@wk1 Γ na dom⟩ | rdom ]).
+    * change ([ Γ ,, dom ||-< l > tRel 0 : dom⟨@wk1 Γ dom⟩ | rdom ]).
       eapply var0; [|eassumption]. now bsimpl.
     * unshelve eapply codRed. eassumption.
-      change ([ Γ ,, vass na dom ||-< l > tRel 0 : dom⟨@wk1 Γ na dom⟩ | rdom ]).
+      change ([ Γ ,, dom ||-< l > tRel 0 : dom⟨@wk1 Γ dom⟩ | rdom ]).
       eapply var0; [|eassumption]. now bsimpl.
     * eassumption.
     * bsimpl ; rewrite scons_eta' ; now bsimpl.

--- a/theories/LogicalRelation/NormalRed.v
+++ b/theories/LogicalRelation/NormalRed.v
@@ -10,30 +10,29 @@ Context `{GenericTypingProperties}.
 
 Set Printing Primitive Projection Parameters.
 
-Program Definition normRedΠ0 {Γ nF F G l} (h : [Γ ||-Π<l> tProd nF F G])
-  : [Γ ||-Π<l> tProd nF F G] :=
-  {| PiRedTyPack.na := nF ; 
-     PiRedTyPack.dom := F ;
+Program Definition normRedΠ0 {Γ F G l} (h : [Γ ||-Π<l> tProd F G])
+  : [Γ ||-Π<l> tProd F G] :=
+  {| PiRedTyPack.dom := F ;
      PiRedTyPack.cod := G |}.
 Solve All Obligations with 
   intros;
-  assert (wΠ : whnf (tProd nF F G)) by constructor;
+  assert (wΠ : whnf (tProd F G)) by constructor;
   pose proof (e := redtywf_whnf (PiRedTyPack.red h) wΠ);
   symmetry in e; injection e; clear e; 
-  destruct h as [??????? domRed codRed codExt] ; 
+  destruct h as [?????? domRed codRed codExt] ; 
   intros; cbn in *; subst; eassumption + now eapply domRed + 
   (unshelve eapply codRed ; tea ; irrelevance)
   + ( irrelevance0; [reflexivity| unshelve eapply codExt; tea]; irrelevance).
 
-Definition normRedΠ {Γ nF F G l} (h : [Γ ||-<l> tProd nF F G])
-  : [Γ ||-<l> tProd nF F G] :=
+Definition normRedΠ {Γ F G l} (h : [Γ ||-<l> tProd F G])
+  : [Γ ||-<l> tProd F G] :=
   LRPi' (normRedΠ0 (invLRΠ h)).
 
 #[program]
-Definition normLambda {Γ nF F nF' F' G t l RΠ} 
-  (Rlam : [Γ ||-<l> tLambda nF' F' t : tProd nF F G | normRedΠ RΠ ]) :
-  [Γ ||-<l> tLambda nF' F' t : tProd nF F G | normRedΠ RΠ ] :=
-  {| PiRedTm.nf := tLambda nF' F' t |}.
+Definition normLambda {Γ F F' G t l RΠ} 
+  (Rlam : [Γ ||-<l> tLambda F' t : tProd F G | normRedΠ RΠ ]) :
+  [Γ ||-<l> tLambda F' t : tProd F G | normRedΠ RΠ ] :=
+  {| PiRedTm.nf := tLambda F' t |}.
 Solve All Obligations with
   intros;
   pose proof (e := redtmwf_whnf (PiRedTm.red Rlam) whnf_tLambda);

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -24,10 +24,10 @@ Proof.
     + apply LRne_; exists t; tea; etransitivity; tea.
       constructor; tea; gen_typing.
     + exists t; tea.
-  - intros B [na dom cod] A ? ihdom ihcod; cbn in *; unshelve eexists.
-    + apply LRPi'; unshelve eexists na dom cod _ _; tea; etransitivity; tea.
+  - intros B [dom cod] A ? ihdom ihcod; cbn in *; unshelve eexists.
+    + apply LRPi'; unshelve eexists dom cod _ _; tea; etransitivity; tea.
       constructor; tea; gen_typing.
-    + unshelve eexists na dom cod; tea; cbn.
+    + unshelve eexists dom cod; tea; cbn.
       1,2: intros; apply LRTyEqRefl_.
   - intros B [red] A ?; unshelve eexists.
     + apply LRNat_; constructor; tea; etransitivity; tea.
@@ -76,7 +76,7 @@ Proof.
     + split; tea; exists n n; tea; destruct red; constructor; tea; now etransitivity. 
   - intros ? ΠA ihdom ihcod ?? ru' ?; pose (ru := ru'); destruct ru' as [f].
     assert [Γ |- A ≅ PiRedTyPack.prod ΠA]. 1:{
-      destruct ΠA as [??? []]. cbn in *.
+      destruct ΠA as [?? []]. cbn in *.
       eapply convty_exp; tea.
       now apply redtywf_refl.
     }
@@ -129,7 +129,7 @@ Proof.
     1: constructor; now eapply ty_ne_whne.
     econstructor; tea.
     eapply redtywf_refl; gen_typing.
-  - intros ??? [??? red] ?? ? red' ?.
+  - intros ??? [?? red] ?? ? red' ?.
     eapply LRPi'. 
     unshelve erewrite (redtywf_det _ _ _ _ _ _ red' red); tea.
     1: constructor.

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -90,8 +90,7 @@ Proof.
   - intros ? NA t ? Ru red; inversion Ru; subst.
     assert [Γ |- A ≅ tNat] by (destruct NA; gen_typing).
     assert [Γ |- t :⇒*: nf : tNat]. 1:{
-      constructor. 2: gen_typing.
-      1: eapply ty_conv; gen_typing.
+      constructor. 1: gen_typing.
       etransitivity. 2: gen_typing.
       now eapply redtm_conv.
     }

--- a/theories/LogicalRelation/SimpleArr.v
+++ b/theories/LogicalRelation/SimpleArr.v
@@ -11,7 +11,7 @@ Section SimpleArrow.
   Lemma ArrRedTy0 {Γ l A B} : [Γ ||-<l> A] -> [Γ ||-<l> B] -> [Γ ||-Π<l> arr A B].
   Proof.
     intros RA RB; escape.
-    unshelve econstructor; [exact anDummy|exact A| exact B⟨↑⟩|..]; tea.
+    unshelve econstructor; [exact A| exact B⟨↑⟩|..]; tea.
     - intros; now eapply wk.
     - cbn; intros.
       bsimpl; rewrite <- rinstInst'_term.
@@ -197,10 +197,9 @@ Section SimpleArrow.
     - constructor.
     - apply tm_nf_lam.
       + now eapply reifyType.
-      + change (PiRedTy.na (PiRedTyPack.toPiRedTy ΠAC)) with anDummy.
-        change (PiRedTy.dom (PiRedTyPack.toPiRedTy ΠAC)) with A.
+      + change (PiRedTy.dom (PiRedTyPack.toPiRedTy ΠAC)) with A.
         change (PiRedTy.cod (PiRedTyPack.toPiRedTy ΠAC)) with C⟨↑⟩.
-        pose (ρ := @wk_step Γ Γ anDummy A wk_id).
+        pose (ρ := @wk_step Γ Γ A wk_id).
         assert (Hr : forall (t : term), t⟨↑⟩ = t⟨ρ⟩).
         { unfold ρ; bsimpl; reflexivity. }
         do 3 rewrite Hr.

--- a/theories/LogicalRelation/Transitivity.v
+++ b/theories/LogicalRelation/Transitivity.v
@@ -30,12 +30,12 @@ Proof.
     etransitivity. 1: eassumption. destruct neB as [? red']. cbn in *.
     unshelve erewrite (redtywf_det _ _ _ _ _ _ red red').
     1,2 : eapply whnf_whne, ty_ne_whne. all: eassumption.
-  - destruct RAB as [nB domB codB redB ? domRedEq codRedEq], RBC as [nC domC codC redC ? domRedEq' codRedEq'].
-    destruct ΠB as [??? redB' ??? domRedB codRedB], ΠC as [??? redC' ??? domRedC codRedC], ΠBad as [domAdB codAdB], ΠCad as [domAdC codAdC]; cbn in *.
+  - destruct RAB as [domB codB redB ? domRedEq codRedEq], RBC as [domC codC redC ? domRedEq' codRedEq'].
+    destruct ΠB as [?? redB' ??? domRedB codRedB], ΠC as [?? redC' ??? domRedC codRedC], ΠBad as [domAdB codAdB], ΠCad as [domAdC codAdC]; cbn in *.
     unshelve epose proof (eqΠB := redtywf_det _ _ _ _ _ _ redB' redB).  1,2 : constructor.
-    injection eqΠB; intros eqcod eqdom eqna; clear eqΠB;  subst. 
+    injection eqΠB; intros eqcod eqdom; clear eqΠB;  subst. 
     unshelve epose proof (eqΠC := redtywf_det _ _ _ _ _ _ redC' redC).  1,2 : constructor.
-    injection eqΠC; intros eqcod eqdom eqna; clear eqΠC;  subst. 
+    injection eqΠC; intros eqcod eqdom; clear eqΠC;  subst. 
     assert (domRedAC : forall (Δ : context) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ]),
       [PiRedTy.domRed ΠA ρ h | Δ ||- (PiRedTy.dom ΠA)⟨ρ⟩ ≅ domC⟨ρ⟩]).
     { intros. unshelve eapply ihdom.
@@ -45,7 +45,7 @@ Proof.
       3: apply domAdB.
       now apply (PiRedTy.domRed ΠA).
     }
-    exists nC domC codC.
+    exists domC codC.
     + eassumption.
     + etransitivity; eassumption.
     + apply domRedAC.

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -17,13 +17,13 @@ Section Weakenings.
       [Δ' ||-< l > (PiRedTyPack.cod ΠA)[a .: ρ >> tRel]⟨ρ'⟩]) :
     [Δ ||-Π< l > A⟨ρ⟩].
   Proof.
-    destruct ΠA as[na dom cod];  cbn in *.
+    destruct ΠA as[dom cod];  cbn in *.
     assert (domRed' : forall Δ' (ρ' : Δ' ≤ Δ), [|- Δ'] -> [Δ' ||-< l > dom⟨ρ⟩⟨ρ'⟩ ]).
     {
       intros ? ρ' ?; replace (_⟨_⟩) with (dom⟨ρ' ∘w ρ⟩) by now bsimpl.
       econstructor; now unshelve eapply domRed.
     }
-    set (cod' := cod⟨wk_up na dom ρ⟩).
+    set (cod' := cod⟨wk_up dom ρ⟩).
     assert (codRed' : forall Δ' a (ρ' : Δ' ≤ Δ) (h : [|- Δ']),
       [domRed' Δ' ρ' h | _ ||- a : _] -> [Δ' ||-< l > cod'[a .: ρ' >> tRel]]).
     {
@@ -32,11 +32,11 @@ Section Weakenings.
       econstructor; unshelve eapply codRed; [assumption|].
       irrelevance.
     }
-    exists na (dom ⟨ρ⟩) cod' domRed' codRed'.
-    + unfold cod'; change (tProd ?na _ _) with ((tProd na dom cod)⟨ρ⟩);  gen_typing.
+    exists (dom ⟨ρ⟩) cod' domRed' codRed'.
+    + unfold cod'; change (tProd _ _) with ((tProd dom cod)⟨ρ⟩);  gen_typing.
     + gen_typing.
-    + unfold cod'; set (ρ1 := wk_up na (dom) ρ); eapply wft_wk; gen_typing.
-    + unfold cod'; change (tProd ?na _ _) with ((tProd na dom cod)⟨ρ⟩);  gen_typing.
+    + unfold cod'; set (ρ1 := wk_up (dom) ρ); eapply wft_wk; gen_typing.
+    + unfold cod'; change (tProd _ _) with ((tProd dom cod)⟨ρ⟩);  gen_typing.
     + intros Δ' a b ρ' wfΔ' ???. 
       replace (cod'[b .: ρ' >> tRel]) with (cod[ b .: (ρ' ∘w ρ) >> tRel]) by (unfold cod'; now bsimpl).
       subst cod'; unshelve epose (codExt Δ' a b (ρ' ∘w ρ) wfΔ' _ _ _); irrelevance.
@@ -88,11 +88,11 @@ Section Weakenings.
       2: now apply ty_ne_wk, ne.
       1: gen_typing.
       cbn ; change U with U⟨ρ⟩; eapply convneu_wk; assumption.
-    - intros * ihdom ihcod * [na dom cod]. rewrite wkΠ_eq. set (X := wkΠ' _ _ _).
-      exists na (dom⟨ρ⟩) (cod⟨wk_up na dom ρ⟩). cbn in *.
-      + change (tProd ?na _ _) with ((tProd na dom cod)⟨ρ⟩);  gen_typing.
-      + change (tProd na _ _) with ((tProd na dom cod)⟨ρ⟩).
-        replace (tProd _ _ _) with ((PiRedTyPack.prod ΠA)⟨ρ⟩) by now bsimpl.
+    - intros * ihdom ihcod * [dom cod]. rewrite wkΠ_eq. set (X := wkΠ' _ _ _).
+      exists (dom⟨ρ⟩) (cod⟨wk_up dom ρ⟩). cbn in *.
+      + change (tProd _ _) with ((tProd dom cod)⟨ρ⟩);  gen_typing.
+      + change (tProd dom⟨_⟩ _) with ((tProd dom cod)⟨ρ⟩).
+        replace (tProd _ _) with ((PiRedTyPack.prod ΠA)⟨ρ⟩) by now bsimpl.
         eapply convty_wk; assumption.
       + intros; irrelevanceRefl.
         unshelve eapply ihdom; try eassumption; eapply domRed.
@@ -113,7 +113,7 @@ Section Weakenings.
     [Δ ||-Π u⟨ρ⟩ : A⟨ρ⟩ | PiRedTyPack.toPiRedTy ΠA' ].
   Proof.
     intros [t].
-    exists (t⟨ρ⟩); try change (tProd ?na _ _) with ((PiRedTyPack.prod ΠA)⟨ρ⟩).
+    exists (t⟨ρ⟩); try change (tProd _ _) with ((PiRedTyPack.prod ΠA)⟨ρ⟩).
     + now eapply redtmwf_wk.
     + apply isFun_ren; assumption.
     + now apply tm_nf_wk.
@@ -199,8 +199,8 @@ Section Weakenings.
       1,2: apply tm_ne_wk; assumption.
       now eapply convneu_wk.
     - intros ??? ΠA ihdom ihcod t u ? ρ ? [redL redR].
-      rewrite wkΠ_eq. set (X := wkΠ' _ _ _).
-      unshelve econstructor; try change (tProd ?na _ _) with ((PiRedTyPack.prod ΠA)⟨ρ⟩).
+      rewrite wkΠ_eq. set (X := wkΠ' _ _).
+      unshelve econstructor; try change (tProd _ _) with ((PiRedTyPack.prod ΠA)⟨ρ⟩).
       1,2: now eapply wkΠTerm.
       + now eapply convtm_wk.
       + intros ? a ρ' ? ?. 

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -114,10 +114,7 @@ Section Weakenings.
   Proof.
     intros [t].
     exists (t⟨ρ⟩); try change (tProd ?na _ _) with ((PiRedTyPack.prod ΠA)⟨ρ⟩).
-    + destruct red; unshelve econstructor.
-      eapply ty_wk; eassumption.
-      eapply ty_wk; eassumption.
-      eapply redtm_wk; eassumption.
+    + now eapply redtmwf_wk.
     + apply isFun_ren; assumption.
     + now apply tm_nf_wk.
     + eapply convtm_wk; eassumption.
@@ -150,10 +147,7 @@ Section Weakenings.
       now apply tm_nf_wk.
       apply RedTyRecBwd ; apply wk; [assumption|]; now apply (RedTyRecFwd h).
     - intros ?????? ρ ? [te]. exists te⟨ρ⟩; cbn.
-      + destruct red; unshelve econstructor.
-        eapply ty_wk; eassumption.
-        eapply ty_wk; eassumption.
-        eapply redtm_wk; eassumption.
+      + now eapply redtmwf_wk.
       + apply tm_ne_wk; assumption.
       + eapply convneu_wk; eassumption.
     - intros ???? ihdom ihcod ?? ρ ?; apply wkΠTerm. 
@@ -201,15 +195,9 @@ Section Weakenings.
       + apply TyEqRecBwd. eapply wkEq. now apply TyEqRecFwd.
     - intros ??????? ρ ? [tL tR].
       exists (tL⟨ρ⟩) (tR⟨ρ⟩); cbn.
-      + destruct redL; unshelve econstructor.
-        1,2: eapply ty_wk; eassumption.
-        eapply redtm_wk; eassumption.
-      + destruct redR; unshelve econstructor.
-        1,2: eapply ty_wk; eassumption.
-        eapply redtm_wk; eassumption.
-      + apply tm_ne_wk; assumption.
-      + apply tm_ne_wk; assumption.
-      + now eapply convneu_wk.
+      1,2: now eapply redtmwf_wk. 
+      1,2: apply tm_ne_wk; assumption.
+      now eapply convneu_wk.
     - intros ??? ΠA ihdom ihcod t u ? ρ ? [redL redR].
       rewrite wkΠ_eq. set (X := wkΠ' _ _ _).
       unshelve econstructor; try change (tProd ?na _ _) with ((PiRedTyPack.prod ΠA)⟨ρ⟩).

--- a/theories/NormalForms.v
+++ b/theories/NormalForms.v
@@ -6,8 +6,8 @@ From LogRel Require Import Utils BasicAst Context.
 
 Inductive whnf : term -> Type :=
   | whnf_tSort {s} : whnf (tSort s)
-  | whnf_tProd {na A B} : whnf (tProd na A B)
-  | whnf_tLambda {na A t} : whnf (tLambda na A t)
+  | whnf_tProd {A B} : whnf (tProd A B)
+  | whnf_tLambda {A t} : whnf (tLambda A t)
   | whnf_tNat : whnf tNat
   | whnf_tZero : whnf tZero
   | whnf_tSucc {n} : whnf (tSucc n)
@@ -30,12 +30,12 @@ Proof.
   inversion 1.
 Qed.
 
-Lemma nePi na A B : whne (tProd na A B) -> False.
+Lemma nePi A B : whne (tProd A B) -> False.
 Proof.
   inversion 1.
 Qed.
 
-Lemma neLambda na A t : whne (tLambda na A t) -> False.
+Lemma neLambda A t : whne (tLambda A t) -> False.
 Proof.
   inversion 1.
 Qed.
@@ -46,7 +46,7 @@ Qed.
 
 Inductive isType : term -> Type :=
   | UnivType {s} : isType (tSort s)
-  | ProdType {na A B} : isType (tProd na A B)
+  | ProdType { A B} : isType (tProd A B)
   | NatType : isType tNat
   | NeType {A}  : whne A -> isType A.
 
@@ -56,7 +56,7 @@ Inductive isPosType : term -> Type :=
   | NePos {A}  : whne A -> isPosType A.
 
 Inductive isFun : term -> Type :=
-  | LamFun {na A t} : isFun (tLambda na A t)
+  | LamFun {A t} : isFun (tLambda A t)
   | NeFun  {f} : whne f -> isFun f.
 
 Definition isPosType_isType t (i : isPosType t) : isType t :=

--- a/theories/Substitution/Introductions/Application.v
+++ b/theories/Substitution/Introductions/Application.v
@@ -12,11 +12,11 @@ Set Printing Primitive Projection Parameters.
 
 Set Printing Universes.
 
-Lemma appValid {Γ nF F G t u l}
+Lemma appValid {Γ F G t u l}
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
-  {VΠFG : [Γ ||-v<l> tProd nF F G | VΓ]}
-  (Vt : [Γ ||-v<l> t : tProd nF F G | VΓ | VΠFG])
+  {VΠFG : [Γ ||-v<l> tProd F G | VΓ]}
+  (Vt : [Γ ||-v<l> t : tProd F G | VΓ | VΠFG])
   (Vu : [Γ ||-v<l> u : F | VΓ | VF])
   (VGu := substSΠ VΠFG Vu) :
   [Γ ||-v<l> tApp t u : G[u..] | VΓ | VGu].
@@ -32,11 +32,11 @@ Proof.
     unshelve eapply LRTyEqSym. 2,3: tea.
 Qed.
 
-Lemma appcongValid {Γ nF F G t u a b l}
+Lemma appcongValid {Γ F G t u a b l}
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
-  {VΠFG : [Γ ||-v<l> tProd nF F G | VΓ]}
-  (Vtu : [Γ ||-v<l> t ≅ u : tProd nF F G | VΓ | VΠFG])
+  {VΠFG : [Γ ||-v<l> tProd F G | VΓ]}
+  (Vtu : [Γ ||-v<l> t ≅ u : tProd F G | VΓ | VΠFG])
   (Va : [Γ ||-v<l> a : F | VΓ | VF])
   (Vb : [Γ ||-v<l> b : F | VΓ | VF])
   (Vab : [Γ ||-v<l> a ≅ b : F | VΓ | VF])

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -16,29 +16,29 @@ Context `{GenericTypingProperties}.
 
 
 
-Context {Γ nF F G l} {VΓ : [||-v Γ]} (VF : [Γ ||-v<l> F | VΓ]) 
-  (VΓF := validSnoc nF VΓ VF)
-  (VG : [Γ ,, vass nF F ||-v<l> G | VΓF])
+Context {Γ F G l} {VΓ : [||-v Γ]} (VF : [Γ ||-v<l> F | VΓ]) 
+  (VΓF := validSnoc VΓ VF)
+  (VG : [Γ ,, F ||-v<l> G | VΓF])
   (VΠFG := PiValid VΓ VF VG).
 
 
-Lemma consWkEq {Δ Ξ} σ (ρ : Δ ≤ Ξ) a Z : Z[up_term_term σ]⟨wk_up nF F[σ] ρ⟩[a..] = Z[a .: σ⟨ρ⟩].
+Lemma consWkEq {Δ Ξ} σ (ρ : Δ ≤ Ξ) a Z : Z[up_term_term σ]⟨wk_up F[σ] ρ⟩[a..] = Z[a .: σ⟨ρ⟩].
 Proof. bsimpl; cbn; now rewrite rinstInst'_term_pointwise. Qed.
 
 Lemma consWkEq' {Δ Ξ} σ (ρ : Δ ≤ Ξ) a Z : Z[up_term_term σ][a .: ρ >> tRel] = Z[a .: σ⟨ρ⟩].
 Proof. bsimpl; cbn; now rewrite rinstInst'_term_pointwise. Qed.
 
-Lemma lamBetaRed {t} (Vt : [Γ ,, vass nF F ||-v<l> t : G | VΓF | VG]) 
+Lemma lamBetaRed {t} (Vt : [Γ ,, F ||-v<l> t : G | VΓF | VG]) 
   {Δ σ} (wfΔ : [ |-[ ta ] Δ]) (Vσ : [VΓ | Δ ||-v σ : Γ | wfΔ]) 
   {Δ0 a} (ρ : Δ0 ≤ Δ) (wfΔ0 : [|-Δ0])
   (RFσ : [Δ0 ||-<l> F[σ]⟨ρ⟩]) 
   (ha : [RFσ | _ ||- a : _])
   (RGσ : [Δ0 ||-<l> G[up_term_term σ][a .: ρ >> tRel]]) :
-    [_ ||-<l> tApp (tLambda nF F t)[σ]⟨ρ⟩ a : _ | RGσ] × 
-    [_ ||-<l> tApp (tLambda nF F t)[σ]⟨ρ⟩ a ≅ t[a .: σ⟨ρ⟩] : _ | RGσ].
+    [_ ||-<l> tApp (tLambda F t)[σ]⟨ρ⟩ a : _ | RGσ] × 
+    [_ ||-<l> tApp (tLambda F t)[σ]⟨ρ⟩ a ≅ t[a .: σ⟨ρ⟩] : _ | RGσ].
 Proof.
-  pose proof (Vσa := consWkSubstS nF VF ρ wfΔ0 Vσ ha); instValid Vσa.
-  pose proof (VσUp :=  liftSubstS' nF VF Vσ).
+  pose proof (Vσa := consWkSubstS VF ρ wfΔ0 Vσ ha); instValid Vσa.
+  pose proof (VσUp :=  liftSubstS' VF Vσ).
   instValid Vσ. instValid VσUp.  escape.
   irrelevance0. 1: now rewrite consWkEq'.
   eapply redwfSubstTerm; tea.
@@ -49,13 +49,13 @@ Proof.
   eapply wfc_cons; tea; eapply wft_wk; tea.
 Qed.
 
-Lemma betaValid {t a} (Vt : [Γ ,, vass nF F ||-v<l> t : G | VΓF | VG]) 
+Lemma betaValid {t a} (Vt : [Γ ,, F ||-v<l> t : G | VΓF | VG]) 
   (Va : [Γ ||-v<l> a : F | VΓ | VF]) :
-  [Γ ||-v<l> tApp (tLambda nF F t) a ≅ t[a..] : G[a..] | VΓ | substS nF VG Va].
+  [Γ ||-v<l> tApp (tLambda F t) a ≅ t[a..] : G[a..] | VΓ | substS VG Va].
 Proof.
   constructor; intros. instValid Vσ.
-  pose (Vσa := consSubstS (nA := nF) _ _ Vσ _ RVa). instValid Vσa.
-  pose proof (VσUp :=  liftSubstS' nF VF Vσ).
+  pose (Vσa := consSubstS _ _ Vσ _ RVa). instValid Vσa.
+  pose proof (VσUp :=  liftSubstS' VF Vσ).
   instValid Vσ. instValid VσUp.  escape.
   assert (eq : forall t, t[a..][σ] = t[up_term_term σ][a[σ]..]) by (intros; now bsimpl).
   assert (eq' : forall t, t[a..][σ] = t[a[σ].: σ]) by (intros; now bsimpl).
@@ -68,16 +68,16 @@ Proof.
     Unshelve. 2:rewrite <- eq; now rewrite eq'.
 Qed.
 
-Lemma lamValid0 {t} (Vt : [Γ ,, vass nF F ||-v<l> t : G | VΓF | VG]) 
+Lemma lamValid0 {t} (Vt : [Γ ,, F ||-v<l> t : G | VΓF | VG]) 
   {Δ σ} (wfΔ : [ |-[ ta ] Δ]) (Vσ : [VΓ | Δ ||-v σ : Γ | wfΔ]) :
-  [validTy VΠFG wfΔ Vσ | Δ ||- (tLambda nF F t)[σ] : (tProd nF F G)[σ]].
+  [validTy VΠFG wfΔ Vσ | Δ ||- (tLambda F t)[σ] : (tProd F G)[σ]].
 Proof.
-  pose proof (VσUp :=  liftSubstS' nF VF Vσ).
+  pose proof (VσUp :=  liftSubstS' VF Vσ).
   instValid Vσ. instValid VσUp. escape.
   pose (RΠ := normRedΠ RVΠFG); refold.
-  enough [RΠ | Δ ||- (tLambda nF F t)[σ] : (tProd nF F G)[σ]] by irrelevance.
-  assert [Δ |- (tLambda nF F t)[σ] : (tProd nF F G)[σ]] by (escape; cbn; gen_typing).
-  exists (tLambda nF F t)[σ]; intros; cbn in *.
+  enough [RΠ | Δ ||- (tLambda F t)[σ] : (tProd F G)[σ]] by irrelevance.
+  assert [Δ |- (tLambda F t)[σ] : (tProd F G)[σ]] by (escape; cbn; gen_typing).
+  exists (tLambda F t)[σ]; intros; cbn in *.
   + now eapply redtmwf_refl.
   + constructor.
   + apply tm_nf_lam.
@@ -87,7 +87,7 @@ Proof.
     1,2: now constructor.
     assert (eqσ : forall Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])
     by (intro; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
-    assert [Δ,, vass nF F[σ] |-[ ta ] tApp (tLambda nF F[σ] t[up_term_term σ])⟨S⟩ (tRel 0) ⇒*  t[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0)..] : G[up_term_term σ]].
+    assert [Δ,, F[σ] |-[ ta ] tApp (tLambda F[σ] t[up_term_term σ])⟨S⟩ (tRel 0) ⇒*  t[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0)..] : G[up_term_term σ]].
     {
       rewrite (eqσ G). eapply redtm_beta.
       * renToWk; eapply wft_wk; tea; gen_typing.
@@ -99,8 +99,8 @@ Proof.
     1: now eapply redty_refl.
     rewrite <- (eqσ t); eapply escapeEqTerm; now eapply LREqTermRefl_.
   + eapply lamBetaRed; tea. 
-  + pose proof (Vσa := consWkSubstS nF VF ρ h Vσ ha).
-    pose proof (Vσb := consWkSubstS nF VF ρ h Vσ hb).
+  + pose proof (Vσa := consWkSubstS VF ρ h Vσ ha).
+    pose proof (Vσb := consWkSubstS VF ρ h Vσ hb).
     assert (Vσab : [_ ||-v _ ≅ (b .: σ⟨ρ⟩) : _ | _ | _ | Vσa]).
     1:{
       unshelve eapply consSubstSEq'.
@@ -118,25 +118,25 @@ Proof.
       irrelevance. now rewrite consWkEq'.
 Qed.
 
-Lemma lamValid {t} (Vt : [Γ ,, vass nF F ||-v<l> t : G | VΓF | VG])
+Lemma lamValid {t} (Vt : [Γ ,, F ||-v<l> t : G | VΓF | VG])
    :
-    [Γ ||-v<l> tLambda nF F t : tProd nF F G | VΓ | VΠFG ].
+    [Γ ||-v<l> tLambda F t : tProd F G | VΓ | VΠFG ].
 Proof.
   opector. 1: now apply lamValid0.
   intros.
-  pose (VσUp :=  liftSubstS' nF VF Vσ).
-  pose proof (VσUp' :=  liftSubstS' nF VF Vσ').
-  pose proof (VσUprea :=  liftSubstSrealign' nF VF Vσσ' Vσ').
-  pose proof (VσσUp := liftSubstSEq' nF VF Vσσ').
+  pose (VσUp :=  liftSubstS' VF Vσ).
+  pose proof (VσUp' :=  liftSubstS' VF Vσ').
+  pose proof (VσUprea :=  liftSubstSrealign' VF Vσσ' Vσ').
+  pose proof (VσσUp := liftSubstSEq' VF Vσσ').
   instAllValid Vσ Vσ' Vσσ';  instValid VσUp'; instAllValid VσUp VσUprea VσσUp.
   pose (RΠ := normRedΠ RVΠFG); refold.
-  enough [RΠ | Δ ||- (tLambda nF F t)[σ] ≅ (tLambda nF F t)[σ'] : (tProd nF F G)[σ]] by irrelevance.
+  enough [RΠ | Δ ||- (tLambda F t)[σ] ≅ (tLambda F t)[σ'] : (tProd F G)[σ]] by irrelevance.
   unshelve econstructor.
-  - change [RΠ | Δ ||- (tLambda nF F t)[σ] : (tProd nF F G)[σ]].
+  - change [RΠ | Δ ||- (tLambda F t)[σ] : (tProd F G)[σ]].
     eapply normLambda.
     epose (lamValid0 Vt wfΔ Vσ).
     irrelevance.
-  - change [RΠ | Δ ||- (tLambda nF F t)[σ'] : (tProd nF F G)[σ]].
+  - change [RΠ | Δ ||- (tLambda F t)[σ'] : (tProd F G)[σ]].
     eapply normLambda.
     eapply LRTmRedConv.
     2: epose (lamValid0 Vt wfΔ Vσ'); irrelevance.
@@ -169,14 +169,14 @@ Proof.
         set (x := ren_term _ _); change x with (t[up_term_term σ']⟨upRen_term_term S⟩); clear x.
         do 2 rewrite <- eqσ ; eapply escapeEqTerm; now eapply validTmExt.
   - refold; cbn; intros.
-    pose proof (Vσa := consWkSubstS nF VF ρ h Vσ ha).
+    pose proof (Vσa := consWkSubstS VF ρ h Vσ ha).
     assert (ha' : [ _||-<l> a : _| wk ρ h RVF0]).
     1: {
       eapply LRTmRedConv; tea.
       irrelevance0; [reflexivity|].
       eapply wkEq; eapply (validTyExt VF); tea.
     }
-    pose proof (Vσa' := consWkSubstS nF VF ρ h Vσ' ha').
+    pose proof (Vσa' := consWkSubstS VF ρ h Vσ' ha').
     assert (Vσσa : [_ ||-v _ ≅ (a .: σ'⟨ρ⟩) : _ | _ | _ | Vσa]).
     {
       unshelve eapply consSubstSEq'.
@@ -195,21 +195,21 @@ Qed.
 
 
 
-Lemma ηeqEqTermConvNf {σ Δ f} (ρ := @wk1 Γ nF F)
+Lemma ηeqEqTermConvNf {σ Δ f} (ρ := @wk1 Γ F)
   (wfΔ : [|- Δ]) (Vσ : [Δ ||-v σ : Γ | VΓ| wfΔ])
   (RΠFG := normRedΠ (validTy VΠFG wfΔ Vσ))
-  (Rf : [Δ ||-<l> f[σ] : (tProd nF F G)[σ] | RΠFG ]) :
-  [Δ ,, vass nF F[σ] |- tApp f⟨ρ⟩[up_term_term σ] (tRel 0) ≅ tApp (PiRedTm.nf Rf)⟨↑⟩ (tRel 0) : G[up_term_term σ]].
+  (Rf : [Δ ||-<l> f[σ] : (tProd F G)[σ] | RΠFG ]) :
+  [Δ ,, F[σ] |- tApp f⟨ρ⟩[up_term_term σ] (tRel 0) ≅ tApp (PiRedTm.nf Rf)⟨↑⟩ (tRel 0) : G[up_term_term σ]].
 Proof.
   refold.
-  pose (VσUp :=  liftSubstS' nF VF Vσ).
+  pose (VσUp :=  liftSubstS' VF Vσ).
   instValid Vσ; instValid VσUp; escape.
   destruct (PiRedTm.red Rf); cbn in *.
-  assert (wfΔF : [|- Δ,, vass nF F[σ]]) by gen_typing.
-  unshelve epose proof (r := PiRedTm.app Rf (@wk1 Δ nF F[σ]) wfΔF (var0 _ _ _ _)).
+  assert (wfΔF : [|- Δ,, F[σ]]) by gen_typing.
+  unshelve epose proof (r := PiRedTm.app Rf (@wk1 Δ F[σ]) wfΔF (var0 _ _ _)).
   1: now rewrite wk1_ren_on.
   assumption.
-  assert (eqσ : forall σ Z, Z[up_term_term σ] = Z[up_term_term σ][(tRel 0) .: @wk1 Δ nF F[σ] >> tRel])
+  assert (eqσ : forall σ Z, Z[up_term_term σ] = Z[up_term_term σ][(tRel 0) .: @wk1 Δ F[σ] >> tRel])
   by (intros; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
   eapply convtm_exp. 
   1: now eapply redty_refl.
@@ -218,32 +218,32 @@ Proof.
     1: eapply redtm_app.
     2: eapply (ty_var wfΔF (in_here _ _)).
     1:{
-      replace (f⟨_⟩[_]) with f[σ]⟨@wk1 Δ nF F[σ]⟩ by (unfold ρ; now bsimpl).
+      replace (f⟨_⟩[_]) with f[σ]⟨@wk1 Δ F[σ]⟩ by (unfold ρ; now bsimpl).
       eapply redtm_meta_conv. 3: reflexivity.
       1: eapply redtm_wk; tea.
       now rewrite wk1_ren_on.
     }
     fold ren_term. rewrite eqσ; now bsimpl. 
-  * rewrite <- (wk1_ren_on Δ nF F[σ]); unshelve eapply redtmwf_refl.
+  * rewrite <- (wk1_ren_on Δ F[σ]); unshelve eapply redtmwf_refl.
     rewrite eqσ; eapply escapeTerm ; irrelevance.
     Unshelve. 2,4: rewrite <- eqσ; tea.
 Qed.
 
 
-Lemma ηeqEqTerm {σ Δ f g} (ρ := @wk1 Γ nF F)
-  (Vfg : [Γ ,, vass nF F ||-v<l> tApp f⟨ρ⟩ (tRel 0) ≅ tApp g⟨ρ⟩ (tRel 0) : G | VΓF | VG ])
+Lemma ηeqEqTerm {σ Δ f g} (ρ := @wk1 Γ F)
+  (Vfg : [Γ ,, F ||-v<l> tApp f⟨ρ⟩ (tRel 0) ≅ tApp g⟨ρ⟩ (tRel 0) : G | VΓF | VG ])
   (wfΔ : [|- Δ]) (Vσ : [Δ ||-v σ : Γ | VΓ| wfΔ])
   (RΠFG := validTy VΠFG wfΔ Vσ)
-  (Rf : [Δ ||-<l> f[σ] : (tProd nF F G)[σ] | RΠFG ])
-  (Rg : [Δ ||-<l> g[σ] : (tProd nF F G)[σ] | RΠFG ]) :
-  [Δ ||-<l> f[σ] ≅ g[σ] : (tProd nF F G)[σ] | RΠFG ].
+  (Rf : [Δ ||-<l> f[σ] : (tProd F G)[σ] | RΠFG ])
+  (Rg : [Δ ||-<l> g[σ] : (tProd F G)[σ] | RΠFG ]) :
+  [Δ ||-<l> f[σ] ≅ g[σ] : (tProd F G)[σ] | RΠFG ].
 Proof.
   set (RΠ := normRedΠ RΠFG); refold.
-  enough [Δ ||-<l> f[σ] ≅ g[σ] : (tProd nF F G)[σ] | RΠ ] by irrelevance.
+  enough [Δ ||-<l> f[σ] ≅ g[σ] : (tProd F G)[σ] | RΠ ] by irrelevance.
   opector.
-  - change [Δ ||-<l> f[σ] : (tProd nF F G)[σ] | RΠ ]; irrelevance.
-  - change [Δ ||-<l> g[σ] : (tProd nF F G)[σ] | RΠ ]; irrelevance.
-  - cbn; pose (VσUp :=  liftSubstS' nF VF Vσ).
+  - change [Δ ||-<l> f[σ] : (tProd F G)[σ] | RΠ ]; irrelevance.
+  - change [Δ ||-<l> g[σ] : (tProd F G)[σ] | RΠ ]; irrelevance.
+  - cbn; pose (VσUp :=  liftSubstS' VF Vσ).
     instValid Vσ; instValid VσUp; escape.
     destruct (PiRedTm.red p); destruct (PiRedTm.red p0); cbn in *.
     eapply convtm_eta; tea.
@@ -251,9 +251,9 @@ Proof.
     etransitivity ; [symmetry| etransitivity]; tea; eapply ηeqEqTermConvNf.
   - cbn; intros.
     set (ν := (a .: σ⟨ρ0⟩)).
-    pose (Vν := consWkSubstS nF VF ρ0 h Vσ ha).
+    pose (Vν := consWkSubstS VF ρ0 h Vσ ha).
     instValid Vσ; instValid Vν; escape.
-    assert (wfΔF : [|- Δ,, vass nF F[σ]]) by gen_typing.
+    assert (wfΔF : [|- Δ,, F[σ]]) by gen_typing.
     cbn in *.
     assert (eq : forall t, t⟨ρ⟩[a .: σ⟨ρ0⟩] = t[σ]⟨ρ0⟩) by (intros; unfold ρ; now bsimpl).
     do 2 rewrite eq in RVfg.
@@ -271,11 +271,11 @@ Proof.
       now bsimpl.
 Qed.
 
-Lemma etaeqValid {f g} (ρ := @wk1 Γ nF F)
-  (Vf : [Γ ||-v<l> f : tProd nF F G | VΓ | VΠFG ])
-  (Vg : [Γ ||-v<l> g : tProd nF F G | VΓ | VΠFG ]) 
-  (Vfg : [Γ ,, vass nF F ||-v<l> tApp f⟨ρ⟩ (tRel 0) ≅ tApp g⟨ρ⟩ (tRel 0) : G | VΓF | VG ]) :
-  [Γ ||-v<l> f ≅ g : tProd nF F G | VΓ | VΠFG].
+Lemma etaeqValid {f g} (ρ := @wk1 Γ F)
+  (Vf : [Γ ||-v<l> f : tProd F G | VΓ | VΠFG ])
+  (Vg : [Γ ||-v<l> g : tProd F G | VΓ | VΠFG ]) 
+  (Vfg : [Γ ,, F ||-v<l> tApp f⟨ρ⟩ (tRel 0) ≅ tApp g⟨ρ⟩ (tRel 0) : G | VΓF | VG ]) :
+  [Γ ||-v<l> f ≅ g : tProd F G | VΓ | VΠFG].
 Proof.
   constructor; intros ??? Vσ; instValid Vσ; now eapply ηeqEqTerm.
 Qed.

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -43,13 +43,10 @@ Proof.
   irrelevance0. 1: now rewrite consWkEq'.
   eapply redwfSubstTerm; tea.
   constructor; tea.
-  * rewrite <- consWkEq.  eapply (ty_app (na:= nF)); tea.
-    change (tProd _ _ _) with ((tProd nF F G)[σ]⟨ρ⟩).
-    eapply ty_wk; tea; cbn; gen_typing.
-  * do 2 rewrite <- consWkEq.
-    eapply redtm_beta; tea.
-    fold subst_term; renToWk;  eapply ty_wk; tea.
-    eapply wfc_cons; tea; eapply wft_wk; tea.
+  do 2 rewrite <- consWkEq.
+  eapply redtm_beta; tea.
+  fold subst_term; renToWk;  eapply ty_wk; tea.
+  eapply wfc_cons; tea; eapply wft_wk; tea.
 Qed.
 
 Lemma betaValid {t a} (Vt : [Γ ,, vass nF F ||-v<l> t : G | VΓF | VG]) 
@@ -66,7 +63,6 @@ Proof.
   rewrite eq;  eapply redwfSubstTerm; tea.
   1: rewrite <- eq; rewrite eq'; irrelevance.
   constructor; tea.
-  * eapply (ty_app (na:= nF)); tea. refold. gen_typing.
   * do 2 (rewrite <- eq; rewrite eq'); tea.
   * eapply redtm_beta; tea.
     Unshelve. 2:rewrite <- eq; now rewrite eq'.

--- a/theories/Substitution/Introductions/Nat.v
+++ b/theories/Substitution/Introductions/Nat.v
@@ -128,33 +128,6 @@ Proof.
 Qed.
 
 
-Lemma rtc_osredtm_redtm {Γ A x y} :
-  reflTransClos (osred_tm Γ A) x y ->
-  [Γ |- y : A] ->
-  [Γ |- x ⇒* y : A].
-Proof.
-  intros r ?; induction r.
-  + now eapply redtm_refl.
-  + intros. etransitivity.
-    2: now eapply IHr.
-    now eapply redtm_one_step.
-Qed.
-
-Lemma rtc_osredtm_redtmwf {Γ A x y} :
-  reflTransClos (osred_tm Γ A) x y ->
-  [Γ |- y : A] ->
-  [Γ |- x :⇒*: y : A].
-Proof.
-  intros reds yty.
-  pose proof (rtc_osredtm_redtm reds yty).
-  constructor; tea; gen_typing.
-Qed.
-
-Lemma osredtm_ty_src {Γ t u A} : [Γ |- t ⇒ u : A] -> [Γ |- t : A].
-Proof.
-  intros ?%redtm_one_step; gen_typing.
-Qed.
-
 
 Lemma red_natElimSubst {Γ l P hz hs n n'} :
   [Γ ,, tNat |- P] ->

--- a/theories/Substitution/Introductions/Nat.v
+++ b/theories/Substitution/Introductions/Nat.v
@@ -172,7 +172,7 @@ Lemma red_natElimSubst {Γ l nN P hz hs n n'} :
 Proof.
   intros hp hhz hhs red rN rn' congP.
   generalize (tmr_wf_red _ _ _ _ red).
-  destruct red as [_ _ r%redtm_rtc]. 
+  destruct red as [_ r%redtm_rtc]. 
   induction r as [|??? step reds ih] ; intros red; escape.
   - eapply redtmwf_refl; gen_typing.
   - unshelve epose (reds' := rtc_osredtm_redtm reds _); tea.
@@ -188,7 +188,6 @@ Proof.
       all: now eapply redSubstTerm.
     }
     constructor.
-    + eapply ty_natElim; tea. now eapply osredtm_ty_src.
     + eapply ty_conv; gen_typing.
     + etransitivity.
       1: eapply redtm_one_step; now eapply osredtm_natElim.

--- a/theories/Substitution/Introductions/Nat.v
+++ b/theories/Substitution/Introductions/Nat.v
@@ -156,10 +156,10 @@ Proof.
 Qed.
 
 
-Lemma red_natElimSubst {Γ l nN P hz hs n n'} :
-  [Γ ,, vass nN tNat |- P] ->
+Lemma red_natElimSubst {Γ l P hz hs n n'} :
+  [Γ ,, tNat |- P] ->
   [Γ |- hz : P[tZero..]] ->
-  [Γ |- hs : elimSuccHypTy nN P] ->
+  [Γ |- hs : elimSuccHypTy P] ->
   [Γ |- n :⇒*: n' : tNat ] ->
   forall (RN : [Γ ||-<l> tNat]),
   [Γ ||-<l> n' : tNat | RN] ->
@@ -211,8 +211,8 @@ Proof.
   unfold funcomp; now rewrite  rinstInst'_term.
 Qed.
 
-Lemma elimSuccHypTy_subst {nN P} σ :
-  elimSuccHypTy nN P[up_term_term σ] = (elimSuccHypTy nN P)[σ].
+Lemma elimSuccHypTy_subst {P} σ :
+  elimSuccHypTy P[up_term_term σ] = (elimSuccHypTy P)[σ].
 Proof.
   unfold elimSuccHypTy.
   cbn. rewrite shift_up_eq.
@@ -232,11 +232,11 @@ Proof.
 Defined.
 
 Section NatElimRed.
-  Context {Γ l nN P hs hz}
+  Context {Γ l P hs hz}
     (wfΓ : [|- Γ])
     (NN : [Γ ||-Nat tNat])
     (RN := LRNat_ _ NN)
-    (RP : [Γ,, vass nN tNat ||-<l> P])
+    (RP : [Γ,, tNat ||-<l> P])
     (RPpt : forall n, [Γ ||-<l> n : _ | RN] -> [Γ ||-<l> P[n..]])
     (RPext : forall n n' (Rn : [Γ ||-<l> n : _ | RN]),
       [Γ ||-<l> n' : _ | RN] ->
@@ -244,7 +244,7 @@ Section NatElimRed.
       [Γ ||-<l> P[n..] ≅ P[n'..] | RPpt _ Rn])
     (RPz := RPpt _ (zeroRed wfΓ))
     (Rhz : [Γ ||-<l> hz : P[tZero..] | RPz]) 
-    (RPs : [Γ ||-<l> elimSuccHypTy nN P])
+    (RPs : [Γ ||-<l> elimSuccHypTy P])
     (Rhs : [Γ ||-<l> hs : _ | RPs]).
 
   Definition natRedElimStmt :=
@@ -312,13 +312,13 @@ End NatElimRed.
 
 
 Section NatElimRedEq.
-  Context {Γ l nN P Q hs hs' hz hz'}
+  Context {Γ l P Q hs hs' hz hz'}
     (wfΓ : [|- Γ])
     (NN : [Γ ||-Nat tNat])
     (RN := LRNat_ _ NN)
-    (RP : [Γ,, vass nN tNat ||-<l> P])
-    (RQ : [Γ,, vass nN tNat ||-<l> Q])
-    (eqPQ : [Γ,, vass nN tNat |- P ≅ Q])
+    (RP : [Γ,, tNat ||-<l> P])
+    (RQ : [Γ,, tNat ||-<l> Q])
+    (eqPQ : [Γ,, tNat |- P ≅ Q])
     (RPpt : forall n, [Γ ||-<l> n : _ | RN] -> [Γ ||-<l> P[n..]])
     (RQpt : forall n, [Γ ||-<l> n : _ | RN] -> [Γ ||-<l> Q[n..]])
     (RPQext : forall n n' (Rn : [Γ ||-<l> n : _ | RN]),
@@ -330,8 +330,8 @@ Section NatElimRedEq.
     (Rhz : [Γ ||-<l> hz : P[tZero..] | RPz]) 
     (RQhz : [Γ ||-<l> hz' : Q[tZero..] | RQz]) 
     (RPQhz : [Γ ||-<l> hz ≅ hz' : _ | RPz])
-    (RPs : [Γ ||-<l> elimSuccHypTy nN P])
-    (RQs : [Γ ||-<l> elimSuccHypTy nN Q])
+    (RPs : [Γ ||-<l> elimSuccHypTy P])
+    (RQs : [Γ ||-<l> elimSuccHypTy Q])
     (Rhs : [Γ ||-<l> hs : _ | RPs])
     (RQhs : [Γ ||-<l> hs' : _ | RQs])
     (RPQhs : [Γ ||-<l> hs ≅ hs' : _ | RPs ])
@@ -437,14 +437,14 @@ End NatElimRedEq.
 
 
 Section NatElimValid.
-  Context {Γ l nN P}
+  Context {Γ l P}
     (VΓ : [||-v Γ])
     (VN := natValid (l:=l) VΓ)
-    (VΓN := validSnoc nN VΓ VN)
-    (VP : [Γ ,, vass nN tNat ||-v<l> P | VΓN]).
+    (VΓN := validSnoc VΓ VN)
+    (VP : [Γ ,, tNat ||-v<l> P | VΓN]).
   
   Lemma elimSuccHypTyValid :
-    [Γ ||-v<l> elimSuccHypTy nN P | VΓ].
+    [Γ ||-v<l> elimSuccHypTy P | VΓ].
   Proof.
     unfold elimSuccHypTy.
     unshelve eapply PiValid.
@@ -454,26 +454,26 @@ Section NatElimValid.
     eapply irrelevanceTm.
     eapply succValid.
     eapply irrelevanceTm.
-    change tNat with tNat⟨@wk1 Γ nN tNat⟩ at 2.
+    change tNat with tNat⟨@wk1 Γ tNat⟩ at 2.
     eapply var0Valid.
     Unshelve. all: tea.
   Qed.
 
   Context {hz hs}
-    (VPz := substS nN VP (zeroValid VΓ))
+    (VPz := substS VP (zeroValid VΓ))
     (Vhz : [Γ ||-v<l> hz : P[tZero..] | VΓ | VPz]) 
     (Vhs : [Γ ||-v<l> hs : _ | VΓ | elimSuccHypTyValid]).
 
 
   Lemma natElimValid {n}
     (Vn : [Γ ||-v<l> n : tNat | VΓ | VN])
-    (VPn := substS nN VP Vn)
+    (VPn := substS VP Vn)
     : [Γ ||-v<l> tNatElim P hz hs n : _ | VΓ | VPn].
   Proof.
     constructor; intros.
     - instValid Vσ; cbn.
       irrelevance0.  1: now rewrite singleSubstComm'.
-      epose proof (Vuσ := liftSubstS' nN VN Vσ).
+      epose proof (Vuσ := liftSubstS' VN Vσ).
       instValid Vuσ; escape.
       unshelve eapply natElimRed; tea.
       + intros m Rm.
@@ -492,10 +492,10 @@ Section NatElimValid.
       + irrelevance. now rewrite elimSuccHypTy_subst. 
     - instAllValid Vσ Vσ' Vσσ'.
       irrelevance0.  1: now rewrite singleSubstComm'.
-      pose (Vuσ := liftSubstS' nN VN Vσ).
-      pose proof (Vuσ' := liftSubstS' nN VN Vσ').
-      pose proof (Vuσrea :=  liftSubstSrealign' nN VN Vσσ' Vσ').
-      pose proof (Vuσσ' := liftSubstSEq' nN VN Vσσ').
+      pose (Vuσ := liftSubstS' VN Vσ).
+      pose proof (Vuσ' := liftSubstS' VN Vσ').
+      pose proof (Vuσrea :=  liftSubstSrealign' VN Vσσ' Vσ').
+      pose proof (Vuσσ' := liftSubstSEq' VN Vσσ').
       instValid Vuσ'; instAllValid Vuσ Vuσrea Vuσσ'; escape.
       unshelve eapply natElimRedEq; tea; fold subst_term.
       6-11: irrelevance; now rewrite elimSuccHypTy_subst.
@@ -521,7 +521,7 @@ Section NatElimValid.
     [Γ ||-v<l> tNatElim P hz hs tZero ≅ hz : _ | VΓ | VPz].
   Proof.
     constructor; intros.
-    epose proof (Vuσ := liftSubstS' nN VN Vσ).
+    epose proof (Vuσ := liftSubstS' VN Vσ).
     instValid Vσ; instValid Vuσ; escape.
     irrelevance0.  1: now rewrite singleSubstComm'.
     unshelve eapply (snd (natElimRedAux _ _ _ _ _ _ _ _) _ NatRedTm.zeroR); tea; fold subst_term.
@@ -545,11 +545,11 @@ Section NatElimValid.
 
   Lemma natElimSuccValid {n}
     (Vn : [Γ ||-v<l> n : tNat | VΓ | VN]) 
-    (VPSn := substS nN VP (succValid _ Vn)) : 
+    (VPSn := substS VP (succValid _ Vn)) : 
     [Γ ||-v<l> tNatElim P hz hs (tSucc n) ≅ tApp (tApp hs n) (tNatElim P hz hs n) : _ | VΓ | VPSn].
   Proof.
     constructor; intros.
-    epose proof (Vuσ := liftSubstS' nN VN Vσ).
+    epose proof (Vuσ := liftSubstS' VN Vσ).
     instValid Vσ; instValid Vuσ; escape.
     irrelevance0.  1: now rewrite singleSubstComm'.
     pose (NSn := NatRedTm.succR RVn).
@@ -573,31 +573,31 @@ Section NatElimValid.
 
 End NatElimValid.
 
-Lemma natElimCongValid {Γ l nN P Q hz hz' hs hs' n n'}
+Lemma natElimCongValid {Γ l P Q hz hz' hs hs' n n'}
     (VΓ : [||-v Γ])
     (VN := natValid (l:=l) VΓ)
-    (VΓN := validSnoc nN VΓ VN)
-    (VP : [Γ ,, vass nN tNat ||-v<l> P | VΓN])
-    (VQ : [Γ ,, vass nN tNat ||-v<l> Q | VΓN])
-    (VPQ : [Γ ,, vass nN tNat ||-v<l> P ≅ Q | VΓN | VP])
-    (VPz := substS nN VP (zeroValid VΓ))
-    (VQz := substS nN VQ (zeroValid VΓ))
+    (VΓN := validSnoc VΓ VN)
+    (VP : [Γ ,, tNat ||-v<l> P | VΓN])
+    (VQ : [Γ ,, tNat ||-v<l> Q | VΓN])
+    (VPQ : [Γ ,, tNat ||-v<l> P ≅ Q | VΓN | VP])
+    (VPz := substS VP (zeroValid VΓ))
+    (VQz := substS VQ (zeroValid VΓ))
     (Vhz : [Γ ||-v<l> hz : P[tZero..] | VΓ | VPz]) 
     (Vhz' : [Γ ||-v<l> hz' : Q[tZero..] | VΓ | VQz])
     (Vheqz : [Γ ||-v<l> hz ≅ hz' : P[tZero..] | VΓ | VPz])
-    (VPs := elimSuccHypTyValid (nN := nN) VΓ VP)
-    (VQs := elimSuccHypTyValid (nN := nN) VΓ VQ)
+    (VPs := elimSuccHypTyValid VΓ VP)
+    (VQs := elimSuccHypTyValid VΓ VQ)
     (Vhs : [Γ ||-v<l> hs : _ | VΓ | VPs]) 
     (Vhs' : [Γ ||-v<l> hs' : _ | VΓ | VQs])
     (Vheqs : [Γ ||-v<l> hs ≅ hs' : _ | VΓ | VPs]) 
     (Vn : [Γ ||-v<l> n : _ | VΓ | VN])
     (Vn' : [Γ ||-v<l> n' : _ | VΓ | VN])
     (Veqn : [Γ ||-v<l> n ≅ n' : _ | VΓ | VN])
-    (VPn := substS nN VP Vn) :
+    (VPn := substS VP Vn) :
     [Γ ||-v<l> tNatElim P hz hs n ≅ tNatElim Q hz' hs' n' : _ | VΓ | VPn].
 Proof.
   constructor; intros.
-  pose (Vuσ := liftSubstS' nN VN Vσ).
+  pose (Vuσ := liftSubstS' VN Vσ).
   instValid Vσ; instValid Vuσ; escape.
   irrelevance0.  1: now rewrite singleSubstComm'.
   unshelve eapply natElimRedEq; tea; fold subst_term.
@@ -627,23 +627,23 @@ Proof.
     unshelve econstructor; [| now cbn]; now bsimpl.
 Qed.
 
-Lemma elimSuccHypTyCongValid {Γ l nN P P'}
+Lemma elimSuccHypTyCongValid {Γ l P P'}
     (VΓ : [||-v Γ])
     (VN := natValid (l:=l) VΓ)
-    (VΓN := validSnoc nN VΓ VN)
-    (VP : [Γ ,, vass nN tNat ||-v<l> P | VΓN])
-    (VP' : [Γ ,, vass nN tNat ||-v<l> P' | VΓN])
-    (VeqP : [Γ ,, vass nN tNat ||-v<l> P ≅ P' | VΓN | VP]) :
-    [Γ ||-v<l> elimSuccHypTy nN P ≅ elimSuccHypTy nN P' | VΓ | elimSuccHypTyValid VΓ VP].
+    (VΓN := validSnoc VΓ VN)
+    (VP : [Γ ,, tNat ||-v<l> P | VΓN])
+    (VP' : [Γ ,, tNat ||-v<l> P' | VΓN])
+    (VeqP : [Γ ,, tNat ||-v<l> P ≅ P' | VΓN | VP]) :
+    [Γ ||-v<l> elimSuccHypTy P ≅ elimSuccHypTy P' | VΓ | elimSuccHypTyValid VΓ VP].
   Proof.
     unfold elimSuccHypTy.
     eapply irrelevanceEq.
-    assert [Γ,, vass nN tNat ||-v< l > P'[tSucc (tRel 0)]⇑ | validSnoc nN VΓ VN]. 1:{
+    assert [Γ,, tNat ||-v< l > P'[tSucc (tRel 0)]⇑ | validSnoc VΓ VN]. 1:{
       eapply substLiftS; tea.
       eapply irrelevanceTm.
       eapply succValid.
       eapply irrelevanceTm.
-      change tNat with tNat⟨@wk1 Γ nN tNat⟩ at 2.
+      change tNat with tNat⟨@wk1 Γ tNat⟩ at 2.
       eapply var0Valid.
     }
     eapply PiCong.

--- a/theories/Substitution/Introductions/Pi.v
+++ b/theories/Substitution/Introductions/Pi.v
@@ -7,7 +7,7 @@ From LogRel.Substitution.Introductions Require Import Universe.
 
 (* Set Universe Polymorphism. *)
 
-Lemma eq_subst_1 F na G Δ σ : G[up_term_term σ] = G[tRel 0 .: σ⟨ @wk1 Δ na F[σ] ⟩].
+Lemma eq_subst_1 F G Δ σ : G[up_term_term σ] = G[tRel 0 .: σ⟨ @wk1 Δ F[σ] ⟩].
 Proof.
   now bsimpl.
 Qed.
@@ -20,9 +20,9 @@ Qed.
 Section PiTyValidity.
 
   Context `{GenericTypingProperties}.
-  Context {l Γ na F G} (vΓ : [||-v Γ])
+  Context {l Γ F G} (vΓ : [||-v Γ])
     (vF : [Γ ||-v< l > F | vΓ ])
-    (vG : [Γ ,, vass na F ||-v< l > G | validSnoc na vΓ vF]).
+    (vG : [Γ ,, F ||-v< l > G | validSnoc vΓ vF]).
 
   Lemma domainRed {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
     : [ Δ ||-< l > F[σ] ].
@@ -48,7 +48,7 @@ Section PiTyValidity.
     (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
     (vσ' : [vΓ | Δ ||-v σ' : _ | tΔ])
     (vσσ' : [vΓ | Δ ||-v σ ≅ σ' : _ | tΔ | vσ ])
-    : [Δ,, vass na F[σ] |-[ ta ] F[σ⟨@wk1 Δ na F[σ]⟩] ≅ F[σ'⟨@wk1 Δ na F[σ]⟩]].
+    : [Δ,, F[σ] |-[ ta ] F[σ⟨@wk1 Δ F[σ]⟩] ≅ F[σ'⟨@wk1 Δ F[σ]⟩]].
   Proof.
     eapply escapeEq.
     eapply (validTyExt vF).
@@ -58,21 +58,21 @@ Section PiTyValidity.
 
 
   Lemma codomainRed {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ,, vass na F[σ] ||-< l > G[ up_term_term σ ] ].
+    : [ Δ ,, F[σ] ||-< l > G[ up_term_term σ ] ].
   Proof.
-    rewrite (eq_subst_1 F na G Δ σ).
+    rewrite (eq_subst_1 F G Δ σ).
     refine (validTy vG _ (liftSubstS vΓ tΔ vF vσ)).
   Qed.
 
   Lemma codomainTy {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ,, vass na F[σ] |-[ ta ] G[ up_term_term σ ] ].
+    : [ Δ ,, F[σ] |-[ ta ] G[ up_term_term σ ] ].
   Proof.
     eapply escape.
     now eapply codomainRed.
   Qed.
 
   Lemma codomainTyRefl {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ,, vass na F[σ] |-[ ta ] G[ up_term_term σ ] ≅ G[ up_term_term σ ]].
+    : [ Δ ,, F[σ] |-[ ta ] G[ up_term_term σ ] ≅ G[ up_term_term σ ]].
   Proof.
     refine (escapeEq (codomainRed tΔ vσ) _).
     now eapply LRTyEqRefl_.
@@ -134,21 +134,21 @@ Section PiTyValidity.
     (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
     (vσ' : [vΓ | Δ ||-v σ' : _ | tΔ])
     (vσσ' : [vΓ | Δ ||-v σ ≅ σ' : _ | tΔ | vσ ])
-    : [Δ |-[ ta ] tProd na F[σ] G[up_term_term σ] ≅ tProd na F[σ'] G[up_term_term σ']].
+    : [Δ |-[ ta ] tProd F[σ] G[up_term_term σ] ≅ tProd F[σ'] G[up_term_term σ']].
   Proof.
-    refine (convty_prod I (domainTy tΔ vσ) _ _).
+    refine (convty_prod (domainTy tΔ vσ) _ _).
     - eapply escapeEq. eapply (validTyExt vF tΔ vσ vσ' vσσ').
-    - rewrite (eq_subst_1 F na G Δ σ). rewrite (eq_subst_1 F na G Δ σ').
-      assert ([Δ,, vass na F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ⟨@wk1 Δ na F[σ]⟩)]]).
+    - rewrite (eq_subst_1 F G Δ σ). rewrite (eq_subst_1 F G Δ σ').
+      assert ([Δ,, F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ⟨@wk1 Δ F[σ]⟩)]]).
       { replace (F[_ >> _]) with (F[σ]⟨S⟩) by (now bsimpl).
-        refine (ty_var (wfc_cons na tΔ (domainTy _ vσ)) (in_here _ _)). }
+        refine (ty_var (wfc_cons tΔ (domainTy _ vσ)) (in_here _ _)). }
       eapply escapeEq. unshelve refine (validTyExt vG _ _ _ _).
       + eapply wfc_cons. easy. refine (domainTy tΔ vσ).
       + refine (liftSubstS vΓ tΔ vF vσ).
       + unshelve econstructor.
         * refine (wk1SubstS vΓ tΔ (domainTy tΔ vσ) vσ').
-        * set (ρ' := @wk1 Δ na F[σ']).
-          assert ([Δ,, vass na F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ'⟨ρ'⟩)]]).
+        * set (ρ' := @wk1 Δ F[σ']).
+          assert ([Δ,, F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ'⟨ρ'⟩)]]).
           { eapply ty_conv; [eassumption|].
             eapply (domainTyEq tΔ vσ vσ' vσσ'). }
           cbn; eapply neuTerm; [|assumption|now apply convneu_var].
@@ -159,7 +159,7 @@ Section PiTyValidity.
           eapply escapeEq, vF; tea.
       + unshelve econstructor.
         * refine (wk1SubstSEq vΓ tΔ (domainTy tΔ vσ) vσ vσσ').
-        * assert (ne : Ne[ Δ,, vass na F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ⟨@wk1 Δ na F[σ]⟩)]]).
+        * assert (ne : Ne[ Δ,, F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ⟨@wk1 Δ F[σ]⟩)]]).
           { replace (F[_ >> _]) with (F[σ]⟨↑⟩) by (now bsimpl).
             apply tm_ne_rel; now eapply escape, vF. }
           cbn; eapply neuTermEq; try apply convneu_var; tea.
@@ -167,14 +167,14 @@ Section PiTyValidity.
 
   Lemma PiRed {Δ σ} (tΔ : [ |-[ ta ] Δ])
     (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ||-< l > (tProd na F G)[σ] ].
+    : [ Δ ||-< l > (tProd F G)[σ] ].
   Proof.
     cbn. eapply LRPi'. econstructor.
     - apply redtywf_refl.
       exact (wft_prod (domainTy tΔ vσ) (codomainTy tΔ vσ)).
     - exact (domainTy tΔ vσ).
     - exact (codomainTy tΔ vσ).
-    - exact (convty_prod I (domainTy tΔ vσ) (domainTyRefl tΔ vσ) (codomainTyRefl tΔ vσ)).
+    - exact (convty_prod (domainTy tΔ vσ) (domainTyRefl tΔ vσ) (codomainTyRefl tΔ vσ)).
     - intros Δ' a b ρ tΔ'.
       refine (codomainSubstRedEq1 tΔ tΔ' ρ vσ).
   Defined.
@@ -183,7 +183,7 @@ Section PiTyValidity.
     (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
     (vσ' : [vΓ | Δ ||-v σ' : _ | tΔ])
     (vσσ' : [vΓ | Δ ||-v σ ≅ σ' : _ | tΔ | vσ])
-    : [ Δ ||-< l > (tProd na F G)[σ] ≅ (tProd na F G)[σ'] | PiRed tΔ vσ ].
+    : [ Δ ||-< l > (tProd F G)[σ] ≅ (tProd F G)[σ'] | PiRed tΔ vσ ].
   Proof.
     cbn. econstructor.
     - apply redtywf_refl.
@@ -196,7 +196,7 @@ Section PiTyValidity.
       refine (codomainSubstRedEq2 _ _ _ vσ vσ' vσσ' ra).
   Defined.
 
-  Lemma PiValid : [Γ ||-v< l > tProd na F G | vΓ].
+  Lemma PiValid : [Γ ||-v< l > tProd F G | vΓ].
   Proof.
     unshelve econstructor.
     - intros Δ σ. eapply PiRed.
@@ -209,23 +209,23 @@ End PiTyValidity.
 Section PiTyCongruence.
 
   Context `{GenericTypingProperties}.
-  Context {Γ F nF G F' nF' G' l}
+  Context {Γ F G F' G' l}
     (vΓ : [||-v Γ])
     (vF : [ Γ ||-v< l > F | vΓ ])
-    (vG : [ Γ ,, vass nF F ||-v< l > G | validSnoc nF vΓ vF ])
+    (vG : [ Γ ,, F ||-v< l > G | validSnoc vΓ vF ])
     (vF' : [ Γ ||-v< l > F' | vΓ ])
-    (vG' : [ Γ ,, vass nF' F' ||-v< l > G' | validSnoc nF' vΓ vF' ])
+    (vG' : [ Γ ,, F' ||-v< l > G' | validSnoc vΓ vF' ])
     (vFF' : [ Γ ||-v< l > F ≅ F' | vΓ | vF ])
-    (vGG' : [ Γ ,, vass nF F ||-v< l > G ≅ G' | validSnoc nF vΓ vF | vG ]).
+    (vGG' : [ Γ ,, F ||-v< l > G ≅ G' | validSnoc vΓ vF | vG ]).
 
   Lemma PiEqRed2 {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ||-< l > (tProd nF F G)[σ] ≅ (tProd nF' F' G')[σ] | validTy (PiValid vΓ vF vG) tΔ vσ ].
+    : [ Δ ||-< l > (tProd F G)[σ] ≅ (tProd F' G')[σ] | validTy (PiValid vΓ vF vG) tΔ vσ ].
   Proof.
     econstructor.
     - apply redtywf_refl.
       exact (wft_prod (domainTy vΓ vF' tΔ vσ) (codomainTy vΓ vF' vG' tΔ vσ)).
     - cbn. fold subst_term.
-      refine (convty_prod I (domainTy vΓ vF tΔ vσ) _ _).
+      refine (convty_prod (domainTy vΓ vF tΔ vσ) _ _).
       + eapply escapeEq. eapply (validTyEq vFF' tΔ vσ).
       + eapply escapeEq. unshelve eapply (validTyEq vGG').
         2: unshelve eapply liftSubstS' ; tea.
@@ -239,7 +239,7 @@ Section PiTyCongruence.
         irrelevance.
   Qed.
 
-  Lemma PiCong : [ Γ ||-v< l > tProd nF F G ≅ tProd nF' F' G' | vΓ | PiValid vΓ vF vG ].
+  Lemma PiCong : [ Γ ||-v< l > tProd F G ≅ tProd F' G' | vΓ | PiValid vΓ vF vG ].
   Proof.
     econstructor. intros Δ σ. eapply PiEqRed2.
   Qed.
@@ -250,11 +250,11 @@ End PiTyCongruence.
 Section PiTmValidity.
 
   Context `{GenericTypingProperties}.
-  Context {Γ F nF G} (vΓ : [||-v Γ])
+  Context {Γ F G} (vΓ : [||-v Γ])
     (vF : [ Γ ||-v< one > F | vΓ ])
-    (vU : [ Γ ,, vass nF F ||-v< one > U | validSnoc nF vΓ vF ])
+    (vU : [ Γ ,, F ||-v< one > U | validSnoc vΓ vF ])
     (vFU : [ Γ ||-v< one > F : U | vΓ | UValid vΓ ])
-    (vGU : [ Γ ,, vass nF F ||-v< one > G : U | validSnoc nF vΓ vF | vU ]).
+    (vGU : [ Γ ,, F ||-v< one > G : U | validSnoc vΓ vF | vU ]).
 
   Lemma domainRedU {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
     : [ Δ ||-< one > F[σ] : U | validTy (UValid vΓ) tΔ vσ ].
@@ -278,13 +278,13 @@ Section PiTmValidity.
   Qed.
 
   Lemma codomainRedU {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ,, vass nF F[σ] ||-< one > G[ up_term_term σ ] : U | validTy vU _ (liftSubstS' nF vF vσ) ].
+    : [ Δ ,, F[σ] ||-< one > G[ up_term_term σ ] : U | validTy vU _ (liftSubstS' vF vσ) ].
   Proof.
-    refine (validTm vGU _ (liftSubstS' _ vF vσ)).
+    refine (validTm vGU _ (liftSubstS' vF vσ)).
   Qed.
 
   Lemma codomainTmU {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ,, vass nF F[σ] |-[ ta ] G[ up_term_term σ ] : U ].
+    : [ Δ ,, F[σ] |-[ ta ] G[ up_term_term σ ] : U ].
   Proof.
     eapply escapeTerm.
     now eapply codomainRedU.
@@ -292,9 +292,9 @@ Section PiTmValidity.
   Qed.
 
   Lemma codomainTmReflU {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ,, vass nF F[σ] |-[ ta ] G[ up_term_term σ ] ≅ G[ up_term_term σ ] : U].
+    : [ Δ ,, F[σ] |-[ ta ] G[ up_term_term σ ] ≅ G[ up_term_term σ ] : U].
   Proof.
-    refine (escapeEqTerm (validTy vU _ (liftSubstS' _ vF vσ)) _).
+    refine (escapeEqTerm (validTy vU _ (liftSubstS' vF vσ)) _).
     eapply LREqTermRefl_. now eapply codomainRedU.
   Qed.
 
@@ -302,15 +302,15 @@ Section PiTmValidity.
     (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
     (vσ' : [vΓ | Δ ||-v σ' : _ | tΔ])
     (vσσ' : [vΓ | Δ ||-v σ ≅ σ' : _ | tΔ | vσ ])
-    : [Δ |-[ ta ] tProd nF F[σ] G[up_term_term σ] ≅ tProd nF F[σ'] G[up_term_term σ'] : U].
+    : [Δ |-[ ta ] tProd F[σ] G[up_term_term σ] ≅ tProd F[σ'] G[up_term_term σ'] : U].
   Proof.
-    assert ([Δ,, vass nF F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ⟨@wk1 Δ nF F[σ]⟩)]]).
+    assert ([Δ,, F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ⟨@wk1 Δ F[σ]⟩)]]).
     { replace (F[_ >> _]) with (F[σ]⟨S⟩) by (now bsimpl).
-      refine (ty_var (wfc_cons nF tΔ (domainTy vΓ vF _ vσ)) (in_here _ _)). }
-    assert ([ Δ,, vass nF F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ'⟨@wk1 Δ nF F[σ']⟩)]]).
+      refine (ty_var (wfc_cons tΔ (domainTy vΓ vF _ vσ)) (in_here _ _)). }
+    assert ([ Δ,, F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ'⟨@wk1 Δ F[σ']⟩)]]).
     { eapply ty_conv; [tea|].
       eapply (domainTyEq vΓ vF tΔ vσ vσ' vσσ'). }
-    assert (Ne[ Δ,, vass nF F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ'⟨@wk1 Δ nF F[σ']⟩)]]).
+    assert (Ne[ Δ,, F[σ] |-[ ta ] tRel 0 : F[↑ >> (tRel 0 .: σ'⟨@wk1 Δ F[σ']⟩)]]).
     { eapply tm_ne_conv; [eapply tm_ne_rel|].
       - pose proof vF as [vF0 _].
         unshelve (eapply escape; eapply vF0, vσ).
@@ -318,9 +318,9 @@ Section PiTmValidity.
       do 2 erewrite <- wk1_ren_on.
       apply convty_wk; [eapply wfc_ty; tea|].
       eapply escapeEq, vF; tea. }
-    refine (convtm_prod I (domainTmU tΔ vσ) _ _).
+    refine (convtm_prod (domainTmU tΔ vσ) _ _).
     - eapply escapeEqTerm. eapply (validTmExt vFU tΔ vσ vσ' vσσ').
-    - rewrite (eq_subst_1 F nF G Δ σ). rewrite (eq_subst_1 F nF G Δ σ').
+    - rewrite (eq_subst_1 F G Δ σ). rewrite (eq_subst_1 F G Δ σ').
       eapply escapeEqTerm. unshelve refine (validTmExt vGU _ _ _ _).
       + eapply wfc_cons. easy. refine (domainTy vΓ vF tΔ vσ).
       + refine (liftSubstS vΓ tΔ vF vσ).
@@ -336,7 +336,7 @@ Section PiTmValidity.
 
   Lemma PiRedU {Δ σ}
     (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ||-< one > (tProd nF F G)[σ] : U | validTy (UValid vΓ) tΔ vσ ].
+    : [ Δ ||-< one > (tProd F G)[σ] : U | validTy (UValid vΓ) tΔ vσ ].
   Proof.
     econstructor.
     - apply redtmwf_refl ; cbn.
@@ -344,26 +344,26 @@ Section PiTmValidity.
     - cbn; constructor.
     - cbn; apply tm_nf_prod.
       + assert (HF := validTm vFU tΔ vσ); now apply reifyTerm in HF.
-      + assert (vρ := liftSubstS (nF := nF) vΓ tΔ vF vσ).
+      + assert (vρ := liftSubstS vΓ tΔ vF vσ).
         assert (HG := validTm vGU _ vρ).
         apply reifyTerm in HG.
         erewrite eq_subst_1; apply HG.
-    - cbn. eapply (convtm_prod I (domainTmU tΔ vσ) (domainTmReflU tΔ vσ) (codomainTmReflU tΔ vσ)).
+    - cbn. eapply (convtm_prod (domainTmU tΔ vσ) (domainTmReflU tΔ vσ) (codomainTmReflU tΔ vσ)).
     - cbn. unshelve refine (LRCumulative (PiRed _ _ _ tΔ vσ)).
       refine (univValid _ _ vFU).
-      eapply (irrelevanceValidity (validSnoc nF vΓ vF) _).
+      eapply (irrelevanceValidity (validSnoc vΓ vF) _).
       refine (univValid _ _ vGU).
   Defined.
 
-  Lemma PiValidU : [ Γ ||-v< one > tProd nF F G : U | vΓ | UValid vΓ ].
+  Lemma PiValidU : [ Γ ||-v< one > tProd F G : U | vΓ | UValid vΓ ].
   Proof.
     econstructor.
     - intros Δ σ tΔ vσ.
       exact (PiRedU tΔ vσ).
     - intros Δ σ σ' tΔ vσ vσ' vσσ'.
       pose proof (univValid (l' := zero) _ _ vFU) as VF0.
-      pose proof (irrelevanceValidity (validSnoc nF vΓ vF)
-                    (validSnoc (l := zero) nF vΓ VF0)
+      pose proof (irrelevanceValidity (validSnoc vΓ vF)
+                    (validSnoc (l := zero) vΓ VF0)
                     (univValid (l' := zero) _ _ vGU)) as VG0.
       unshelve econstructor ; cbn.
       + exact (PiRedU tΔ vσ).
@@ -381,44 +381,44 @@ End PiTmValidity.
 Section PiTmCongruence.
 
   Context `{GenericTypingProperties}.
-  Context {Γ F nF G F' nF' G'}
+  Context {Γ F G F' G'}
     (vΓ : [||-v Γ])
     (vF : [ Γ ||-v< one > F | vΓ ])
-    (vU : [ Γ ,, vass nF F ||-v< one > U | validSnoc nF vΓ vF ])
+    (vU : [ Γ ,, F ||-v< one > U | validSnoc vΓ vF ])
     (vFU : [ Γ ||-v< one > F : U | vΓ | UValid vΓ ])
-    (vGU : [ Γ ,, vass nF F ||-v< one > G : U | validSnoc nF vΓ vF | vU ])
+    (vGU : [ Γ ,, F ||-v< one > G : U | validSnoc vΓ vF | vU ])
     (vF' : [ Γ ||-v< one > F' | vΓ ])
-    (vU' : [ Γ ,, vass nF' F' ||-v< one > U | validSnoc nF' vΓ vF' ])
+    (vU' : [ Γ ,, F' ||-v< one > U | validSnoc vΓ vF' ])
     (vF'U : [ Γ ||-v< one > F' : U | vΓ | UValid vΓ ])
-    (vG'U : [ Γ ,, vass nF' F' ||-v< one > G' : U | validSnoc nF' vΓ vF' | vU' ])
+    (vG'U : [ Γ ,, F' ||-v< one > G' : U | validSnoc vΓ vF' | vU' ])
     (vFF' : [ Γ ||-v< one > F ≅ F' : U | vΓ | UValid vΓ ])
-    (vGG' : [ Γ ,, vass nF F ||-v< one > G ≅ G' : U | validSnoc nF vΓ vF | vU ]).
+    (vGG' : [ Γ ,, F ||-v< one > G ≅ G' : U | validSnoc vΓ vF | vU ]).
 
-  Lemma PiCongTm : [ Γ ||-v< one > tProd nF F G ≅ tProd nF' F' G' : U | vΓ | UValid vΓ ].
+  Lemma PiCongTm : [ Γ ||-v< one > tProd F G ≅ tProd F' G' : U | vΓ | UValid vΓ ].
   Proof.
     econstructor.
     intros Δ σ tΔ vσ.
     pose proof (univValid (l' := zero) _ _ vFU) as vF0.
-    pose proof (irrelevanceValidity (validSnoc nF vΓ vF)
-                  (validSnoc (l := zero) nF vΓ vF0)
+    pose proof (irrelevanceValidity (validSnoc vΓ vF)
+                  (validSnoc (l := zero) vΓ vF0)
                   (univValid (l' := zero) _ _ vGU)) as vG0.
     pose proof (univValid (l' := zero) _ _ vF'U) as vF'0.
-    pose proof (irrelevanceValidity (validSnoc nF' vΓ vF')
-                  (validSnoc (l := zero) nF' vΓ vF'0)
+    pose proof (irrelevanceValidity (validSnoc vΓ vF')
+                  (validSnoc (l := zero) vΓ vF'0)
                   (univValid (l' := zero) _ _ vG'U)) as vG'0.
     unshelve econstructor ; cbn.
     - exact (PiRedU vΓ vF vU vFU vGU tΔ vσ).
     - exact (PiRedU vΓ vF' vU' vF'U vG'U tΔ vσ).
     - exact (LRCumulative (PiRed vΓ vF0 vG0 tΔ vσ)).
-    - cbn. refine (convtm_prod I (domainTmU vΓ vFU tΔ vσ) _ _).
+    - cbn. refine (convtm_prod (domainTmU vΓ vFU tΔ vσ) _ _).
       + eapply escapeEqTerm. eapply (validTmEq vFF' tΔ vσ).
       + eapply escapeEqTerm. unshelve eapply (validTmEq vGG').
         2: unshelve eapply liftSubstS' ; tea.
     - exact (LRCumulative (PiRed vΓ vF'0 vG'0 tΔ vσ)).
-    - enough ([ Δ ||-< zero > (tProd nF F G)[σ] ≅ (tProd nF' F' G')[σ] | PiRed vΓ vF0 vG0 tΔ vσ]) by irrelevanceCum.
+    - enough ([ Δ ||-< zero > (tProd F G)[σ] ≅ (tProd F' G')[σ] | PiRed vΓ vF0 vG0 tΔ vσ]) by irrelevanceCum.
       refine (PiEqRed2 vΓ vF0 vG0 vF'0 vG'0 _ _ tΔ vσ).
       + exact (univEqValid vΓ (UValid vΓ) vF0 vFF').
-      + pose proof (univEqValid (validSnoc nF vΓ vF) vU (univValid (l' := zero) _ _ vGU) vGG') as vGG'0.
+      + pose proof (univEqValid (validSnoc vΓ vF) vU (univValid (l' := zero) _ _ vGU) vGG') as vGG'0.
         refine (irrelevanceEq _ _ _ _ vGG'0).
   Qed.
 
@@ -429,11 +429,11 @@ Section FuncTyValidity.
 
   Context `{GenericTypingProperties}.
 
-  Lemma FunValid {Γ F nF G l}
+  Lemma FunValid {Γ F G l}
       (vΓ : [||-v Γ])
       (vF : [ Γ ||-v< l > F | vΓ ])
       (vG : [ Γ ||-v< l > G | vΓ ])
-    : [ Γ ||-v< l > tProd nF F (G⟨@wk1 Γ nF F⟩) | vΓ ].
+    : [ Γ ||-v< l > tProd F (G⟨@wk1 Γ F⟩) | vΓ ].
   Proof.
     unshelve eapply PiValid ; tea.
     eapply wk1ValidTy. eassumption.
@@ -446,7 +446,7 @@ Section FuncTyCongruence.
 
   Context `{GenericTypingProperties}.
 
-  Lemma FunCong {Γ F nF G F' nF' G' l}
+  Lemma FunCong {Γ F G F' G' l}
       (vΓ : [||-v Γ])
       (vF : [ Γ ||-v< l > F | vΓ ])
       (vG : [ Γ ||-v< l > G | vΓ ])
@@ -454,11 +454,11 @@ Section FuncTyCongruence.
       (vG' : [ Γ ||-v< l > G' | vΓ ])
       (vFF' : [ Γ ||-v< l > F ≅ F' | vΓ | vF ])
       (vGG' : [ Γ ||-v< l > G ≅ G' | vΓ | vG ])
-    : [ Γ ||-v< l > tProd nF F (G⟨@wk1 Γ nF F⟩) ≅ tProd nF' F' (G'⟨@wk1 Γ nF' F'⟩) | vΓ | FunValid vΓ vF vG ].
+    : [ Γ ||-v< l > tProd F (G⟨@wk1 Γ F⟩) ≅ tProd F' (G'⟨@wk1 Γ F'⟩) | vΓ | FunValid vΓ vF vG ].
   Proof.
     unshelve eapply PiCong ; tea.
     - eapply wk1ValidTy. eassumption.
-    - replace (G'⟨@wk1 Γ nF' F'⟩) with (G'⟨@wk1 Γ nF F⟩) by (now bsimpl).
+    - replace (G'⟨@wk1 Γ F'⟩) with (G'⟨@wk1 Γ F⟩) by (now bsimpl).
       eapply wk1ValidTyEq. eassumption.
   Qed.
 

--- a/theories/Substitution/Introductions/SimpleArr.v
+++ b/theories/Substitution/Introductions/SimpleArr.v
@@ -17,7 +17,7 @@ Section SimpleArrValidity.
     [Γ ||-v<l> arr F G | VΓ].
   Proof.
     unshelve eapply PiValid; tea.
-    replace G⟨↑⟩ with G⟨@wk1 Γ anDummy F⟩ by now bsimpl.
+    replace G⟨↑⟩ with G⟨@wk1 Γ F⟩ by now bsimpl.
     now eapply wk1ValidTy.
   Qed.
 
@@ -32,11 +32,11 @@ Section SimpleArrValidity.
   Proof.
     eapply irrelevanceEq.
     unshelve eapply PiCong; tea. 
-    + replace G⟨↑⟩ with G⟨@wk1 Γ anDummy F⟩ by now bsimpl.
+    + replace G⟨↑⟩ with G⟨@wk1 Γ F⟩ by now bsimpl.
       now eapply wk1ValidTy.
-    + replace G'⟨↑⟩ with G'⟨@wk1 Γ anDummy F'⟩ by now bsimpl.
+    + replace G'⟨↑⟩ with G'⟨@wk1 Γ F'⟩ by now bsimpl.
       now eapply wk1ValidTy.
-    + replace G'⟨↑⟩ with G'⟨@wk1 Γ anDummy F⟩ by now bsimpl.
+    + replace G'⟨↑⟩ with G'⟨@wk1 Γ F⟩ by now bsimpl.
       eapply irrelevanceEq'.
       2: now eapply wk1ValidTyEq.
       now bsimpl.

--- a/theories/Substitution/Introductions/Var.v
+++ b/theories/Substitution/Introductions/Var.v
@@ -11,8 +11,8 @@ Set Printing Primitive Projection Parameters.
 Section Var.
   Context `{GenericTypingProperties}.
   
-  Lemma var0Valid {Γ l nA A} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) :
-    [Γ,, vass nA A ||-v<l> tRel 0 : _ | validSnoc nA VΓ VA | wk1ValidTy nA _ VA ].
+  Lemma var0Valid {Γ l A} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) :
+    [Γ,, A ||-v<l> tRel 0 : _ | validSnoc VΓ VA | wk1ValidTy _ VA ].
   Proof.
     constructor; intros; cbn.
     + epose (validHead Vσ); irrelevance.

--- a/theories/Substitution/Irrelevance.v
+++ b/theories/Substitution/Irrelevance.v
@@ -17,7 +17,7 @@ Proof.
   revert vsubst' veqsubst' vr'.  pattern Γ, vsubst, veqsubst, vr.
   apply VR_rect; clear Γ vsubst veqsubst vr.
   - intros ?? h. inversion h. split; reflexivity.
-  - intros ??????? ih ?? h. inversion h.
+  - intros ?????? ih ?? h. inversion h.
     specialize (ih _ _ VΓad0); destruct ih as [ih1 ih2].
     split.
     + intros. split; intros []; unshelve econstructor.
@@ -101,11 +101,11 @@ Proof.
 Qed.
 
 
-Lemma irrelevanceLift {l A nF F nG G Γ} (VΓ : [||-v Γ])
+Lemma irrelevanceLift {l A F G Γ} (VΓ : [||-v Γ])
   (VF: [Γ ||-v<l> F | VΓ]) (VG: [Γ ||-v<l> G | VΓ])
   (VFeqG : [Γ ||-v<l> F ≅ G | VΓ | VF]) :
-  [Γ ,, vass nF F ||-v<l> A | validSnoc nF VΓ VF] ->
-  [Γ ,, vass nG G ||-v<l> A | validSnoc nG VΓ VG].
+  [Γ ,, F ||-v<l> A | validSnoc VΓ VF] ->
+  [Γ ,, G ||-v<l> A | validSnoc VΓ VG].
 Proof.
   intros [VA VAext]; unshelve econstructor.
   - intros ??? [hd tl]. eapply VA.
@@ -171,13 +171,13 @@ Proof.
   intros ->; now eapply irrelevanceTm.
 Qed.
 
-Lemma irrelevanceTmLift {l t A nF F nG G Γ} (VΓ : [||-v Γ])
+Lemma irrelevanceTmLift {l t A F G Γ} (VΓ : [||-v Γ])
   (VF: [Γ ||-v<l> F | VΓ]) (VG: [Γ ||-v<l> G | VΓ])
   (VFeqG : [Γ ||-v<l> F ≅ G | VΓ | VF])
-  (VA : [Γ ,, vass nF F ||-v<l> A | validSnoc nF VΓ VF])
-  (VA' : [Γ ,, vass nG G ||-v<l> A | validSnoc nG VΓ VG])  :
-  [Γ ,, vass nF F ||-v<l> t : A | validSnoc nF VΓ VF | VA] ->
-  [Γ ,, vass nG G ||-v<l> t : A | validSnoc nG VΓ VG | VA'].
+  (VA : [Γ ,, F ||-v<l> A | validSnoc VΓ VF])
+  (VA' : [Γ ,, G ||-v<l> A | validSnoc VΓ VG])  :
+  [Γ ,, F ||-v<l> t : A | validSnoc VΓ VF | VA] ->
+  [Γ ,, G ||-v<l> t : A | validSnoc VΓ VG | VA'].
 Proof.
   intros [Vt Vtext]; unshelve econstructor.
   - intros ??? [hd tl]. irrelevanceRefl. 
@@ -233,7 +233,7 @@ Lemma irrelevanceSubstExt {Γ} (VΓ : [||-v Γ]) {σ σ' Δ} (wfΔ : [|- Δ]) :
 Proof.
   revert σ σ'; pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - constructor.
-  - intros ?????? ih ?? eq.  unshelve econstructor.
+  - intros ????? ih ?? eq.  unshelve econstructor.
     + eapply ih. 2: now eapply validTail.
       now rewrite eq.
     + rewrite <- (eq var_zero).
@@ -249,7 +249,7 @@ Lemma irrelevanceSubstEqExt {Γ} (VΓ : [||-v Γ]) {σ1 σ1' σ2 σ2' Δ}
 Proof.
   revert σ1 σ1' σ2 σ2' eq1 eq2 Vσ1; pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - constructor.
-  - intros ?????? ih ???? eq1 eq2 ? X. unshelve econstructor.
+  - intros ????? ih ???? eq1 eq2 ? X. unshelve econstructor.
     + eapply irrelevanceSubstEq.
       unshelve eapply ih.
       6: now eapply eqTail.

--- a/theories/Substitution/Properties.v
+++ b/theories/Substitution/Properties.v
@@ -30,62 +30,62 @@ Proof.
     + now escape.
 Qed.
 
-Lemma consSubstS {Γ σ t l nA A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
+Lemma consSubstS {Γ σ t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) (VA : [Γ ||-v<l> A | VΓ])
   (Vt : [ Δ ||-<l> t : A[σ] | validTy VA wfΔ Vσ]) :
-  [Δ ||-v (t .: σ) : Γ ,, vass nA A | validSnoc nA VΓ VA | wfΔ].
+  [Δ ||-v (t .: σ) : Γ ,, A | validSnoc VΓ VA | wfΔ].
 Proof.  unshelve econstructor; eassumption. Defined.
 
 Lemma consValid {Γ Δ σ a A l} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
-  nA {VA : [Γ ||-v<l> A| VΓ]}
+  {VA : [Γ ||-v<l> A| VΓ]}
   (Va : [Γ ||-v<l> a : A | VΓ | VA])
-  (VΓA := validSnoc nA VΓ VA) :
-  [Δ ||-v (a[σ] .: σ) : Γ,, vass nA A | VΓA | wfΔ].
+  (VΓA := validSnoc VΓ VA) :
+  [Δ ||-v (a[σ] .: σ) : Γ,, A | VΓA | wfΔ].
 Proof.
   unshelve eapply consSubstS; tea; now eapply validTm.
 Qed.
 
 
-Lemma consSubstSEq {Γ σ σ' t l nA A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
+Lemma consSubstSEq {Γ σ σ' t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
   (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ])
   (VA : [Γ ||-v<l> A | VΓ])
   (Vt : [Δ ||-<l> t : A[σ] | validTy VA wfΔ Vσ]) :
-  [Δ ||-v (t .: σ) ≅  (t .: σ') : Γ ,, vass nA A | validSnoc nA VΓ VA | wfΔ | consSubstS VΓ wfΔ Vσ VA Vt].
+  [Δ ||-v (t .: σ) ≅  (t .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ | consSubstS VΓ wfΔ Vσ VA Vt].
 Proof.
   unshelve econstructor.
   1: eassumption.
   eapply LRTmEqRefl; [apply (validTy VA wfΔ)| exact Vt].
 Qed.
 
-Lemma consSubstSEq' {Γ σ σ' t u l nA A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
+Lemma consSubstSEq' {Γ σ σ' t u l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
   (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ])
   (VA : [Γ ||-v<l> A | VΓ])
   (Vt : [Δ ||-<l> t : A[σ] | validTy VA wfΔ Vσ])
   (Vtu : [Δ ||-<l> t ≅ u : A[σ] | validTy VA wfΔ Vσ]) :
-  [Δ ||-v (t .: σ) ≅  (u .: σ') : Γ ,, vass nA A | validSnoc nA VΓ VA | wfΔ | consSubstS VΓ wfΔ Vσ VA Vt].
+  [Δ ||-v (t .: σ) ≅  (u .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ | consSubstS VΓ wfΔ Vσ VA Vt].
 Proof.
   unshelve econstructor; tea.
 Qed.  
 
 
-Lemma consSubstSvalid {Γ σ t l nA A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
+Lemma consSubstSvalid {Γ σ t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) (VA : [Γ ||-v<l> A | VΓ])
   (Vt : [ Γ ||-v<l> t : A | VΓ | VA]) :
-  [Δ ||-v (t[σ] .: σ) : Γ ,, vass nA A | validSnoc nA VΓ VA | wfΔ].
+  [Δ ||-v (t[σ] .: σ) : Γ ,, A | validSnoc VΓ VA | wfΔ].
 Proof. unshelve eapply consSubstS; tea; now eapply validTm. Defined.
 
 Set Printing Primitive Projection Parameters.
 
-Lemma consSubstSEqvalid {Γ σ σ' t l nA A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
+Lemma consSubstSEqvalid {Γ σ σ' t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) 
   (Vσ' : [Δ ||-v σ' : Γ | VΓ | wfΔ]) 
   (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ])
   (VA : [Γ ||-v<l> A | VΓ])
   (Vt : [Γ ||-v<l> t : A | VΓ | VA]) :
-  [Δ ||-v (t[σ] .: σ) ≅  (t[σ'] .: σ') : Γ ,, vass nA A | validSnoc nA VΓ VA | wfΔ | consSubstSvalid VΓ wfΔ Vσ VA Vt].
+  [Δ ||-v (t[σ] .: σ) ≅  (t[σ'] .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ | consSubstSvalid VΓ wfΔ Vσ VA Vt].
 Proof.
   unshelve econstructor; intros; tea.
   now apply validTmExt.
@@ -120,39 +120,39 @@ Proof.
       now asimpl.
 Qed.
 
-Lemma wk1SubstS {Γ σ Δ nF F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ]) (wfF : [Δ |- F]) :
+Lemma wk1SubstS {Γ σ Δ F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ]) (wfF : [Δ |- F]) :
   [Δ ||-v σ : Γ | VΓ | wfΔ ] ->
-  [Δ ,, vass nF F ||-v σ ⟨ @wk1 Δ nF F ⟩ : Γ | VΓ | wfc_cons nF wfΔ wfF].
+  [Δ ,, F ||-v σ ⟨ @wk1 Δ F ⟩ : Γ | VΓ | wfc_cons wfΔ wfF].
 Proof. eapply wkSubstS. Defined.
 
-Lemma wk1SubstSEq {Γ σ σ' Δ nF F} (VΓ : [||-v Γ])
+Lemma wk1SubstSEq {Γ σ σ' Δ F} (VΓ : [||-v Γ])
   (wfΔ : [|- Δ]) (wfF : [Δ |- F])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
   [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
-  let ρ := @wk1 Δ nF F in
-  [Δ ,, vass nF F ||-v σ ⟨ ρ ⟩ ≅ σ' ⟨ ρ ⟩ : Γ | VΓ | wfc_cons nF wfΔ wfF | wk1SubstS VΓ wfΔ wfF Vσ].
+  let ρ := @wk1 Δ F in
+  [Δ ,, F ||-v σ ⟨ ρ ⟩ ≅ σ' ⟨ ρ ⟩ : Γ | VΓ | wfc_cons wfΔ wfF | wk1SubstS VΓ wfΔ wfF Vσ].
 Proof.
   intro vσσ'. eapply wkSubstSEq ; eassumption.
 Qed.
 
-Lemma consWkSubstS {Γ F Δ Ξ σ a l VΓ wfΔ } nF VF
+Lemma consWkSubstS {Γ F Δ Ξ σ a l VΓ wfΔ } VF
   (ρ : Ξ ≤ Δ) wfΞ {RF}:
   [Δ ||-v σ : Γ | VΓ | wfΔ] ->
   [Ξ ||-<l> a : F[σ]⟨ρ⟩ | RF] ->
-  [Ξ ||-v (a .: σ⟨ρ⟩) : Γ,, vass nF F | validSnoc (l:=l) nF VΓ VF | wfΞ].
+  [Ξ ||-v (a .: σ⟨ρ⟩) : Γ,, F | validSnoc (l:=l) VΓ VF | wfΞ].
 Proof.
   intros. unshelve eapply consSubstS.  2: irrelevance.
   now eapply wkSubstS.
 Qed.
 
 
-Lemma liftSubstS {Γ σ Δ lF nF F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
+Lemma liftSubstS {Γ σ Δ lF F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   (VF : [Γ ||-v<lF> F | VΓ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
-  let VΓF := validSnoc nF VΓ VF in
-  let ρ := @wk1 Δ nF F[σ] in
-  let wfΔF := wfc_cons nF wfΔ (escape (validTy VF wfΔ Vσ)) in
-  [Δ ,, vass nF F[σ] ||-v (tRel 0 .: σ ⟨ ρ ⟩) : Γ ,, vass nF F | VΓF | wfΔF ].
+  let VΓF := validSnoc VΓ VF in
+  let ρ := @wk1 Δ F[σ] in
+  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
+  [Δ ,, F[σ] ||-v (tRel 0 .: σ ⟨ ρ ⟩) : Γ ,, F | VΓF | wfΔF ].
 Proof.
   intros; unshelve econstructor.
   - now eapply wk1SubstS.
@@ -160,20 +160,20 @@ Proof.
     now eapply escape, VF.
 Defined.
 
-Lemma liftSubstSrealign {Γ σ σ' Δ lF F} nF {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+Lemma liftSubstSrealign {Γ σ σ' Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (VF : [Γ ||-v<lF> F | VΓ])
   {Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]} :
-  let VΓF := validSnoc nF VΓ VF in
-  let ρ := @wk1 Δ nF F[σ]  in
-  let wfΔF := wfc_cons nF wfΔ (escape (validTy VF wfΔ Vσ)) in
+  let VΓF := validSnoc VΓ VF in
+  let ρ := @wk1 Δ F[σ]  in
+  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
   [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
   [Δ ||-v σ' : Γ | VΓ | wfΔ ] ->
-  [Δ ,, vass nF F[σ] ||-v (tRel 0 .: σ'⟨ρ⟩) : Γ ,, vass nF F | VΓF | wfΔF].
+  [Δ ,, F[σ] ||-v (tRel 0 .: σ'⟨ρ⟩) : Γ ,, F | VΓF | wfΔF].
 Proof.
   intros; unshelve econstructor.
   + now eapply wk1SubstS.
   + cbn.
-    assert [Δ,, vass nF F[σ] |-[ ta ] tRel 0 : F[S >> (tRel 0 .: σ'⟨ρ⟩)]].
+    assert [Δ,, F[σ] |-[ ta ] tRel 0 : F[S >> (tRel 0 .: σ'⟨ρ⟩)]].
     { replace F[_ >> _] with F[σ']⟨S⟩ by (unfold ρ; now bsimpl).
       eapply ty_conv. 1: apply (ty_var wfΔF (in_here _ _)).
       cbn; renToWk. eapply convty_wk; tea.
@@ -188,42 +188,42 @@ Proof.
     - apply convneu_var; tea.
 Qed.
 
-Lemma liftSubstS' {Γ σ Δ lF F} nF {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+Lemma liftSubstS' {Γ σ Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (VF : [Γ ||-v<lF> F | VΓ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
-  let VΓF := validSnoc nF VΓ VF in
-  let wfΔF := wfc_cons nF wfΔ (escape (validTy VF wfΔ Vσ)) in
-  [Δ ,, vass nF F[σ] ||-v up_term_term σ : Γ ,, vass nF F | VΓF | wfΔF ].
+  let VΓF := validSnoc VΓ VF in
+  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
+  [Δ ,, F[σ] ||-v up_term_term σ : Γ ,, F | VΓF | wfΔF ].
 Proof.
   eapply irrelevanceSubstExt.
   2: eapply liftSubstS.
   intros ?; now bsimpl.
 Qed.
 
-Lemma liftSubstSEq {Γ σ σ' Δ lF nF F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
+Lemma liftSubstSEq {Γ σ σ' Δ lF F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   (VF : [Γ ||-v<lF> F | VΓ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
-  let VΓF := validSnoc nF VΓ VF in
-  let ρ := @wk1 Δ nF F[σ] in
-  let wfΔF := wfc_cons nF wfΔ (escape (validTy VF wfΔ Vσ)) in
+  let VΓF := validSnoc VΓ VF in
+  let ρ := @wk1 Δ F[σ] in
+  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
   let Vliftσ := liftSubstS VΓ wfΔ VF Vσ in
   [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
-  [Δ ,, vass nF F[σ] ||-v (tRel 0 .: σ ⟨ ρ ⟩) ≅ (tRel 0 .: σ' ⟨ ρ ⟩) : Γ ,, vass nF F | VΓF | wfΔF | Vliftσ].
+  [Δ ,, F[σ] ||-v (tRel 0 .: σ ⟨ ρ ⟩) ≅ (tRel 0 .: σ' ⟨ ρ ⟩) : Γ ,, F | VΓF | wfΔF | Vliftσ].
 Proof.
   intros; unshelve econstructor.
   + now apply wk1SubstSEq.
   + apply LREqTermRefl_; exact (validHead Vliftσ).
 Qed.
 
-Lemma liftSubstSEq' {Γ σ σ' Δ lF F} nF {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+Lemma liftSubstSEq' {Γ σ σ' Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (VF : [Γ ||-v<lF> F | VΓ])
   {Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]} :
-  let VΓF := validSnoc nF VΓ VF in
-  let ρ := wk_up nF F (@wk_id Γ) in
-  let wfΔF := wfc_cons nF wfΔ (escape (validTy VF wfΔ Vσ)) in
-  let Vliftσ := liftSubstS' nF VF Vσ in
+  let VΓF := validSnoc VΓ VF in
+  let ρ := wk_up F (@wk_id Γ) in
+  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
+  let Vliftσ := liftSubstS' VF Vσ in
   [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
-  [Δ ,, vass nF F[σ] ||-v up_term_term σ ≅ up_term_term σ' : Γ ,, vass nF F | VΓF | wfΔF | Vliftσ].
+  [Δ ,, F[σ] ||-v up_term_term σ ≅ up_term_term σ' : Γ ,, F | VΓF | wfΔF | Vliftσ].
 Proof.
   intros.
   eapply irrelevanceSubstEq.
@@ -233,15 +233,15 @@ Proof.
   Unshelve. all: tea.
 Qed.
 
-Lemma liftSubstSrealign' {Γ σ σ' Δ lF F} nF {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+Lemma liftSubstSrealign' {Γ σ σ' Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (VF : [Γ ||-v<lF> F | VΓ])
   {Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]} :
-  let VΓF := validSnoc nF VΓ VF in
-  let ρ := wk_up nF F (@wk_id Γ) in
-  let wfΔF := wfc_cons nF wfΔ (escape (validTy VF wfΔ Vσ)) in
+  let VΓF := validSnoc VΓ VF in
+  let ρ := wk_up F (@wk_id Γ) in
+  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
   [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
   [Δ ||-v σ' : Γ | VΓ | wfΔ ] ->
-  [Δ ,, vass nF F[σ] ||-v up_term_term σ' : Γ ,, vass nF F | VΓF | wfΔF].
+  [Δ ,, F[σ] ||-v up_term_term σ' : Γ ,, F | VΓF | wfΔF].
 Proof.
   intros.
   eapply irrelevanceSubstExt.
@@ -249,11 +249,11 @@ Proof.
   intros ?; now bsimpl.
 Qed.
 
-Lemma wk1ValidTy {Γ lA A lF F} {VΓ : [||-v Γ]} nF (VF : [Γ ||-v<lF> F | VΓ]) :
+Lemma wk1ValidTy {Γ lA A lF F} {VΓ : [||-v Γ]} (VF : [Γ ||-v<lF> F | VΓ]) :
   [Γ ||-v<lA> A | VΓ] -> 
-  [Γ ,, vass nF F ||-v<lA> A ⟨ @wk1 Γ nF F ⟩ | validSnoc nF VΓ VF ].
+  [Γ ,, F ||-v<lA> A ⟨ @wk1 Γ F ⟩ | validSnoc VΓ VF ].
 Proof.
-  assert (forall σ, (A ⟨@wk1 Γ nF F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren) ;
+  assert (forall σ, (A ⟨@wk1 Γ F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren) ;
   intros [VA VAext]; unshelve econstructor.
   - abstract (intros * [tl _]; rewrite h; exact (VA _ _ wfΔ tl)).
   - intros * [tl _] [tleq _].
@@ -264,12 +264,12 @@ Proof.
     eapply symmetrySubstEq. eassumption.
 Qed.
 
-Lemma wk1ValidTyEq {Γ lA A B lF F} {VΓ : [||-v Γ]} nF (VF : [Γ ||-v<lF> F | VΓ]) 
+Lemma wk1ValidTyEq {Γ lA A B lF F} {VΓ : [||-v Γ]} (VF : [Γ ||-v<lF> F | VΓ]) 
   {VA : [Γ ||-v<lA> A | VΓ]} :
   [Γ ||-v<lA> A ≅ B | VΓ | VA] -> 
-  [Γ ,, vass nF F ||-v<lA> A ⟨ @wk1 Γ nF F ⟩ ≅ B ⟨ @wk1 Γ nF F ⟩ | validSnoc nF VΓ VF | wk1ValidTy nF VF VA].
+  [Γ ,, F ||-v<lA> A ⟨ @wk1 Γ F ⟩ ≅ B ⟨ @wk1 Γ F ⟩ | validSnoc VΓ VF | wk1ValidTy VF VA].
 Proof.
-  assert (forall A σ, (A ⟨@wk1 Γ nF F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren).
+  assert (forall A σ, (A ⟨@wk1 Γ F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren).
   intros []; constructor; intros.
   rewrite h. irrelevance0.
   1: symmetry; apply h.
@@ -277,24 +277,24 @@ Proof.
 Qed.
 
 Lemma wk1ValidTm {Γ lA t A lF F} {VΓ : [||-v Γ]}
-  nF (VF : [Γ ||-v<lF> F | VΓ])
+  (VF : [Γ ||-v<lF> F | VΓ])
   (VA : [Γ ||-v<lA> A | VΓ])
-  (Vt : [Γ ||-v<lA> t : A | VΓ | VA]) (ρ := @wk1 Γ nF F):
-  [Γ,, vass nF F ||-v<lA> t⟨ρ⟩ : A⟨ρ⟩ | validSnoc nF VΓ VF | wk1ValidTy nF VF VA].
+  (Vt : [Γ ||-v<lA> t : A | VΓ | VA]) (ρ := @wk1 Γ F):
+  [Γ,, F ||-v<lA> t⟨ρ⟩ : A⟨ρ⟩ | validSnoc VΓ VF | wk1ValidTy VF VA].
 Proof.
-  assert (forall A σ, (A ⟨@wk1 Γ nF F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren).
+  assert (forall A σ, (A ⟨@wk1 Γ F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren).
   constructor; intros; repeat rewrite h.
   - instValid (validTail Vσ); irrelevance.
   - instValidExt (validTail Vσ') (eqTail Vσσ'); irrelevance.
 Qed.
 
 Lemma wk1ValidTmEq {Γ lA t u A lF F} {VΓ : [||-v Γ]}
-  nF (VF : [Γ ||-v<lF> F | VΓ])
+  (VF : [Γ ||-v<lF> F | VΓ])
   (VA : [Γ ||-v<lA> A | VΓ])
-  (Vtu : [Γ ||-v<lA> t ≅ u : A | VΓ | VA]) (ρ := @wk1 Γ nF F):
-  [Γ,, vass nF F ||-v<lA> t⟨ρ⟩ ≅ u⟨ρ⟩ : A⟨ρ⟩ | validSnoc nF VΓ VF | wk1ValidTy nF VF VA].
+  (Vtu : [Γ ||-v<lA> t ≅ u : A | VΓ | VA]) (ρ := @wk1 Γ F):
+  [Γ,, F ||-v<lA> t⟨ρ⟩ ≅ u⟨ρ⟩ : A⟨ρ⟩ | validSnoc VΓ VF | wk1ValidTy VF VA].
 Proof.
-  assert (forall A σ, (A ⟨@wk1 Γ nF F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren).
+  assert (forall A σ, (A ⟨@wk1 Γ F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren).
   constructor; intros; repeat rewrite h.
   instValid (validTail Vσ); irrelevance.
 Qed.
@@ -327,7 +327,7 @@ Proof.
   pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - exists ε, eq_refl, wfc_nil; constructor.
   - intros * [Δ [e [wfΔ Vid]]].
-    exists (Δ,, vass na A[tRel]); unshelve eexists. 
+    exists (Δ,, A[tRel]); unshelve eexists. 
     1: asimpl; now rewrite e.
     unshelve eexists.
     + apply wfc_cons; tea.

--- a/theories/Substitution/SingleSubst.v
+++ b/theories/Substitution/SingleSubst.v
@@ -14,9 +14,9 @@ Lemma singleSubstComm G t σ : G[t..][σ] = G[t[σ] .: σ].
 Proof. now asimpl. Qed.
 
 
-Lemma substS {Γ F G t l} {VΓ : [||-v Γ]} nF
+Lemma substS {Γ F G t l} {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
-  (VG : [Γ,, vass nF F ||-v<l> G | validSnoc nF VΓ VF])
+  (VG : [Γ,, F ||-v<l> G | validSnoc VΓ VF])
   (Vt : [Γ ||-v<l> t : F | VΓ | VF]) :
   [Γ ||-v<l> G[t..] | VΓ].
 Proof.
@@ -30,25 +30,25 @@ Proof.
     Unshelve. all: eassumption.
 Qed.
 
-Lemma substSEq {Γ F F' G G' t t' l} {VΓ : [||-v Γ]} nF 
+Lemma substSEq {Γ F F' G G' t t' l} {VΓ : [||-v Γ]} 
   {VF : [Γ ||-v<l> F | VΓ]}
   {VF' : [Γ ||-v<l> F' | VΓ]}
   (VFF' : [Γ ||-v<l> F ≅ F' | VΓ | VF])
-  (VΓF := validSnoc nF VΓ VF)
-  (VΓF' := validSnoc nF VΓ VF')
-  {VG : [Γ,, vass nF F ||-v<l> G | VΓF]}
-  (VG' : [Γ,, vass nF F' ||-v<l> G' | VΓF'])
-  (VGG' : [Γ ,, vass nF F ||-v<l> G ≅ G' | VΓF | VG])
+  (VΓF := validSnoc VΓ VF)
+  (VΓF' := validSnoc VΓ VF')
+  {VG : [Γ,, F ||-v<l> G | VΓF]}
+  (VG' : [Γ,, F' ||-v<l> G' | VΓF'])
+  (VGG' : [Γ ,, F ||-v<l> G ≅ G' | VΓF | VG])
   (Vt : [Γ ||-v<l> t : F | VΓ | VF])
   (Vt' : [Γ ||-v<l> t' : F' | VΓ | VF'])
   (Vtt' : [Γ ||-v<l> t ≅ t' : F | VΓ | VF])
-  (VGt := substS nF VG Vt) :
+  (VGt := substS VG Vt) :
   [Γ ||-v<l> G[t..] ≅ G'[t'..] | VΓ | VGt].
 Proof.
   constructor; intros.
   assert (VtF' : [Γ ||-v<l> t : F' | VΓ | VF']) by now eapply conv.
-  pose proof (consSubstSvalid (nA:=nF) _ _ Vσ _ Vt').
-  pose proof (consSubstSvalid (nA:=nF) _ _ Vσ _ VtF').
+  pose proof (consSubstSvalid _ _ Vσ _ Vt').
+  pose proof (consSubstSvalid _ _ Vσ _ VtF').
   rewrite singleSubstComm; irrelevance0.
   1: symmetry; apply singleSubstComm.
   eapply transEq.
@@ -66,13 +66,13 @@ Qed.
 
 
 
-Lemma substSTm {Γ F G t f l} {VΓ : [||-v Γ]} nF
+Lemma substSTm {Γ F G t f l} {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
-  (VΓF := validSnoc nF VΓ VF)
-  {VG : [Γ,, vass nF F ||-v<l> G | VΓF]}
+  (VΓF := validSnoc VΓ VF)
+  {VG : [Γ,, F ||-v<l> G | VΓF]}
   (Vt : [Γ ||-v<l> t : F | VΓ | VF]) 
-  (Vf : [Γ ,, vass nF F ||-v<l> f : G | VΓF | VG])
-  (VGt := substS nF VG Vt) :
+  (Vf : [Γ ,, F ||-v<l> f : G | VΓF | VG])
+  (VGt := substS VG Vt) :
   [Γ ||-v<l> f[t..] : G[t..] | VΓ | VGt].
 Proof.
   constructor; intros; rewrite !singleSubstComm; irrelevance0. 
@@ -85,22 +85,22 @@ Proof.
     now apply consSubstSvalid.
 Qed.
 
-Lemma substSTmEq {Γ F F' G G' t t' f f' l} (VΓ : [||-v Γ]) nF 
+Lemma substSTmEq {Γ F F' G G' t t' f f' l} (VΓ : [||-v Γ]) 
   (VF : [Γ ||-v<l> F | VΓ])
   (VF' : [Γ ||-v<l> F' | VΓ])
   (VFF' : [Γ ||-v<l> F ≅ F' | VΓ | VF])
-  (VΓF := validSnoc nF VΓ VF)
-  (VΓF' := validSnoc nF VΓ VF')
-  (VG : [Γ,, vass nF F ||-v<l> G | VΓF])
-  (VG' : [Γ,, vass nF F' ||-v<l> G' | VΓF'])
-  (VGG' : [Γ ,, vass nF F ||-v<l> G ≅ G' | VΓF | VG])
+  (VΓF := validSnoc VΓ VF)
+  (VΓF' := validSnoc VΓ VF')
+  (VG : [Γ,, F ||-v<l> G | VΓF])
+  (VG' : [Γ,, F' ||-v<l> G' | VΓF'])
+  (VGG' : [Γ ,, F ||-v<l> G ≅ G' | VΓF | VG])
   (Vt : [Γ ||-v<l> t : F | VΓ | VF])
   (Vt' : [Γ ||-v<l> t' : F' | VΓ | VF'])
   (Vtt' : [Γ ||-v<l> t ≅ t' : F | VΓ | VF]) 
-  (Vf : [Γ ,, vass nF F ||-v<l> f : G | VΓF | VG])
-  (Vf' : [Γ ,, vass nF F' ||-v<l> f' : G' | VΓF' | VG'])
-  (Vff' : [Γ ,, vass nF F ||-v<l> f ≅ f' : G | VΓF | VG]) :
-  [Γ ||-v<l> f[t..] ≅ f'[t'..] : G[t..] | VΓ | substS nF VG Vt].
+  (Vf : [Γ ,, F ||-v<l> f : G | VΓF | VG])
+  (Vf' : [Γ ,, F' ||-v<l> f' : G' | VΓF' | VG'])
+  (Vff' : [Γ ,, F ||-v<l> f ≅ f' : G | VΓF | VG]) :
+  [Γ ||-v<l> f[t..] ≅ f'[t'..] : G[t..] | VΓ | substS VG Vt].
 Proof.
   constructor; intros; rewrite !singleSubstComm; irrelevance0. 
   1: symmetry; apply singleSubstComm.
@@ -130,16 +130,16 @@ Lemma liftSubstComm G t σ : G[t]⇑[σ] = G[t[σ] .: ↑ >> σ].
 Proof. now bsimpl. Qed.
 
 
-Lemma substLiftS {Γ F G t l} (VΓ : [||-v Γ]) nF
+Lemma substLiftS {Γ F G t l} (VΓ : [||-v Γ])
   (VF : [Γ ||-v<l> F | VΓ])
-  (VΓF := validSnoc nF VΓ VF)
-  (VG : [Γ,, vass nF F ||-v<l> G | VΓF])
-  (VF' := wk1ValidTy nF VF VF)
-  (Vt : [Γ,, vass nF F ||-v<l> t : F⟨@wk1 Γ nF F⟩ | VΓF | VF']) :
-  [Γ ,, vass nF F ||-v<l> G[t]⇑ | VΓF].
+  (VΓF := validSnoc VΓ VF)
+  (VG : [Γ,, F ||-v<l> G | VΓF])
+  (VF' := wk1ValidTy VF VF)
+  (Vt : [Γ,, F ||-v<l> t : F⟨@wk1 Γ F⟩ | VΓF | VF']) :
+  [Γ ,, F ||-v<l> G[t]⇑ | VΓF].
 Proof.
   assert (h : forall Δ σ (wfΔ: [|- Δ])
-    (vσ: [VΓF | Δ ||-v σ : Γ,, vass nF F | wfΔ]),
+    (vσ: [VΓF | Δ ||-v σ : Γ,, F | wfΔ]),
     [VΓF | Δ ||-v (t[σ] .: ↑ >> σ) : _ | wfΔ ]).
   1:{
     unshelve econstructor.
@@ -164,15 +164,15 @@ Proof.
       Unshelve. all:tea.
 Qed.
 
-Lemma substLiftSEq {Γ F G G' t l} (VΓ : [||-v Γ]) nF
+Lemma substLiftSEq {Γ F G G' t l} (VΓ : [||-v Γ])
   (VF : [Γ ||-v<l> F | VΓ])
-  (VΓF := validSnoc nF VΓ VF)
-  (VG : [Γ,, vass nF F ||-v<l> G | VΓF])
-  (VG' : [Γ,, vass nF F ||-v<l> G' | VΓF])
-  (VGeq : [Γ,, vass nF F ||-v<l> G ≅ G' | VΓF | VG])
-  (VF' := wk1ValidTy nF VF VF)
-  (Vt : [Γ,, vass nF F ||-v<l> t : F⟨@wk1 Γ nF F⟩ | VΓF | VF']) :
-  [Γ ,, vass nF F ||-v<l> G[t]⇑ ≅ G'[t]⇑ | VΓF | substLiftS _ nF VF VG Vt].
+  (VΓF := validSnoc VΓ VF)
+  (VG : [Γ,, F ||-v<l> G | VΓF])
+  (VG' : [Γ,, F ||-v<l> G' | VΓF])
+  (VGeq : [Γ,, F ||-v<l> G ≅ G' | VΓF | VG])
+  (VF' := wk1ValidTy VF VF)
+  (Vt : [Γ,, F ||-v<l> t : F⟨@wk1 Γ F⟩ | VΓF | VF']) :
+  [Γ ,, F ||-v<l> G[t]⇑ ≅ G'[t]⇑ | VΓF | substLiftS _ VF VG Vt].
 Proof.
   constructor; intros; rewrite liftSubstComm.
   assert (Vσt : [Δ ||-v (t[σ] .: ↑ >> σ) : _ | VΓF | wfΔ ]). 1:{
@@ -183,13 +183,13 @@ Proof.
   instValid Vσt. irrelevance.
 Qed.
 
-Lemma singleSubstΠ1 {Γ nF F G t l lF}
-  (ΠFG : [Γ ||-<l> tProd nF F G])
+Lemma singleSubstΠ1 {Γ F G t l lF}
+  (ΠFG : [Γ ||-<l> tProd F G])
   {RF : [Γ ||-<lF> F]}
   (Rt : [Γ ||-<lF> t : F | RF]) :
   [Γ ||-<l> G[t..]].
 Proof.
-  apply invLRΠ in ΠFG; destruct ΠFG as [??? red ??? domRed codRed].
+  apply invLRΠ in ΠFG; destruct ΠFG as [?? red ??? domRed codRed].
   unshelve eassert (h :=redtywf_whnf red _).
   1: constructor.
   symmetry in h; injection h; clear h; intros ;  subst.
@@ -200,9 +200,9 @@ Proof.
   now bsimpl.
 Qed.
 
-Lemma singleSubstΠ2 {Γ nF nF' F F' G G' t t' l lF lF'}
-  {ΠFG : [Γ ||-<l> tProd nF F G]}
-  (ΠFGeq : [Γ ||-<l> tProd nF F G ≅ tProd nF' F' G' | ΠFG])
+Lemma singleSubstΠ2 {Γ F F' G G' t t' l lF lF'}
+  {ΠFG : [Γ ||-<l> tProd F G]}
+  (ΠFGeq : [Γ ||-<l> tProd F G ≅ tProd F' G' | ΠFG])
   {RF : [Γ ||-<lF> F]}
   {RF' : [Γ ||-<lF'> F']}
   (Rt : [Γ ||-<lF> t : F | RF]) 
@@ -213,10 +213,10 @@ Lemma singleSubstΠ2 {Γ nF nF' F F' G G' t t' l lF lF'}
   [Γ ||-<lF> G[t..] ≅ G'[t'..] | RGt ].
 Proof.
   pose (hΠ := invLRΠ ΠFG).
-  assert (heq : [Γ ||-<l> tProd nF F G ≅ tProd nF' F' G' | LRPi' hΠ]) by irrelevance.
-  destruct hΠ as [??? red ??? domRed codRed codExt]; clear ΠFG ΠFGeq.
+  assert (heq : [Γ ||-<l> tProd F G ≅ tProd F' G' | LRPi' hΠ]) by irrelevance.
+  destruct hΠ as [?? red ??? domRed codRed codExt]; clear ΠFG ΠFGeq.
   assert (wfΓ : [|-Γ]) by gen_typing.
-  destruct heq as [??? red' ? domRedEq codRedEq]; cbn in *.
+  destruct heq as [?? red' ? domRedEq codRedEq]; cbn in *.
   unshelve eassert (h :=redtywf_whnf red _).  1: constructor.
   unshelve eassert (h' :=redtywf_whnf red' _).  1: constructor.
   symmetry in h; symmetry in h' ; injection h; injection h'; clear h h'; intros ;  subst.
@@ -238,10 +238,10 @@ Proof.
   irrelevance0; tea; now bsimpl.
 Qed.
 
-Lemma substSΠaux {Γ nF F G t l} 
+Lemma substSΠaux {Γ F G t l} 
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
-  (VΠFG : [Γ ||-v<l> tProd nF F G | VΓ])
+  (VΠFG : [Γ ||-v<l> tProd F G | VΓ])
   (Vt : [Γ ||-v<l> t : F | VΓ | VF])
   (Δ : context) (σ : nat -> term) 
   (wfΔ : [ |-[ ta ] Δ]) (vσ : [VΓ | Δ ||-v σ : Γ | wfΔ]) :
@@ -256,10 +256,10 @@ Qed.
 Lemma singleSubstComm' G t σ : G[t..][σ] = G[up_term_term σ][t[σ]..].
 Proof. now asimpl. Qed.
 
-Lemma substSΠ {Γ nF F G t l} 
+Lemma substSΠ {Γ F G t l} 
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
-  (VΠFG : [Γ ||-v<l> tProd nF F G | VΓ])
+  (VΠFG : [Γ ||-v<l> tProd F G | VΓ])
   (Vt : [Γ ||-v<l> t : F | VΓ | VF]) :
   [Γ ||-v<l> G[t..] | VΓ].
 Proof.
@@ -277,13 +277,13 @@ Proof.
     now eapply substSΠaux.
 Qed.
 
-Lemma substSΠeq {Γ nF nF' F F' G G' t u l} 
+Lemma substSΠeq {Γ F F' G G' t u l} 
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
   {VF' : [Γ ||-v<l> F' | VΓ]}
-  {VΠFG : [Γ ||-v<l> tProd nF F G | VΓ]}
-  (VΠFG' : [Γ ||-v<l> tProd nF' F' G' | VΓ])
-  (VΠFGeq : [Γ ||-v<l> tProd nF F G ≅ tProd nF' F' G' | VΓ | VΠFG])
+  {VΠFG : [Γ ||-v<l> tProd F G | VΓ]}
+  (VΠFG' : [Γ ||-v<l> tProd F' G' | VΓ])
+  (VΠFGeq : [Γ ||-v<l> tProd F G ≅ tProd F' G' | VΓ | VΠFG])
   (Vt : [Γ ||-v<l> t : F | VΓ | VF]) 
   (Vu : [Γ ||-v<l> u : F' | VΓ | VF']) 
   (Vtu : [Γ ||-v<l> t ≅ u : F | VΓ | VF]) 

--- a/theories/UntypedReduction.v
+++ b/theories/UntypedReduction.v
@@ -8,8 +8,8 @@ From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakenin
 (** *** One-step reduction. *)
 
 Inductive OneRedAlg : term -> term -> Type :=
-| BRed {na} {A a t} :
-    [ tApp (tLambda na A t) a ⇒ t[a..] ]
+| BRed {A a t} :
+    [ tApp (tLambda A t) a ⇒ t[a..] ]
 | appSubst {t u a} :
     [ t ⇒ u ] ->
     [ tApp t a ⇒ tApp u a ]

--- a/theories/UntypedValues.v
+++ b/theories/UntypedValues.v
@@ -5,8 +5,8 @@ Unset Elimination Schemes.
 
 Inductive snf (r : term) : Type :=
   | snf_tSort {s} : [ r ⇒* tSort s ] -> snf r
-  | snf_tProd {na A B} : [ r ⇒* tProd na A B ] -> snf A -> snf B -> snf r
-  | snf_tLambda {na A t} : [ r ⇒* tLambda na A t ] -> snf A -> snf t -> snf r
+  | snf_tProd {A B} : [ r ⇒* tProd A B ] -> snf A -> snf B -> snf r
+  | snf_tLambda {A t} : [ r ⇒* tLambda A t ] -> snf A -> snf t -> snf r
   | snf_tNat : [ r ⇒* tNat ] -> snf r
   | snf_tZero : [ r ⇒* tZero ] -> snf r
   | snf_tSucc {n} : [ r ⇒* tSucc n ] -> snf n -> snf r
@@ -73,11 +73,11 @@ Qed.
 
 Inductive isSNType : term -> Type :=
   | UnivType {s} : isSNType (tSort s)
-  | ProdType {na A B} : snf A -> snf B -> isSNType (tProd na A B)
+  | ProdType {A B} : snf A -> snf B -> isSNType (tProd A B)
   | NeType {A}  : sne A -> isSNType A.
 
 Inductive isSNFun : term -> Type :=
-  | LamFun {na A t} : snf A -> snf t -> isSNFun (tLambda na A t)
+  | LamFun {A t} : snf A -> snf t -> isSNFun (tLambda A t)
   | NeFun  {f} : sne f -> isSNFun f.
 
 Lemma isSNType_snf t : isSNType t -> snf t.
@@ -126,10 +126,10 @@ Section RenSnf.
   + intros r s Hr ρ.
     apply credalg_wk with (ρ := ρ) in Hr.
     eapply snf_tSort; eassumption.
-  + intros r na A B Hr HA IHA HB IHB ρ.
+  + intros r A B Hr HA IHA HB IHB ρ.
     apply credalg_wk with (ρ := ρ) in Hr.
     eapply snf_tProd; eauto.
-  + intros r na A t Hr HA IHA Ht IHt ρ.
+  + intros r A t Hr HA IHA Ht IHt ρ.
     apply credalg_wk with (ρ := ρ) in Hr.
     eapply snf_tLambda; eauto.
   + intros r Hr ρ.

--- a/theories/Validity.v
+++ b/theories/Validity.v
@@ -126,7 +126,7 @@ Section snocValid.
       eqHead : [ Δ ||-< l > σ var_zero ≅ σ' var_zero : A[↑ >> σ] | validTy vA wfΔ (validTail vσ) ]
     }.
 
-  Definition snocVPack na := Build_VPack@{u (* max(u,k) *)} (Γ ,, vass na A) snocValidSubst (@snocEqSubst).
+  Definition snocVPack := Build_VPack@{u (* max(u,k) *)} (Γ ,, A) snocValidSubst (@snocEqSubst).
 End snocValid.
 
 Arguments snocValidSubst : clear implicits.
@@ -145,11 +145,11 @@ Inductive VR@{i j k l} `{ta : tag}
   `{ConvType ta} `{ConvTerm ta} `{ConvNeuConv ta}
   `{RedType ta} `{!TypeNf ta} `{!TypeNe ta} `{RedTerm ta} `{!TermNf ta} `{!TermNe ta} : VRel@{k l} :=
   | VREmpty : VR ε emptyValidSubst@{k} emptyEqSubst@{k}
-  | VRSnoc : forall {Γ na A l}
+  | VRSnoc : forall {Γ A l}
     (VΓ : VPack@{k} Γ)
     (VΓad : VPackAdequate@{k l} VR VΓ)
     (VA : typeValidity@{k i j k l} Γ VΓ l A (*[ VΓ | Γ ||-v< l > A ]*)),
-    VR (Γ ,, vass na A) (snocValidSubst Γ VΓ A l VA) (snocEqSubst Γ VΓ A l VA).
+    VR (Γ ,, A) (snocValidSubst Γ VΓ A l VA) (snocEqSubst Γ VΓ A l VA).
 
 
 Set Elimination Schemes.
@@ -166,10 +166,10 @@ Section MoreDefs.
 
   Definition validEmpty@{i j k l} : [VR@{i j k l}| ||-v ε ] := Build_VAdequate emptyVPack VREmpty.
 
-  Definition validSnoc@{i j k l} {Γ} na {A l}
+  Definition validSnoc@{i j k l} {Γ} {A l}
     (VΓ : [VR@{i j k l}| ||-v Γ]) (VA : [Γ ||-v< l > A | VΓ])
-    : [||-v Γ ,, vass na A ] :=
-    Build_VAdequate (snocVPack Γ VΓ A l VA na) (VRSnoc VΓ VΓ VA).
+    : [||-v Γ ,, A ] :=
+    Build_VAdequate (snocVPack Γ VΓ A l VA) (VRSnoc VΓ VΓ VA).
 
   Record termValidity@{i j k l} {Γ l} {t A : term}
     {VΓ : [VR@{i j k l}| ||-v Γ]}
@@ -253,8 +253,8 @@ Section Inductions.
   Theorem VR_rect
     (P : forall {Γ vSubst vSubstExt}, VR Γ vSubst vSubstExt -> Type)
     (hε : P VREmpty)
-    (hsnoc : forall {Γ na A l VΓ VΓad VA},
-      P VΓad -> P (VRSnoc (Γ := Γ) (na := na) (A := A) (l := l) VΓ VΓad VA)) :
+    (hsnoc : forall {Γ A l VΓ VΓad VA},
+      P VΓad -> P (VRSnoc (Γ := Γ) (A := A) (l := l) VΓ VΓad VA)) :
     forall {Γ vSubst vSubstExt} (VΓ : VR Γ vSubst vSubstExt), P VΓ.
   Proof.
     fix ih 4; destruct VΓ; [exact hε | apply hsnoc; apply ih].
@@ -263,7 +263,7 @@ Section Inductions.
   Theorem validity_rect
     (P : forall {Γ : context}, [||-v Γ] -> Type)
     (hε : P validEmpty)
-    (hsnoc : forall {Γ na A l} (VΓ : [||-v Γ]) (VA : [Γ ||-v< l > A | VΓ]), P VΓ -> P (validSnoc na VΓ VA)) :
+    (hsnoc : forall {Γ A l} (VΓ : [||-v Γ]) (VA : [Γ ||-v< l > A | VΓ]), P VΓ -> P (validSnoc VΓ VA)) :
     forall {Γ : context} (VΓ : [||-v Γ]), P VΓ.
   Proof.
     intros Γ [[s eq] VΓad]; revert Γ s eq VΓad.
@@ -275,8 +275,8 @@ Section Inductions.
   Lemma invValidity {Γ} (VΓ : [||-v Γ]) :
     match Γ as Γ return [||-v Γ] -> Type with
     | nil => fun VΓ₀ => VΓ₀ = validEmpty
-    | ({| decl_name := na ; decl_type := A|} :: Γ)%list => fun VΓ₀ =>
-      ∑ l (VΓ : [||-v Γ]) (VA : [Γ ||-v< l > A | VΓ]), VΓ₀ = validSnoc na VΓ VA
+    | (A :: Γ)%list => fun VΓ₀ =>
+      ∑ l (VΓ : [||-v Γ]) (VA : [Γ ||-v< l > A | VΓ]), VΓ₀ = validSnoc VΓ VA
     end VΓ.
   Proof.
     pattern Γ, VΓ. apply validity_rect.
@@ -287,8 +287,8 @@ Section Inductions.
   Lemma invValidityEmpty (VΓ : [||-v ε]) : VΓ = validEmpty.
   Proof. apply (invValidity VΓ). Qed.
 
-  Lemma invValiditySnoc {Γ na A} (VΓ₀ : [||-v Γ ,, vass na A ]) :
-      ∑ l (VΓ : [||-v Γ]) (VA : [Γ ||-v< l > A | VΓ]), VΓ₀ = validSnoc na VΓ VA.
+  Lemma invValiditySnoc {Γ A} (VΓ₀ : [||-v Γ ,, A ]) :
+      ∑ l (VΓ : [||-v Γ]) (VA : [Γ ||-v< l > A | VΓ]), VΓ₀ = validSnoc VΓ VA.
   Proof. apply (invValidity VΓ₀). Qed.
 
 End Inductions.


### PR DESCRIPTION
Remove the redundant typing constraint on well-typed multi-step reduction, remove binder names (up to `LogRelConsequences.v`) and move some generic lemmas.