### PR TITLE
Split conversion function into its 6 components

### DIFF
--- a/theories/Decidability/Completeness.v
+++ b/theories/Decidability/Completeness.v
@@ -343,7 +343,7 @@ Proof.
   apply BundledConvInduction.
   - intros * ?? Hconv [IH] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ty ; cbn.
     repeat (match goal with |- orec_graph _ _ _ => econstructor end) ; cbn.
     + eapply wh_red_complete_whnf_ty ; tea.
       eapply algo_conv_wh in Hconv as [].
@@ -354,7 +354,7 @@ Proof.
     + exact (IH tt). (* eapply fails with universe issues? *)
   - intros * HA [IHA] HB [IHB] ** ; cbn in *.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ty_red ; cbn.
     repeat (match goal with |- orec_graph _ _ _ => econstructor end) ; cbn.
     1: exact (IHA tt).
     econstructor.
@@ -362,19 +362,19 @@ Proof.
     now econstructor.
   - intros ; cbn in *.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ty_red ; cbn.
     econstructor.
   - intros.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ty_red ; cbn.
     econstructor.
   - intros.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ty_red ; cbn.
     econstructor.
   - intros * HA [IHA] HB [IHB] **; cbn in *.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ty_red ; cbn.
     repeat (match goal with |- orec_graph _ _ _ => econstructor end) ; cbn.
     1: exact (IHA tt).
     econstructor.
@@ -382,7 +382,7 @@ Proof.
     now econstructor.
   - intros * HM [IHM []] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ty_red ; cbn.
     rewrite whne_ty_view2.
     2-3: now eapply algo_conv_wh in HM as [].
     cbn.
@@ -391,13 +391,13 @@ Proof.
     now constructor.
   - intros **.
     unfold graph.
-    simp conv.
+    simp conv conv_ne.
     rewrite Nat.eqb_refl ; cbn.
     erewrite ctx_access_complete ; tea ; cbn.
     now econstructor.
   - intros * Hm [IHm []] Ht [IHt] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ne ; cbn.
     econstructor.
     1: exact (IHm tt).
     cbn.
@@ -406,7 +406,7 @@ Proof.
     now constructor.
   - intros * ? [IHn []] ? [IHP] ? [IHz] ? [IHs] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ne ; cbn.
     econstructor.
     1: exact (IHn tt).
     econstructor.
@@ -418,7 +418,7 @@ Proof.
     now econstructor.
   - intros * ? [IHe []] ? [IHP] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ne ; cbn.
     econstructor.
     1: exact (IHe tt).
     econstructor.
@@ -426,19 +426,19 @@ Proof.
     now econstructor.
   - intros * ? [IH []] **.
     unfold graph.
-    simp conv; cbn.
+    simp conv conv_ne; cbn.
     econstructor.
     1: exact (IH tt).
     econstructor.
   - intros * ? [IH []] **.
     unfold graph.
-    simp conv; cbn.
+    simp conv conv_ne; cbn.
     econstructor.
     1: exact (IH tt).
     econstructor.
   - intros * ? [IHm []] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_ne_red ; cbn.
     econstructor.
     1: exact (IHm tt).
     econstructor.
@@ -447,17 +447,17 @@ Proof.
     boundary.
   - intros * ??? []%algo_conv_wh [IHt'] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_tm ; cbn.
     repeat (match goal with |- orec_graph _ _ _ => econstructor end) ; cbn.
     + eapply wh_red_complete_whnf_ty ; tea.
       1: boundary.
       now gen_typing.
     + now eapply wh_red_complete_whnf_tm.
     + now eapply wh_red_complete_whnf_tm.
-    + apply IHt'. 
+    + apply IHt'.
   - intros * ? [IHA] ? [IHB] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_tm_red ; cbn.
     econstructor.
     1: exact IHA.
     econstructor.
@@ -465,31 +465,32 @@ Proof.
     now constructor.
   - intros.
     unfold graph.
-    simp conv.
+    simp conv conv_tm_red.
     constructor.
   - intros.
     unfold graph.
-    simp conv.
+    simp conv conv_tm_red.
     constructor.
   - intros * ? [IHt] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_tm_red; cbn.
+    (* change (conv_full_cod (tm_state; Γ; tNat; t; t')) with (conv_full_cod (tm_red_state; Γ; tNat; tSucc t; tSucc t')). *)
     econstructor.
     1: exact IHt.
     now constructor.
   - intros.
     unfold graph.
-    simp conv.
+    simp conv conv_tm_red.
     now constructor.
   - intros * ?? ? [IHf] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_tm_red ; cbn.
     econstructor.
     1: exact IHf.
     now constructor.
   - intros * ? [IHA] ? [IHB] **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_tm_red ; cbn.
     econstructor.
     1: exact IHA.
     econstructor.
@@ -497,7 +498,7 @@ Proof.
     now constructor.
   - intros * ??? [ihFst] ? [ihSnd] **.
     unfold graph.
-    simp conv; cbn.
+    simp conv conv_tm_red ; cbn.
     econstructor.
     1: exact ihFst.
     econstructor.
@@ -505,7 +506,7 @@ Proof.
     now constructor.
   - intros * ? [IHm []] wP **.
     unfold graph.
-    simp conv ; cbn.
+    simp conv conv_tm_red ; cbn.
     unshelve erewrite whne_nf_view3 ; tea.
     2-3: now eapply algo_conv_wh in H as [].
     destruct wP ; cbn.

--- a/theories/Decidability/Termination.v
+++ b/theories/Decidability/Termination.v
@@ -49,7 +49,7 @@ Proof.
   apply BundledConvInduction.
   - intros * ?? HA' [IH] **.
     apply compute_domain.
-    simp conv.
+    simp conv conv_ty.
     cbn.
     split.
     1: eapply wh_red_complete ; now exists istype.
@@ -73,7 +73,7 @@ Proof.
       all: now eapply red_sound.
   - intros * ? [IHA] ? [IHB] ? []%prod_ty_inv []%prod_ty_inv ? B' wB' HtyB'.
     apply compute_domain.
-    simp conv.
+    simp conv conv_ty_red.
     destruct wB' as [|A'' B''| | | |? wB'].
     all: simp build_nf_ty_view2 ; cbn ; try easy.
     2: now rewrite (whne_ty_view1 wB') ; cbn.
@@ -86,25 +86,25 @@ Proof.
       now eapply stability1.
   - intros * ??? ? ? wB' ?.
     apply compute_domain.
-    simp conv.
+    simp conv conv_ty_red.
     destruct wB'.
     all: simp build_nf_ty_view2 ; cbn ; try easy.
     match goal with H : whne _ |- _ => now rewrite (whne_ty_view1 H) ; cbn end.
   - intros * ??? ? ? wB' ?.
     apply compute_domain.
-    simp conv.
+    simp conv conv_ty_red.
     destruct wB'.
     all: simp build_nf_ty_view2 ; cbn ; try easy.
     match goal with H : whne _ |- _ => now rewrite (whne_ty_view1 H) ; cbn end.
   - intros * ??? ? ? wB' ?.
     apply compute_domain.
-    simp conv.
+    simp conv conv_ty_red.
     destruct wB'.
     all: simp build_nf_ty_view2 ; cbn ; try easy.
     match goal with H : whne _ |- _ => now rewrite (whne_ty_view1 H) ; cbn end.
   - intros * ? [IHA] ? [IHB] ? []%sig_ty_inv []%sig_ty_inv ? B' wB' HtyB'.
     apply compute_domain.
-    simp conv.
+    simp conv conv_ty_red.
     destruct wB' as [| | | | A'' B'' |? wB'].
     all: simp build_nf_ty_view2 ; cbn ; try easy.
     2: now rewrite (whne_ty_view1 wB') ; cbn.
@@ -117,7 +117,7 @@ Proof.
       now eapply stability1.
   - intros * HM [IHM []] ??? ? ? wB' Hty.
     apply compute_domain.
-    simp conv.
+    simp conv conv_ty_red.
     eapply algo_conv_wh in HM as [].
     destruct wB'.
     1-5: simp build_nf_ty_view2 ; cbn.
@@ -132,7 +132,7 @@ Proof.
   - intros * ???? ? ? wu' ?.
     apply compute_domain.
     destruct wu' as [n'| | | | |].
-    all: simp conv ; cbn ; try easy.
+    all: simp conv conv_ne ; cbn ; try easy.
     destruct (Nat.eqb_spec n n') ; cbn.
     2: easy.
     erewrite ctx_access_complete ; tea.
@@ -140,7 +140,7 @@ Proof.
   - intros ? ???? A B Hm [IHm []] ? [IHt] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [|m' t'| | | |].
-    all: simp conv ; cbn ; try easy.
+    all: simp conv conv_ne ; cbn ; try easy.
     split.
     + apply (IHm tt m') ; tea.
       destruct Hty as [? (?&(?&?&[])&?)%termGen'].
@@ -160,7 +160,7 @@ Proof.
   - intros * Hn [IHn] ? [IHP] ? [IHz] ? [IHs] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| |P'' hz'' hs'' n''| | |].
-    all: simp conv ; cbn ; try easy.
+    all: simp conv conv_ne ; cbn ; try easy.
     destruct Hty as [? (?&[]&?)%termGen'].
     split.
     1: apply (IHn tt n'') ; tea ; now eexists.
@@ -195,7 +195,7 @@ Proof.
   - intros * He [IHe] ? [IHP] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| | | P'' e'' | |].
-    all: simp conv ; cbn ; try easy.
+    all: simp conv conv_ne ; cbn ; try easy.
     destruct Hty as [? (?&[]&?)%termGen'].
     split.
     1: apply (IHe tt e'') ; tea ; now eexists.
@@ -209,7 +209,7 @@ Proof.
   - intros * h [ih []] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| | | | t |].
-    all: simp conv ; cbn ; try easy.
+    all: simp conv conv_ne ; cbn ; try easy.
     destruct Hty as [? hu'%termGen']; cbn in hu'; prod_hyp_splitter; subst.
     split.
     1: apply (ih tt t); tea; now eexists.
@@ -221,7 +221,7 @@ Proof.
   - intros * h [ih []] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| | | | | t].
-    all: simp conv ; cbn ; try easy.
+    all: simp conv conv_ne ; cbn ; try easy.
     destruct Hty as [? hu'%termGen']; cbn in hu'; prod_hyp_splitter; subst.
     split.
     1: apply (ih tt t); tea; now eexists.
@@ -232,7 +232,7 @@ Proof.
     now cbn.
   - intros * ? [IHm] ?? ??? ? u' wu' Hty.
     apply compute_domain.
-    simp conv ; cbn.
+    simp conv conv_ne_red ; cbn.
     split.
     2: intros [T|] ; cbn ; [|easy] ; intros []%implem_conv_sound%algo_conv_sound ; tea.
     2: split ; [|easy].
@@ -242,7 +242,7 @@ Proof.
       boundary.
   - intros * ??? Hconv [IHt'] ??? u' Hty.
     apply compute_domain.
-    simp conv ; cbn.
+    simp conv conv_tm ; cbn.
     split.
     2: intros A'' [redA]%red_sound ; split.
     3: intros t'' []%red_sound ; split.
@@ -275,7 +275,7 @@ Proof.
     + easy.
   - intros * ? [IHA] ? [IHB] ??? u' wu' Hty.
     apply compute_domain.
-    simp conv build_nf_view3 build_nf_ty_view2.
+    simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
     destruct wu' as [ | A'' B'' | | | | ? wu'] ; cycle -1.
     1: rewrite (whne_ty_view1 wu').
@@ -293,21 +293,21 @@ Proof.
     + now intros []. 
   - intros * ??? u' wu' Hty.
     apply compute_domain.
-    simp conv build_nf_view3 build_nf_ty_view2.
+    simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
     destruct wu' as [ | | | | | ? wu'] ; cycle -1.
     1: rewrite (whne_ty_view1 wu').
     all: now cbn.
   - intros * ??? u' wu' Hty.
     apply compute_domain.
-    simp conv build_nf_view3 build_nf_ty_view2.
+    simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply nat_isNat in wu' ; tea.
     destruct wu' as [ | | ? wu'] ; cycle -1.
     1: rewrite (whne_nf_view1 wu').
     all: now cbn.
   - intros * ? [IHt] ??? u' wu' Hty.
     apply compute_domain.
-    simp conv build_nf_view3 build_nf_ty_view2.
+    simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply nat_isNat in wu' ; tea.
     destruct wu' as [ | u' | ? wu'] ; cycle -1.
     1: rewrite (whne_nf_view1 wu').
@@ -318,14 +318,14 @@ Proof.
     now apply termGen' in Hty as (?&[]&?).
   - intros * ??? u' wu' Hty.
     apply compute_domain.
-    simp conv build_nf_view3 build_nf_ty_view2.
+    simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
     destruct wu' as [ | | | | | ? wu'] ; cycle -1.
     1: rewrite (whne_ty_view1 wu').
     all: now cbn.
   - intros * ?? ? [IHf] ??? u' wu' Hty.
     apply compute_domain.
-    simp conv build_nf_view3 ; cbn.
+    simp conv conv_tm_red build_nf_view3 ; cbn.
     split.
     2: easy.
     specialize (IHf (eta_expand u')).
@@ -333,7 +333,7 @@ Proof.
     now eapply typing_eta'.
   - intros * ? [IHA] ? [IHB] ??? u' wu' Hty.
     apply compute_domain.
-    simp conv build_nf_view3 build_nf_ty_view2.
+    simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
     destruct wu' as [ |  | | | A'' B'' | ? wu'] ; cycle -1.
     1: rewrite (whne_ty_view1 wu').
@@ -351,7 +351,7 @@ Proof.
     + now intros []. 
   - intros * ?? ? [ihFst] ? [ihSnd] ??? u' wu' Hty.
     apply compute_domain.
-    simp conv build_nf_view3 build_nf_ty_view2.
+    simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     econstructor.
     1: apply (ihFst (tFst u')); now econstructor.
     intros [T|]; cbn; [|easy].
@@ -365,7 +365,7 @@ Proof.
     now apply TypeRefl.
   - intros * Hm [IHm []] Hpos ??? u' wu' Hu'.
     apply compute_domain.
-    simp conv build_nf_view3.
+    simp conv conv_tm_red build_nf_view3.
     eapply algo_conv_wh in Hm as [].
     destruct Hpos as [[]| | | ].
     + cbn.


### PR DESCRIPTION
This PR is an experiment on splitting the conversion implementation in `Functions.v` to get some "simplifications".

Pros:
+ more clearly delineate the various subcomponents of conversion
+ carves out the perfomance sensitive components (e.g. `conv_ne`)

Cons:
- more functions to specify when `simp`-ing
- `ret` get a "wrongly" inferred return type, so I added them by hand