### PR TITLE
Do not require neutral convertibility soundness.

### DIFF
--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -919,8 +919,6 @@ Qed.
       + now apply whne_ren.
       + now apply algo_conv_wk.
       + now apply typing_wk.
-    - intros * [?????? []%conv_sound] ; tea.
-      now econstructor. 
     - intros * [? ? Hty].
       inversion Hty ; subst ; clear Hty.
       econstructor.
@@ -1152,7 +1150,6 @@ Module IntermediateTypingProperties.
     - intros.
       apply convneu_wk ; tea.
       now split.
-    - eauto using (convneu_sound (ta := bn)).
     - intros * [? [[? [-> ]]]]%termGen'.
       econstructor.
       + gen_typing.

--- a/theories/DeclarativeInstance.v
+++ b/theories/DeclarativeInstance.v
@@ -513,7 +513,6 @@ Module DeclarativeTypingProperties.
     now econstructor.
   - intros.
     now eapply typing_wk.
-  - easy.
   - intros.
     now econstructor.
   - intros.

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -310,7 +310,6 @@ Section GenericTyping.
     convneu_conv {Γ t u A A'} : [Γ |- t ~ u : A] -> [Γ |- A ≅ A'] -> [Γ |- t ~ u : A'] ;
     convneu_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
       [|- Δ ] -> [Γ |- t ~ u : A] -> [Δ |- t⟨ρ⟩ ~ u⟨ρ⟩ : A⟨ρ⟩] ;
-    convneu_sound {Γ A t u} : [Γ |- t ~ u : A] -> [Γ |-[de] t ~ u : A] ;
     convneu_var {Γ n A} :
       [Γ |- tRel n : A] -> [Γ |- tRel n ~ tRel n : A] ;
     convneu_app {Γ f g t u A B} :


### PR DESCRIPTION
This is dead code.