### PR TITLE
Add type reification as part of the main nbe lemma

### DIFF
--- a/theories/LogicalRelation/Escape.v
+++ b/theories/LogicalRelation/Escape.v
@@ -77,6 +77,19 @@ Section Escapes.
     - intros ??? [] []; cbn in *.
       eapply convtm_exp; tea; gen_typing.
   Qed.
+
+  Lemma escapeConv {l Γ A} (RA : [Γ ||-<l> A]) :
+    forall B,
+    [Γ ||-<l> A ≅ B | RA] ->
+    [Γ |- B].
+  Proof.
+    pattern l, Γ, A, RA; eapply LR_rect_TyUr; clear l Γ A RA.
+    - intros * []; gen_typing.
+    - intros * []; gen_typing.
+    - intros * ihdom ihcod ? []; gen_typing.
+    - intros * []; gen_typing.
+    - intros * []; gen_typing.
+  Qed.
   
 End Escapes.
 


### PR DESCRIPTION
This PR adds a variant of type reification to the `complete` record, so that type reification can be used on inductive hypothesis (this is useful for inductive with parameters such as lists).