### PR TITLE
refold weakenings

### DIFF
--- a/theories/AutoSubst/Extra.v
+++ b/theories/AutoSubst/Extra.v
@@ -36,13 +36,19 @@ Notation "'eta_expand' f" := (tApp f⟨↑⟩ (tRel 0)) (at level 40, only parsi
 #[global] Instance Ren1_subst {Y Z : Type} `{Ren1 (nat -> nat) Y Z} :
   (Ren1 (nat -> nat) (nat -> Y) (nat -> Z)) :=
   fun ρ σ i => (σ i)⟨ρ⟩.
-
+    
 Ltac fold_autosubst :=
+    fold ren_term ;
+    fold subst_term.
+
+Smpl Add fold_autosubst : refold.
+
+Ltac change_autosubst :=
     change ren_term with (@ren1 _ _ _ Ren_term) in * ;
     change subst_term with (@subst1 _ _ _ Subst_term) in *;
     change (fun i => (?σ i)⟨?ρ⟩) with (@ren1 _ _ _ Ren1_subst ρ σ) in *.
 
-Smpl Add fold_autosubst : refold.
+Smpl Add 50 change_autosubst : refold.
 
 Arguments ren1 {_ _ _}%type_scope {Ren1} _ !_/.
 (* Ideally, we'd like Ren_term to not be there, and ren_term to be directly the Ren1 instance… *)
@@ -57,3 +63,7 @@ Lemma arr_ren1 {A B} : forall ρ, (arr A B)⟨ρ⟩ = arr A⟨ρ⟩ B⟨ρ⟩.
 Proof.
   now asimpl.
 Qed.
+
+Definition elimSuccHypTy P :=
+  tProd tNat (arr P P[tSucc (tRel 0)]⇑).
+

--- a/theories/DeclarativeInstance.v
+++ b/theories/DeclarativeInstance.v
@@ -61,6 +61,8 @@ Qed.
 Lemma subst_ren_wk_up {Γ Δ P A} {ρ : Γ ≤ Δ}: forall n, P[n..]⟨ρ⟩ = P⟨wk_up A ρ⟩[n⟨ρ⟩..].
 Proof. intros; now bsimpl. Qed.
 
+Lemma shift_up_ren {Γ Δ t} (ρ : Δ ≤ Γ) : t⟨ρ⟩⟨↑⟩ = t⟨↑ >> up_ren ρ⟩.
+Proof. now asimpl. Qed.
 
 Section TypingWk.
   Import DeclarativeTypingData.
@@ -131,16 +133,14 @@ Section TypingWk.
       * eapply typing_meta_conv.
         1: now eapply ihhz.
         now erewrite subst_ren_wk_up.
-      * eapply typing_meta_conv.
-        1: now eapply ihhs.
-        unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
+      * rewrite wk_elimSuccHypTy.
+        now eapply ihhs.
       * now eapply ihn.
     - intros; now constructor.
     - intros * ? ihP ? ihe **; cbn.
       erewrite subst_ren_wk_up; eapply wfTermEmptyElim.
       * eapply ihP; econstructor; tea; now econstructor.
       * now eapply ihe.
-
     - intros * _ IHt _ IHAB ? ρ ?.
       econstructor.
       1: now eapply IHt.
@@ -202,7 +202,8 @@ Section TypingWk.
       cbn in IHe.
       repeat rewrite renRen_term in IHe.
       cbn in * ; refold.
-      bsimpl.
+      do 2 rewrite shift_up_ren.
+      erewrite <- wk_up_ren_on.
       eapply IHe.
       econstructor ; tea.
       now eapply IHA.
@@ -215,10 +216,8 @@ Section TypingWk.
         1: now eapply ihhz.
         2: reflexivity.
         now erewrite subst_ren_wk_up.
-      * eapply convtm_meta_conv.
-        1: now eapply ihhs.
-        2: reflexivity.
-        unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
+      * rewrite wk_elimSuccHypTy. 
+        now eapply ihhs.
       * now eapply ihn.
     - intros * ? ihP ? ihhz ? ihhs **.
       erewrite subst_ren_wk_up.
@@ -227,9 +226,8 @@ Section TypingWk.
       * eapply typing_meta_conv.
         1: now eapply ihhz.
         now erewrite subst_ren_wk_up.
-      * eapply typing_meta_conv.
-        1: now eapply ihhs.
-        unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
+      * rewrite wk_elimSuccHypTy.
+        now eapply ihhs.
     - intros * ? ihP ? ihhz ? ihhs ? ihn **.
       erewrite subst_ren_wk_up.
       eapply TermNatElimSucc; fold ren_term.
@@ -237,9 +235,8 @@ Section TypingWk.
       * eapply typing_meta_conv.
         1: now eapply ihhz.
         now erewrite subst_ren_wk_up.
-      * eapply typing_meta_conv.
-        1: now eapply ihhs.
-        unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
+      * rewrite wk_elimSuccHypTy.
+        now eapply ihhs.
       * now eapply ihn.
     - intros * ? ihP ? ihe **; cbn.
       erewrite subst_ren_wk_up.
@@ -438,8 +435,8 @@ Proof.
       econstructor ; tea.
       now eapply typing_wk.
     + now eapply typing_wk.
-    + now asimpl.
-    + now asimpl. 
+    + apply subst_ren_wk_up.
+    + unshelve eapply subst_ren_wk_up; tea.
   - cbn in *.
     eapply oredtm_meta_conv.
     1: econstructor.
@@ -454,10 +451,10 @@ Proof.
       constructor; tea; now constructor.
     * eapply typing_meta_conv.
       1: now eapply typing_wk.
-      now bsimpl.
-    * eapply typing_meta_conv.
-      1: now eapply typing_wk.
-      unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
+      symmetry; unshelve eapply subst_ren_wk_up; tea.
+    * unshelve erewrite <- wk_up_ren_on; tea.
+      rewrite wk_elimSuccHypTy.
+      now eapply typing_wk.
     Unshelve. all: tea.
   - cbn. erewrite subst_ren_wk_up.
     eapply natElimZero; tea.
@@ -466,10 +463,10 @@ Proof.
       constructor; tea; now constructor.
     * eapply typing_meta_conv.
       1: now eapply typing_wk.
-      now bsimpl.
-    * eapply typing_meta_conv.
-      1: now eapply typing_wk.
-      unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
+      symmetry; unshelve eapply subst_ren_wk_up; tea.
+    * unshelve erewrite <- wk_up_ren_on; tea.
+      rewrite wk_elimSuccHypTy.
+      now eapply typing_wk.
     Unshelve. all: tea.
   - cbn. erewrite (subst_ren_wk_up (A := tNat)).
     eapply natElimSucc.
@@ -478,10 +475,10 @@ Proof.
       constructor; tea; now constructor.
     * eapply typing_meta_conv.
       1: now eapply typing_wk.
-      now bsimpl.
-    * eapply typing_meta_conv.
-      1: now eapply typing_wk.
-      unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
+      symmetry; unshelve eapply subst_ren_wk_up; tea.
+    * unshelve erewrite <- wk_up_ren_on; tea.
+      rewrite wk_elimSuccHypTy.
+      now eapply typing_wk.
     * change tNat with tNat⟨ρ⟩; now eapply typing_wk.
   - cbn. erewrite subst_ren_wk_up.
     eapply (@emptyElimSubst _); tea.

--- a/theories/DeclarativeTyping.v
+++ b/theories/DeclarativeTyping.v
@@ -11,9 +11,6 @@ or typing, done in a declarative fashion. For instance, we _demand_ that convers
 be transitive by adding a corresponding rule. *)
 
 (** ** Definitions *)
-Definition elimSuccHypTy P :=
-  tProd tNat (arr P P[tSucc (tRel 0)]⇑).
-
 Section Definitions.
 
   (* We locally disable typing notations to be able to use them in the definition

--- a/theories/Weakening.v
+++ b/theories/Weakening.v
@@ -143,10 +143,18 @@ Arguments Ren1_wk {_ _ _} _ _/.
 Arguments Ren1_well_wk {_ _ _ _ _} _ _/.
 
 Ltac fold_wk_ren :=
-  change ?t⟨wk_to_ren ?ρ⟩ with t⟨ρ⟩ in * ;
-  change ?t⟨wk_to_ren ?ρ.(wk)⟩ with t⟨ρ⟩ in *.
+  change (@ren1 _ _ _ Ren_term (wk_to_ren (@wk _ _ ?ρ)))
+    with (@ren1 _ _ _ (@Ren1_well_wk _ _ _ _ _) ρ);
+  change (@ren1 _ _ _ (@Ren1_wk _ _ _) (@wk _ _ ?ρ))
+    with (@ren1 _ _ _ (@Ren1_well_wk _ _ _ _ _) ρ).
 
-Smpl Add fold_wk_ren : refold.
+Smpl Add 20 fold_wk_ren : refold.
+
+Ltac change_well_wk :=
+    change ren_term with (@ren1 _ _ _ Ren1_well_wk) in *.
+
+Smpl Add 10 change_well_wk : refold.
+
 
 (** ** The ubiquitous operation of adding one variable at the end of a context *)
 
@@ -332,3 +340,11 @@ Proof. now bsimpl. Qed.
 
 Lemma wk_up_wk1_ren_on Γ F G (H : term) : H⟨wk_up F (@wk1 Γ G)⟩ = H⟨upRen_term_term ↑⟩.
 Proof. now bsimpl. Qed.
+Lemma wk_arr {A B Γ Δ} (ρ : Δ ≤ Γ) : arr A⟨ρ⟩ B⟨ρ⟩ = (arr A B)⟨ρ⟩.
+Proof. now bsimpl. Qed.
+
+Lemma wk_elimSuccHypTy {P Γ Δ} A (ρ : Δ ≤ Γ) :
+  elimSuccHypTy P⟨wk_up A ρ⟩ = (elimSuccHypTy P)⟨ρ⟩.
+Proof.
+  unfold elimSuccHypTy; cbn; f_equal; now bsimpl.
+Qed.


### PR DESCRIPTION
This PR tweaks the `refold` tactic so that we get well-typed weakening refolded as much as possible and replaces a few occurences of `asimpl`/`bsimpl` by explicit rewrite lemmas in places where performances looked terrible.