### PR TITLE
Split typing inference, try to reduce universe issues in decidability

### DIFF
--- a/theories/Decidability/Completeness.v
+++ b/theories/Decidability/Completeness.v
@@ -10,6 +10,7 @@ From PartialFun Require Import Monad PartialFun.
 Set Universe Polymorphism.
 
 Import DeclarativeTypingProperties.
+Import IndexedDefinitions.
 
 Equations Derive NoConfusion Subterm for term.
 
@@ -352,6 +353,7 @@ Proof.
       eapply algo_conv_wh in Hconv as [].
       gen_typing.
     + exact (IH tt). (* eapply fails with universe issues? *)
+    + cbn; econstructor.
   - intros * HA [IHA] HB [IHB] ** ; cbn in *.
     unfold graph.
     simp conv conv_ty_red ; cbn.
@@ -447,14 +449,15 @@ Proof.
     boundary.
   - intros * ??? []%algo_conv_wh [IHt'] **.
     unfold graph.
-    simp conv conv_tm ; cbn.
-    repeat (match goal with |- orec_graph _ _ _ => econstructor end) ; cbn.
+    simp conv conv_tm ; cbn -[PFun_instance_1].
+    repeat (match goal with |- orec_graph _ _ _ => econstructor end) ; cbn -[PFun_instance_1].
     + eapply wh_red_complete_whnf_ty ; tea.
       1: boundary.
       now gen_typing.
     + now eapply wh_red_complete_whnf_tm.
     + now eapply wh_red_complete_whnf_tm.
-    + apply IHt'.
+    + exact IHt'.
+    + cbn; econstructor.
   - intros * ? [IHA] ? [IHB] **.
     unfold graph.
     simp conv conv_tm_red ; cbn.
@@ -550,7 +553,7 @@ Proof.
   all: intros.
   all: prod_hyp_splitter.
   all: unfold graph in *.
-  all: simp typing ; cbn.
+  all: simp typing typing_inf typing_wf_ty typing_inf_red typing_check ; cbn.
   (* Well formed types *)
   1-5:repeat match goal with | |- orec_graph typing _ _ => econstructor ; try eauto ; cbn end.
   - unshelve erewrite can_ty_view1_small ; tea.

--- a/theories/Decidability/Functions.v
+++ b/theories/Decidability/Functions.v
@@ -7,6 +7,7 @@ From PartialFun Require Import Monad PartialFun.
 
 Import MonadNotations.
 Set Universe Polymorphism.
+Import IndexedDefinitions.
 
 (* #[local] Remove Hints MonadOrec : typeclass_instances.
 #[local] Hint Resolve MonadOrec | 3 : typeclass_instances.
@@ -142,8 +143,16 @@ Fixpoint zip t (π : stack) :=
   | cons s π => zip (zip1 t s) π
   end.
 
+Definition empty_store : forall (x: False), match x return Set with end :=
+  fun x => match x as x return match x return Set with end with end.
 
-Equations wh_red_stack : term × stack ⇀ term :=
+#[global]
+Instance empty_pfun : forall (x:False), PFun@{Set Set Set} (empty_store x) | 5 :=
+  fun x => match x as x return PFun (empty_store x) with end.
+
+Arguments rec {_ _ _ _ _ _}. 
+
+Equations wh_red_stack : term × stack ⇀[empty_store] term :=
   wh_red_stack (t,π) with (build_tm_view1 t) :=
   wh_red_stack (?(tRel n)       ,π)                         (tm_view1_rel n) := ret (zip (tRel n) π) ;
   wh_red_stack (?(zip1 t s)     ,π)                         (tm_view1_dest t s) := id <*> rec (t,cons s π) ;
@@ -161,17 +170,25 @@ Equations wh_red_stack : term × stack ⇀ term :=
   wh_red_stack (t               ,nil)                       (tm_view1_type _) := ret t ;
   wh_red_stack (t               ,cons s _)                  (tm_view1_type _) := undefined.
 
-Equations wh_red : term ⇀ term :=
-  wh_red t := id <*> call wh_red_stack (t,nil).
+Set Printing Universes.
+
+Definition singleton_store {F} (f : F) : forall (x : unit), unit := fun _ => tt.
+
+(** DO NOT PUT AS INSTANCE IN GENERAL
+    (create loops in typeclass search since it autofires itself) *)
+Definition singleton_pfun {F} (f : F) `{PFun F f} : forall (x : unit), PFun (singleton_store f x).
+Proof. destruct H; now econstructor. Defined.
+
+Definition call_single {F}
+  (f : F) `{PFun F f} {A B} :=
+  call (pfun:=singleton_pfun f) tt (A:=A) (B:=B).
+
+#[local] Instance: forall x, PFun (singleton_store wh_red_stack x) := singleton_pfun wh_red_stack.
+
+Equations wh_red : term ⇀[singleton_store wh_red_stack] term :=
+  wh_red t := call_single wh_red_stack (t,nil).
 
 Definition wh_red_fuel n t := fueled wh_red n t.
-
-  (* Compute (deep_red_fuel 10 (tApp (tLambda U (tRel 0)) U)).
-  Compute (deep_red_fuel 1000 (tNatElim
-    tNat
-    tZero
-    (tLambda tNat (tLambda tNat (tSucc (tSucc (tRel 0)))))
-    (tSucc (tSucc tZero)))). *)
 
 Inductive nf_ty_view2 : term -> term -> Type :=
   | ty_sorts (s1 s2 : sort) : nf_ty_view2 (tSort s1) (tSort s2)
@@ -278,109 +295,99 @@ Definition cstate_output (c : conv_state) : Type :=
   | ne_state | ne_red_state => term
   end.
 
+Definition errrec {I F} φ {pfun A B} C := @irec I F φ pfun A B (result C).
+
+Definition monad_erec : forall {I F φ pfun A B}, Monad (@errrec I F φ pfun A B) :=
+  fun {I F φ pfun A B} => mon_trans_mon (irec φ A B) _.
+
+Definition ecall {I F} {ϕ : forall i, F i} `{pfun : forall i, PFun (ϕ i)} {A B} (g : I) (x : psrc (ϕ g)) : @errrec I F ϕ pfun A B (ptgt (ϕ g) x) :=
+  lift (irec _ A B) _ _ (call g x).
+
+Section Conversion.
+
+
 Definition conv_dom (c : conv_state) :=
   ∑ (_ : context) (_ : cstate_input c) (_ : term), term.
 Definition conv_full_dom := ∑ (c : conv_state), conv_dom c.
 Definition conv_cod (c : conv_state) := result (cstate_output c).
 Definition conv_full_cod (x : conv_full_dom) := conv_cod (x.π1).
-Definition conv_stmt (c : conv_state) := forall x0 : conv_dom c, orec conv_full_dom conv_full_cod (conv_cod c).
+
+#[local] Instance: forall x, PFun (singleton_store wh_red x) := singleton_pfun wh_red.
+
+#[local]
+Notation M0 := (irec (singleton_store wh_red) (conv_full_dom) (conv_full_cod)).
+#[local]
+Notation M := (errrec (singleton_store wh_red) (A:=conv_full_dom) (B:=conv_full_cod)).
+
+#[local] Instance: Monad M0 := MonadOrec.
+#[local] Instance: Monad M := monad_erec.
+
+Definition conv_stmt (c : conv_state) := forall x0 : conv_dom c, M (cstate_output c).
+
+Definition eta (c : conv_full_dom) (m : M0 (conv_full_cod c)) :
+  M (cstate_output c.π1) :=
+  r ← m ;;[M] ret (A:=cstate_output c.π1) r.
+
+Notation "m ::: c" := (eta c m) (at level 90, c at level 50).
+(* Notation "m ::: c" := (m : @errrec conv_full_dom conv_full_cod (cstate_output c.π1)) (at level 90, c at level 50). *)
 
 Equations conv_ty : conv_stmt ty_state :=
   | (Γ;inp;T;V) :=
-    T' ← call wh_red T ;;
-    V' ← call wh_red V ;;
-    r ← rec (ty_red_state;Γ;tt;T';V') ;;
-    ret (A:=conv_full_cod (ty_state;Γ;inp;T;V)) r.
+    T' ← call_single wh_red T ;;[M0]
+    V' ← call_single wh_red V ;;[M0]
+    rec (ty_red_state;Γ;tt;T';V') ::: (ty_state;Γ;inp;T;V).
 
 Equations conv_ty_red : conv_stmt ty_red_state :=
   | (Γ;inp;T;T') with (build_nf_ty_view2 T T') :=
   {
-    | ty_sorts s s' :=
-        ret (A:=conv_full_cod (ty_red_state;Γ;inp;tSort s;tSort s')) (eq_sort s s') ;
+    | ty_sorts s s' := ret (eq_sort s s') ;
     | ty_prods A A' B B' :=
-      r ← rec (ty_state;Γ;tt;A;A') ;;
-      match r with
-      | error e => raise e
-      | ok _ => 
-        r ← rec (ty_state;(Γ,,A);tt;B;B') ;; 
-        ret (A:=conv_full_cod (ty_red_state;Γ;inp;tProd A B;tProd A' B')) r
-      end ;
+        rec (ty_state;Γ;tt;A;A') ;;
+        rec (ty_state;(Γ,,A);tt;B;B') ::: (ty_red_state;Γ;inp;tProd A B;tProd A' B') ;
     | ty_nats := success ;
     | ty_emptys := success ;
     | ty_sigs A A' B B' :=
-      r ← rec (ty_state;Γ;tt;A;A') ;;
-      match r with
-      | error e => raise e
-      | ok _ => r ← rec (ty_state;(Γ,,A);tt;B;B') ;;
-        ret (A:=conv_full_cod (ty_red_state;Γ;inp;tSig A B;tSig A' B')) r
-      end ;
-    | ty_neutrals _ _ :=
-        r ← rec (ne_state;Γ;tt;T;T') ;;
-        match r with
-        | ok _ => success
-        | error e => raise e
-        end ;
+        rec (ty_state;Γ;tt;A;A') ;;
+        rec (ty_state;(Γ,,A);tt;B;B') ::: (ty_red_state;Γ;inp;tSig A B;tSig A' B') ;
+      | ty_neutrals _ _ :=
+          rec (ne_state;Γ;tt;T;T') ;; success (M:=irec _ _ _) ;
     | ty_mismatch _ _ := raise (head_mismatch None T T') ;
     | ty_anomaly _ _ := undefined ;
   }.
 
 Equations conv_tm : conv_stmt tm_state :=
   | (Γ;A;t;u) :=
-    A' ← call wh_red A ;;
-    t' ← call wh_red t ;;
-    u' ← call wh_red u ;;
-    r ← rec (tm_red_state;Γ;A';t';u') ;;
-    (* Coq does not infer the "right" type here *)
-    ret (A:=conv_full_cod (tm_state;Γ;A;t;u)) r.
+    A' ← call_single wh_red A ;;[M0]
+    t' ← call_single wh_red t ;;[M0]
+    u' ← call_single wh_red u ;;[M0]
+    rec (tm_red_state;Γ;A';t';u') ::: (tm_state;Γ;A;t;u).
 
 Equations conv_tm_red : conv_stmt tm_red_state :=
   | (Γ;A;t;u) with (build_nf_view3 A t u) :=
   {
     | types s (ty_sorts s1 s2) := undefined ;
     | types s (ty_prods A A' B B') :=
-      r ← rec (tm_state;Γ;tSort s;A;A') ;;
-      match r with
-      | error e => raise e
-      | ok _ => r ← rec (tm_state;Γ,,A;tSort s;B;B') ;;
-        ret (A:=conv_full_cod (tm_red_state;Γ;tSort s;tProd A B;tProd A' B')) r
-      end ;
+      rec (tm_state;Γ;tSort s;A;A') ;;
+      rec (tm_state;Γ,,A;tSort s;B;B') ::: (tm_red_state;Γ;tSort s;tProd A B;tProd A' B') ;
     | types _ ty_nats := success ;
     | types _ ty_emptys := success ;
     | types s (ty_sigs A A' B B') :=
-      r ← rec (tm_state;Γ;tSort s;A;A') ;;
-      match r with
-      | error e => raise e
-      | ok _ => r ← rec (tm_state;Γ,,A;tSort s;B;B') ;;
-        ret (A:=conv_full_cod (tm_red_state;Γ;tSort s;tSig A B;tSig A' B')) r
-      end ;
-    | types _ (ty_neutrals _ _) := 
-        r ← rec (ne_state;Γ;tt;t;u) ;;
-          match r with
-          | ok _ => success
-          | error e => raise e
-          end ;
+        rec (tm_state;Γ;tSort s;A;A') ;;
+        rec (tm_state;Γ,,A;tSort s;B;B') ::: (tm_red_state;Γ;tSort s;tSig A B;tSig A' B') ;
+    | types _ (ty_neutrals _ _) :=
+        rec (ne_state;Γ;tt;t;u) ;; success (M:=M0) ;
     | types s (ty_mismatch _ _) := raise (head_mismatch (Some (tSort s)) t u) ;
     | types _ (ty_anomaly _ _) := undefined ;
     | functions A B t u :=
-        r ← rec (tm_state;Γ,,A;B;eta_expand t;eta_expand u) ;;
-        ret (A:=conv_full_cod (tm_red_state;Γ;tProd A B;t;u)) r ;
+        rec (tm_state;Γ,,A;B;eta_expand t;eta_expand u) ::: (tm_red_state;Γ;tProd A B;t;u) ;
     | zeros := success ;
     | succs t' u' :=
-        r ← rec (tm_state;Γ;tNat;t';u') ;;
-        ret (A:=conv_full_cod (tm_red_state;Γ;tNat; tSucc t'; tSucc u')) r ;
+        rec (tm_state;Γ;tNat;t';u') ::: (tm_red_state;Γ;tNat; tSucc t'; tSucc u') ;
     | pairs A B t u :=
-        r ← rec (tm_state;Γ;A;tFst t; tFst u) ;;  
-        match r with
-        | ok _ => r ← rec (tm_state;Γ; B[(tFst t)..]; tSnd t; tSnd u) ;;
-          ret (A:=conv_full_cod (tm_red_state;Γ;tSig A B;t;u)) r
-        | error e => raise e
-        end ;
-    | neutrals _ _ _ := 
-      r ← rec (ne_state;Γ;tt;t;u) ;;
-        match r with
-        | ok _ => success
-        | error e => raise e
-        end ;
+        rec (tm_state;Γ;A;tFst t; tFst u) ;;
+        rec (tm_state;Γ; B[(tFst t)..]; tSnd t; tSnd u) ::: (tm_red_state;Γ;tSig A B;t;u) ;
+    | neutrals _ _ _ :=
+      rec (ne_state;Γ;tt;t;u) ;; success (M:=M0) ;
     | mismatch _ _ _ := raise (head_mismatch (Some A) t u) ;
     | anomaly _ _ _ := undefined ;
   }.
@@ -392,82 +399,68 @@ Equations conv_ne : conv_stmt ne_state :=
       | true with (ctx_access Γ n) := 
         {
         | error e => undefined ;
-        | ok d => ret (A:=conv_full_cod (ne_state;Γ;inp;tRel n; tRel n')) (ok d)
+        | ok d => ret d ::: (ne_state;Γ;inp;tRel n; tRel n')
         }
     } ;
   | (Γ;inp;tApp n t ; tApp n' t') :=
     T ← rec (ne_red_state;Γ;tt;n;n') ;;
     match T with
-    | error e => raise e
-    | (ok (tProd A B)) => r ← rec (tm_state;Γ;A;t;t') ;;
-      match r with
-      | error e => raise e
-      | ok _ => ret (A:=conv_full_cod (ne_state;Γ;inp;tApp n t; tApp n' t')) (ok B[t..])
-      end
-    | (ok _) => undefined (** the whnf of the type of an applied neutral must be a Π type!*)
+    | tProd A B => 
+      rec (tm_state;Γ;A;t;t') ;; ret B[t..]
+      (* (ret (B[t..])) ::: (ne_state;Γ;inp;tApp n t; tApp n' t') *)
+    |  _ => undefined (** the whnf of the type of an applied neutral must be a Π type!*)
     end ;
   | (Γ;inp;tNatElim P hz hs n;tNatElim P' hz' hs' n') :=
     rn ← rec (ne_red_state;Γ;tt;n;n') ;;
     match rn with
-    | error e => raise e
-    | ok tNat =>
-        rP ← rec (ty_state;(Γ,,tNat);tt;P;P') ;;
-        match rP with
-        | error e => raise e
-        | ok _ =>
-            rz ← rec (tm_state;Γ;P[tZero..];hz;hz') ;;
-            rs ← rec (tm_state;Γ;elimSuccHypTy P;hs;hs') ;;
-            match rz, rs with
-            | ok _, ok _ => ret (A:=conv_full_cod (ne_state;Γ;inp;tNatElim P hz hs n;tNatElim P' hz' hs' n')) (ok P[n..])
-            | _, _ => raise conv_error
-            end
-        end
-    | ok _ => undefined
+    | tNat =>
+        rec (ty_state;(Γ,,tNat);tt;P;P') ;;
+        rec (tm_state;Γ;P[tZero..];hz;hz') ;;
+        rec (tm_state;Γ;elimSuccHypTy P;hs;hs') ;;
+        ret P[n..]
+        (* ret (P[n..]) ::: (ne_state;Γ;inp;tNatElim P hz hs n;tNatElim P' hz' hs' n') *)
+    | _ => undefined
     end ;
   | (Γ;inp;tEmptyElim P n;tEmptyElim P' n') :=
     rn ← rec (ne_red_state;Γ;tt;n;n') ;;
     match rn with
-    | error e => raise e
-    | ok tEmpty =>
-        rP ← rec (ty_state;(Γ,,tEmpty);tt;P;P') ;;
-        match rP with
-        | error e => raise e
-        | ok _ => ret (A:=conv_full_cod (ne_state;Γ;inp;tEmptyElim P n;tEmptyElim P' n')) (ok P[n..])
-        end
-    | ok _ => undefined
+    | tEmpty =>
+        rec (ty_state;(Γ,,tEmpty);tt;P;P') ;;
+        ret P[n..]
+        (* ret (P[n..]) ::: (ne_state;Γ;inp;tEmptyElim P n;tEmptyElim P' n') *)
+    | _ => undefined
     end ;
   | ( Γ; inp ; tFst n; tFst n') :=
     T ← rec (ne_red_state;Γ;tt;n;n') ;;
     match T with
-    | error e => raise e
-    | (ok (tSig A B)) => ret (A:=conv_full_cod (ne_state;Γ; inp; tFst n; tFst n')) (ok A)
-    | (ok _) => undefined (** the whnf of the type of a projected neutral must be a Σ type!*)
+    | tSig A B => ret A ::: (ne_state;Γ; inp; tFst n; tFst n')
+    | _ => undefined (** the whnf of the type of a projected neutral must be a Σ type!*)
     end ;
   | ( Γ; inp ; tSnd n; tSnd n') :=
     T ← rec (ne_red_state;Γ;tt;n;n') ;;
     match T with
-    | error e => raise e
-    | (ok (tSig A B)) => ret (A:=conv_full_cod (ne_state;Γ; inp; tSnd n; tSnd n')) (ok (B[(tFst n)..]))
-    | (ok _) => undefined (** the whnf of the type of a projected neutral must be a Σ type!*)
-    end ;
+    | tSig A B => ret B[(tFst n)..]
+      (* ret (B[(tFst n)..]) ::: (ne_state;Γ; inp; tSnd n; tSnd n') *)
+    | _ => undefined (** the whnf of the type of a projected neutral must be a Σ type!*)
+    end ; 
   | (Γ;_;n;n') := raise (destructor_mismatch n n').
 
 Equations conv_ne_red : conv_stmt ne_red_state :=
   | (Γ;inp;t;u) :=
     Ainf ← rec (ne_state;Γ;tt;t;u) ;;
-    match Ainf with
-    | error e => raise e
-    | ok Ainf' => A' ← call wh_red Ainf' ;; 
-      ret (A:=conv_full_cod (ne_red_state;Γ; inp; t; u)) (ok A')
-    end.
+    ecall tt Ainf ::: (ne_red_state;Γ; inp; t; u).
 
-Equations conv : ∇ (x : conv_full_dom), conv_full_cod x :=
+Equations conv : ∇[singleton_store wh_red] (x : conv_full_dom), conv_full_cod x :=
   | (ty_state; Γ ; inp ; T; V) := conv_ty (Γ; inp; T; V);
   | (ty_red_state; Γ ; inp ; T; V) := conv_ty_red (Γ; inp; T; V);
   | (tm_state; Γ ; inp ; T; V) := conv_tm (Γ; inp; T; V);
   | (tm_red_state; Γ ; inp ; T; V) := conv_tm_red (Γ; inp; T; V);
   | (ne_state; Γ ; inp ; T; V) := conv_ne (Γ; inp; T; V);
   | (ne_red_state; Γ ; inp ; T; V) := conv_ne_red (Γ; inp; T; V).
+
+End Conversion.
+
+Section Typing.
 
 Variant typing_state : Type :=
   | inf_state (** inference *)
@@ -487,36 +480,67 @@ Definition tstate_output (s : typing_state) : Type :=
   | wf_ty_state | check_state => unit
   end.
 
-Equations typing : ∇ (x : ∑ (c : typing_state) (_ : context) (_ : tstate_input c), term),
-  (result (tstate_output (x.π1))) :=
-  typing (wf_ty_state;Γ;_;T) with (build_ty_view1 T) :=
+Definition binary_store_ty@{u} F1 F2 := fun b : bool => if b return Type@{u} then F1 else F2.
+Definition binary_store@{u} {F1 F2: Type@{u}} (f1 : F1) (f2 : F2) :
+  forall b, binary_store_ty F1 F2 b :=
+  fun b => if b as b return binary_store_ty F1 F2 b then f1 else f2.
+
+(** DO NOT PUT AS INSTANCE IN GENERAL
+    (create loops in typeclass search since it autofires itself) *)
+Definition binary_pfun@{u a b} {F1 F2: Type@{u}} (f1 : F1) (f2 : F2)
+  `{h1: PFun@{u a b} F1 f1} `{h2: PFun@{u a b} F2 f2} :
+  forall b, PFun@{u a b} (binary_store f1 f2 b).
+Proof.
+  intros b; destruct b; [destruct h1| destruct h2]; now econstructor.
+Defined.
+
+#[local]
+Instance: forall b, PFun (binary_store wh_red conv b) := binary_pfun wh_red conv.
+
+
+Definition typing_dom (c : typing_state) :=
+  ∑ (_ : context) (_ : tstate_input c), term.
+Definition typing_full_dom := ∑ (c : typing_state), typing_dom c.
+Definition typing_cod (c : typing_state) := result (tstate_output c).
+Definition typing_full_cod (x : typing_full_dom) := typing_cod (x.π1).
+
+Definition ϕ := (binary_store wh_red conv).
+Definition wh_red_key := true.
+Definition conv_key := false.
+
+#[local]
+Notation M0 := (irec ϕ (typing_full_dom) (typing_full_cod)).
+#[local]
+Notation M := (errrec ϕ (A:=typing_full_dom) (B:=typing_full_cod)).
+
+#[local] Instance: Monad M0 := MonadOrec.
+#[local] Instance: Monad M := monad_erec.
+
+Definition typing_stmt (c : typing_state) := forall x0 : typing_dom c, M (tstate_output c).
+
+Equations typing_wf_ty : typing_stmt wf_ty_state :=
+  typing_wf_ty (Γ;_;T) with (build_ty_view1 T) :=
   {
     | ty_view1_ty (eSort s) := success ;
     | ty_view1_ty (eProd A B) :=
         rA ← rec (wf_ty_state;Γ;tt;A) ;;
-        match rA with
-        | error e => raise e
-        | ok _ => id <*> rec (wf_ty_state;Γ,,A;tt;B)
-        end ;
+        id <*> rec (wf_ty_state;Γ,,A;tt;B) ;
     | ty_view1_ty (eNat) := success ;
     | ty_view1_ty (eEmpty) := success ;
     | ty_view1_ty (eSig A B) :=
         rA ← rec (wf_ty_state;Γ;tt;A) ;;
-        match rA with
-        | error e => raise e
-        | ok _ => id <*> rec (wf_ty_state;Γ,,A;tt;B)
-        end ;
+        id <*> rec (wf_ty_state;Γ,,A;tt;B) ;
     | ty_view1_small _ :=
-        r ← rec (inf_red_state;Γ;tt;T) ;;
+        r ← rec (inf_red_state;Γ;tt;T) ;;[M]
         match r with
-        | ok (tSort _) => success
-        | ok _ => raise type_error
-        | error e => raise e
+        | tSort _ => success (M:=M0)
+        | _ => raise (M:=M0) type_error
         end
     | ty_view1_anomaly := raise type_error ;
-  } ;
-  typing (inf_state;Γ;_;t) with t :=
-  {
+  }.
+
+  Equations typing_inf : typing_stmt inf_state :=
+  | (Γ;_;t) with t := {
     | tRel n with (ctx_access Γ n) :=
         {
           | error _ := raise (variable_not_in_context n Γ) ;
@@ -526,138 +550,103 @@ Equations typing : ∇ (x : ∑ (c : typing_state) (_ : context) (_ : tstate_inp
     | tProd A B :=
         rA ← rec (inf_red_state;Γ;tt;A) ;;
         match rA with
-        | ok (tSort sA) =>
+        | tSort sA =>
             rB ← rec (inf_red_state;Γ,,A;tt;B) ;;
             match rB with
-            | ok (tSort sB) => ret (ok (tSort (sort_of_product sA sB)))
-            | ok _ => raise type_error
-            | error e => raise e
+            | tSort sB => ret (tSort (sort_of_product sA sB))
+            | _ => raise (M:=M0) type_error
             end
-        | ok _ => raise type_error
-        | error e => raise e
+        | _ => raise (M:=M0) type_error
         end ;
     | tLambda A u :=
-        rA ← rec (wf_ty_state;Γ;tt;A) ;;
-        match rA with
-        | ok _ =>
-            ru ← rec (inf_state;Γ,,A;tt;u) ;;
-            match ru with
-            | ok B => ret (ok (tProd A B))
-            | error e => raise e
-            end
-        | error e => raise e
-        end ;
+        rec (wf_ty_state;Γ;tt;A) ;;[M]
+        B ← rec (inf_state;Γ,,A;tt;u) ;;
+        ret (tProd A B) ;
     | tApp f u :=
       rf ← rec (inf_red_state;Γ;tt;f) ;;
       match rf with
-      | ok (tProd A B) =>
-          ru ← rec (check_state;Γ;A;u) ;;
-          match ru with
-          | ok _ => (ret (ok B[u..])) 
-          | error e => raise e
-          end 
-      | ok _ => raise type_error
-      | error e => raise e 
+      | tProd A B =>
+          rec (check_state;Γ;A;u) ;;
+          ret B[u..]
+      | _ => raise (M:=M0) type_error
       end ;
-    | tNat := ret (ok U) ;
-    | tZero := ret (ok tNat) ;
+    | tNat := ret U ;
+    | tZero := ret tNat ;
     | tSucc u :=
         ru ← rec (inf_red_state;Γ;tt;u) ;;
         match ru with
-        | ok tNat => ret (ok tNat)
-        | ok _ => raise type_error
-        | error e => raise e
+        | tNat => ret tNat
+        | _ => raise (M:=M0) type_error
         end ;
     | tNatElim P hz hs n :=
       rn ← rec (inf_red_state;Γ;tt;n) ;;
       match rn with
-      | error e => raise e
-      | ok tNat =>
-          rP ← rec (wf_ty_state;(Γ,,tNat);tt;P) ;;
-          match rP with
-          | error e => raise e
-          | ok _ =>
-              rz ← rec (check_state;Γ;P[tZero..];hz) ;;
-              rs ← rec (check_state;Γ;elimSuccHypTy P;hs) ;;
-              match rz, rs with
-              | ok _, ok _ => ret (ok P[n..])
-              | _, _ => raise type_error
-              end
-          end
-      | ok _ => raise type_error
+      | tNat =>
+          rec (wf_ty_state;(Γ,,tNat);tt;P) ;;
+          rec (check_state;Γ;P[tZero..];hz) ;;
+          rec (check_state;Γ;elimSuccHypTy P;hs) ;;
+          ret P[n..]
+      | _ => raise (M:=M0) type_error
       end ;
-      | tEmpty := ret (ok U) ;
-      | tEmptyElim P e :=
-          re ← rec (inf_red_state;Γ;tt;e) ;;
-          match re with
-          | error e => raise e
-          | ok tEmpty =>
-              rP ← rec (wf_ty_state;(Γ,,tEmpty);tt;P) ;;
-              match rP with
-              | error e => raise e
-              | ok _ => ret (ok P[e..])
-              end
-          | ok _ => raise type_error
-          end ;
-      | tSig A B :=  
-        rA ← rec (inf_red_state;Γ;tt;A) ;;
-        match rA with
-        | ok (tSort sA) =>
-            rB ← rec (inf_red_state;Γ,,A;tt;B) ;;
-            match rB with
-            | ok (tSort sB) => ret (ok (tSort (sort_of_product sA sB))) (* Should that be taken as a parameter for sigma as well ? *)
-            | ok _ => raise type_error
-            | error e => raise e
-            end
-        | ok _ => raise type_error
-        | error e => raise e
+    | tEmpty := ret U ;
+    | tEmptyElim P e :=
+        re ← rec (inf_red_state;Γ;tt;e) ;;
+        match re with
+        | tEmpty =>
+            rec (wf_ty_state;(Γ,,tEmpty);tt;P) ;;
+            ret P[e..]
+        | _ => raise (M:=M0) type_error
         end ;
-      | tPair A B a b :=  
-        rA ← rec (wf_ty_state;Γ;tt;A) ;;
-        match rA with
-        | ok _ =>
-            rB ← rec (wf_ty_state;Γ,,A;tt;B) ;;
-            match rB with
-            | ok _ => ra ← rec (check_state;Γ;A; a) ;;
-              match ra with
-              | ok _ => rb ← rec (check_state;Γ;B[a..]; b) ;;
-                match rb with
-                | ok _ => ret (ok (tSig A B))
-                | error e => raise e
-                end 
-              | error e => raise e
-              end
-            | error e => raise e
-            end
-        | error e => raise e
-        end ;
-      | tFst u :=
-        rt ← rec (inf_red_state; Γ; tt; u) ;;
-        match rt with
-        | ok (tSig A B) => ret (ok A)
-        | ok _ => raise type_error
-        | error e => raise e
-        end
-      | tSnd u :=
-        rt ← rec (inf_red_state; Γ; tt; u) ;;
-        match rt with
-        | ok (tSig A B) => ret (ok (B[(tFst u)..]))
-        | ok _ => raise type_error
-        | error e => raise e
-        end 
-  } ;
-  typing (inf_red_state;Γ;_;t) :=
-    r ← rec (inf_state;Γ;_;t) ;;
-    match r with
-    | error e => raise e
-    | ok T => ok <*> call wh_red T
-    end ;
-  typing (check_state;Γ;T;t) :=
-    r ← rec (inf_state;Γ;tt;t) ;;
-    match r with
-    | error e => raise e
-    | ok T' => (id (X := result unit)) <*> call conv (ty_state;Γ;tt;T';T)
-    end.
+    | tSig A B :=
+      rA ← rec (inf_red_state;Γ;tt;A) ;;
+      match rA with
+      | tSort sA =>
+          rB ← rec (inf_red_state;Γ,,A;tt;B) ;;
+          match rB with
+          | tSort sB => ret (tSort (sort_of_product sA sB)) (* Should that be taken as a parameter for sigma as well ? *)
+          | _ => raise (M:=M0) type_error
+          end
+      | _ => raise (M:=M0) type_error
+      end ;
+    | tPair A B a b :=
+      rec (wf_ty_state;Γ;tt;A) ;;
+      rec (wf_ty_state;Γ,,A;tt;B) ;;
+      rec (check_state;Γ;A; a) ;;
+      rec (check_state;Γ;B[a..]; b) ;;
+      ret (tSig A B) ;
+    | tFst u :=
+      rt ← rec (inf_red_state; Γ; tt; u) ;;
+      match rt with
+      | tSig A B => ret A
+      | _ => raise (M:=M0) type_error
+      end ;
+    | tSnd u :=
+      rt ← rec (inf_red_state; Γ; tt; u) ;;
+      match rt with
+      | tSig A B => ret (B[(tFst u)..])
+      | _ => raise (M:=M0) type_error
+      end ;
+  }.
+
+  Equations typing_inf_red : typing_stmt inf_red_state :=
+  | (Γ;_;t) :=
+    T ← rec (inf_state;Γ;_;t) ;;
+    ecall wh_red_key T.
+
+  Equations typing_check : typing_stmt check_state :=
+  | (Γ;T;t) :=
+    T' ← rec (inf_state;Γ;tt;t) ;;
+    call (ϕ:=ϕ) conv_key (ty_state;Γ;tt;T';T).
+
+  Equations typing : ∇[ϕ] x, typing_full_cod x :=
+  | (wf_ty_state; Γ; inp; T) := typing_wf_ty (Γ;inp;T)
+  | (inf_state; Γ; inp; t) := typing_inf (Γ;inp;t)
+  | (inf_red_state; Γ; inp; t) := typing_inf_red (Γ;inp;t)
+  | (check_state; Γ; inp; t) := typing_check (Γ;inp;t).
+
+End Typing.
+
+
 
 (* #[local] Definition infer (Γ : context) (t : term) : Fueled (result term) := 
   (fueled typing 1000 (inf_state;Γ;tt;t)).

--- a/theories/Decidability/Soundness.v
+++ b/theories/Decidability/Soundness.v
@@ -8,6 +8,7 @@ From LogRel.Decidability Require Import Functions.
 From PartialFun Require Import Monad PartialFun.
 
 Import DeclarativeTypingProperties.
+Import IndexedDefinitions.
 
 Set Universe Polymorphism.
 
@@ -215,6 +216,13 @@ Section ConversionSound.
 
 End ConversionSound.
 
+Ltac funelim_typing :=
+  funelim (typing _); 
+    [ funelim (typing_inf _) | 
+      funelim (typing_check _) |
+      funelim (typing_inf_red _) | 
+      funelim (typing_wf_ty _) ].
+
 Section TypingCorrect.
 
   Import AlgorithmicTypingData.
@@ -239,11 +247,12 @@ Section TypingCorrect.
   | (check_state;Γ;T;t), (ok _) => [Γ |-[al] t ◃ T]
   end.
 
+
   Lemma _implem_typing_sound :
     funrect typing (fun _ => True) typing_sound_type.
   Proof.
     intros x _.
-    funelim (typing _) ; cbn.
+    funelim_typing ; cbn.
     all: intros ; simp typing_sound_type ; try easy ; cbn.
     all: repeat (
       match goal with
@@ -256,6 +265,7 @@ Section TypingCorrect.
       | H : graph conv _ _ |- _ => eapply implem_conv_sound in H ; simp conv_sound_type in H
       | H : ctx_access _ _ = _ |- _ => eapply ctx_access_correct in H
       | H : (build_ty_view1 _ = ty_view1_small _) |- _ => eapply ty_view1_small_can in H
+      | H : (_;_;_) = (_;_;_) |- _ => injection H; clear H; intros; subst 
       end).
     all: now econstructor.
   Qed.

--- a/theories/Decidability/Termination.v
+++ b/theories/Decidability/Termination.v
@@ -135,7 +135,7 @@ Proof.
   - intros * ???? ? ? wu' ?.
     apply compute_domain.
     destruct wu' as [n'| | | | |].
-    all: simp conv conv_ne ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
     destruct (Nat.eqb_spec n n') ; cbn.
     2: easy.
     erewrite ctx_access_complete ; tea.
@@ -143,7 +143,7 @@ Proof.
   - intros ? ???? A B Hm [IHm []] ? [IHt] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [|m' t'| | | |].
-    all: simp conv conv_ne ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
     split.
     + apply (IHm tt m') ; tea.
       destruct Hty as [? (?&(?&?&[])&?)%termGen'].
@@ -163,7 +163,7 @@ Proof.
   - intros * Hn [IHn] ? [IHP] ? [IHz] ? [IHs] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| |P'' hz'' hs'' n''| | |].
-    all: simp conv conv_ne ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
     destruct Hty as [? (?&[]&?)%termGen'].
     split.
     1: apply (IHn tt n'') ; tea ; now eexists.
@@ -198,7 +198,7 @@ Proof.
   - intros * He [IHe] ? [IHP] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| | | P'' e'' | |].
-    all: simp conv conv_ne ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
     destruct Hty as [? (?&[]&?)%termGen'].
     split.
     1: apply (IHe tt e'') ; tea ; now eexists.
@@ -212,7 +212,7 @@ Proof.
   - intros * h [ih []] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| | | | t |].
-    all: simp conv conv_ne ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
     destruct Hty as [? hu'%termGen']; cbn in hu'; prod_hyp_splitter; subst.
     split.
     1: apply (ih tt t); tea; now eexists.
@@ -224,7 +224,7 @@ Proof.
   - intros * h [ih []] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| | | | | t].
-    all: simp conv conv_ne ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
     destruct Hty as [? hu'%termGen']; cbn in hu'; prod_hyp_splitter; subst.
     split.
     1: apply (ih tt t); tea; now eexists.


### PR DESCRIPTION
This PR reduces the number of universes needed to define all the conversion and typing functions in the hope to get less issues in the future (now all functions only need a single universe level that could morally be set to `Set+1` if algebraic universe instantiations were allowed).

It also:
- splits the typing function in its components (ty, inf, inf_red and check),
- instantiate the error monad transformer to partiality and uses it in the algorithm (swifter code, but requires a few annotations),
- remove annotations on some `rec` calls and replace them by a call to a specific tactic to patch return types when type inference get in the way (`patch_rec_ret` in `Completeness.v`),
- changes the version of coq-partialfun in use (needed for lowering the number of universe levels in use),
- alter the definition of `conv_ne` to less cases in the internal representation of Coq (using `ne_view1`).

I was hoping that I would get better performance with this work but that's not obervable empirically.
More clean-ups might be possible but this is too much of a time sink.