### PR TITLE
Stacks

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -13,6 +13,7 @@ theories/Context.v
 theories/Notations.v
 
 theories/NormalForms.v
+theories/Stacks.v
 theories/Weakening.v
 theories/UntypedReduction.v
 theories/UntypedValues.v

--- a/theories/Decidability/Termination.v
+++ b/theories/Decidability/Termination.v
@@ -77,7 +77,7 @@ Proof.
     simp conv conv_ty_red.
     destruct wB' as [|A'' B''| | | |? wB'].
     all: simp build_nf_ty_view2 ; cbn ; try easy.
-    2: now rewrite (whne_ty_view1 wB') ; cbn.
+    2: now destruct (whne_ty_view1 wB') as [? ->] ; cbn.
     apply prod_ty_inv in HtyB' as [].
     split.
     2: intros [] ; cbn ; [|easy].
@@ -91,25 +91,25 @@ Proof.
     simp conv conv_ty_red.
     destruct wB'.
     all: simp build_nf_ty_view2 ; cbn ; try easy.
-    match goal with H : whne _ |- _ => now rewrite (whne_ty_view1 H) ; cbn end.
+    match goal with H : whne _ |- _ => now destruct (whne_ty_view1 H) as [? ->] ; cbn end.
   - intros * ??? ? ? wB' ?.
     apply compute_domain.
     simp conv conv_ty_red.
     destruct wB'.
     all: simp build_nf_ty_view2 ; cbn ; try easy.
-    match goal with H : whne _ |- _ => now rewrite (whne_ty_view1 H) ; cbn end.
+    match goal with H : whne _ |- _ => now destruct (whne_ty_view1 H) as [? ->] ; cbn end.
   - intros * ??? ? ? wB' ?.
     apply compute_domain.
     simp conv conv_ty_red.
     destruct wB'.
     all: simp build_nf_ty_view2 ; cbn ; try easy.
-    match goal with H : whne _ |- _ => now rewrite (whne_ty_view1 H) ; cbn end.
+    match goal with H : whne _ |- _ => now destruct (whne_ty_view1 H) as [? ->] ; cbn end.
   - intros * ? [IHA] ? [IHB] ? []%sig_ty_inv []%sig_ty_inv ? B' wB' HtyB'.
     apply compute_domain.
     simp conv conv_ty_red.
     destruct wB' as [| | | | A'' B'' |? wB'].
     all: simp build_nf_ty_view2 ; cbn ; try easy.
-    2: now rewrite (whne_ty_view1 wB') ; cbn.
+    2: now destruct (whne_ty_view1 wB') as [? ->] ; cbn.
     apply sig_ty_inv in HtyB' as [].
     split.
     2: intros x; destruct x ; cbn ; [|easy].
@@ -124,7 +124,7 @@ Proof.
     eapply algo_conv_wh in HM as [].
     destruct wB'.
     1-5: simp build_nf_ty_view2 ; cbn.
-    1-5: now unshelve erewrite whne_ty_view1 ; cbn.
+    1-5: match goal with H : whne _ |- _ => now destruct (whne_ty_view1 H) as [? ->] ; cbn end.
     erewrite whne_ty_view2 ; tea.
     split.
     2: intros [|] ; cbn ; easy.
@@ -281,7 +281,7 @@ Proof.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
     destruct wu' as [ | A'' B'' | | | | ? wu'] ; cycle -1.
-    1: rewrite (whne_ty_view1 wu').
+    1: destruct (whne_ty_view1 wu') as [? ->] ; cbn.
     all: cbn ; try easy.
     eapply termGen' in Hty as (?&[]&?) ; subst.
     split.
@@ -299,21 +299,21 @@ Proof.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
     destruct wu' as [ | | | | | ? wu'] ; cycle -1.
-    1: rewrite (whne_ty_view1 wu').
+    1: destruct (whne_ty_view1 wu') as [? ->] ; cbn.
     all: now cbn.
   - intros * ??? u' wu' Hty.
     apply compute_domain.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply nat_isNat in wu' ; tea.
     destruct wu' as [ | | ? wu'] ; cycle -1.
-    1: rewrite (whne_nf_view1 wu').
+    1: destruct (whne_nf_view1 wu') as [? ->] ; cbn.
     all: now cbn.
   - intros * ? [IHt] ??? u' wu' Hty.
     apply compute_domain.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply nat_isNat in wu' ; tea.
     destruct wu' as [ | u' | ? wu'] ; cycle -1.
-    1: rewrite (whne_nf_view1 wu').
+    1: destruct (whne_nf_view1 wu') as [? ->] ; cbn.
     all: cbn ; try easy.
     split.
     2: now intros [|] ; cbn.
@@ -324,7 +324,7 @@ Proof.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
     destruct wu' as [ | | | | | ? wu'] ; cycle -1.
-    1: rewrite (whne_ty_view1 wu').
+    1: destruct (whne_ty_view1 wu') as [? ->] ; cbn.
     all: now cbn.
   - intros * ?? ? [IHf] ??? u' wu' Hty.
     apply compute_domain.
@@ -339,7 +339,7 @@ Proof.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
     destruct wu' as [ |  | | | A'' B'' | ? wu'] ; cycle -1.
-    1: rewrite (whne_ty_view1 wu').
+    1: destruct (whne_ty_view1 wu') as [? ->] ; cbn.
     all: cbn ; try easy.
     eapply termGen' in Hty as (?&[]&?) ; subst.
     split.
@@ -369,44 +369,39 @@ Proof.
   - intros * Hm [IHm []] Hpos ??? u' wu' Hu'.
     apply compute_domain.
     simp conv conv_tm_red build_nf_view3.
-    eapply algo_conv_wh in Hm as [].
-    destruct Hpos as [[]| | | ].
+    eapply algo_conv_wh in Hm as [wm wn].
+    destruct Hpos as [[]| | | ? wP' ].
     + cbn.
       simp build_nf_ty_view2.
-      unshelve erewrite whne_ty_view1 ; tea.
-      cbn.
+      1: destruct (whne_ty_view1 wm) as [? ->] ; cbn.
       eapply Uterm_isType in wu' ; tea.
       destruct wu' as [ | | | | | u' wu'] ; cbn ; try easy.
-      rewrite (whne_ty_view1 wu').
-      cbn.
+      destruct (whne_ty_view1 wu') as [? ->] ; cbn.
       split.
       2: now intros [] ; cbn.
       eapply (IHm tt u') ; tea.
       now eexists.
     + cbn.
-      unshelve erewrite whne_nf_view1 ; tea.
-      cbn.
+      destruct (whne_nf_view1 wm) as [? ->] ; cbn.
       eapply nat_isNat in wu' ; tea.
       inversion wu'  as [| | u'' wu'' ] ; subst ; clear wu'.
       all: cbn ; try easy.
-      rewrite (whne_nf_view1 wu'').
+      1: destruct (whne_nf_view1 wu'') as [? ->] ; cbn.
       cbn.
       split.
       2: now intros [] ; cbn.
       eapply (IHm tt u') ; tea.
       now eexists.
     + cbn.
-      unshelve erewrite whne_nf_view1 ; tea.
+      destruct (whne_nf_view1 wm) as [? ->] ; cbn.
       cbn.
       eapply empty_isEmpty in wu' ; tea.
-      rewrite (whne_nf_view1 wu').
-      cbn.
+      1: destruct (whne_nf_view1 wu') as [? ->] ; cbn.
       split.
       2: now intros [] ; cbn.
       apply (IHm tt u') ; tea.
       now eexists.
-    + unshelve erewrite whne_ty_view1 ; tea.
-      cbn.
+    + destruct (whne_ty_view1 wP') as [? ->] ; cbn.
       eapply neutral_isNeutral in wu' ; tea.
       split.
       2: now intros [] ; cbn.

--- a/theories/NormalForms.v
+++ b/theories/NormalForms.v
@@ -121,3 +121,28 @@ Inductive isCanonical : term -> Type :=
   | can_tPair {A B a b}: isCanonical (tPair A B a b).
 
 #[global] Hint Constructors isCanonical : gen_typing.
+
+Definition isCanonical_whnf t (i : isCanonical t) : whnf t.
+Proof.
+  case i ; intros ; constructor.
+Defined.
+
+#[global] Hint Resolve isCanonical_whnf : gen_typing.
+
+Lemma whnf_can_whne t :
+  whnf t <~> (isCanonical t) + whne t.
+Proof.
+  split.
+  - intros [] ; cycle -1.
+    1: now right.
+    all: left ; constructor.
+  - intros [[]|].
+    all: now constructor.
+Qed.
+
+Lemma can_whne t :
+  isCanonical t -> whne t -> False.
+Proof.
+  intros [].
+  all: now inversion 1.
+Qed.

--- a/theories/Notations.v
+++ b/theories/Notations.v
@@ -197,6 +197,10 @@ Reserved Notation "[ K | Γ ||- A ≅ B | R ]" (at level 0, K, Γ, A, B, R at le
 Reserved Notation "[ K | Γ ||- t : A | R ]"  (at level 0, K, Γ, t, A, R at level 50).
 (** The terms t and u are reducibly convertible at type A in Γ, given the proof R than A is reducible, according to the kit K *)
 Reserved Notation "[ K | Γ ||- t ≅ u : A | R ]" (at level 0, K, Γ, t, u, A, R at level 50).
+(** The stack π is reducible at type A in Γ, given the proof R than A is reducible, according to the kit K *)
+Reserved Notation "[ K | Γ ||- π <:> A | R ]"  (at level 0, K, Γ, π, A, R at level 50).
+(** The stacks π and π' are reducibly convertible at type A in Γ, given the proof R than A is reducible, according to the kit K *)
+Reserved Notation "[ K | Γ ||- π ≅ π' <:> A | R ]" (at level 0, K, Γ, π, π', A, R at level 50).
 
 (** The types A and B are reducibly equal in Γ, according to the pack P for Γ and A *)
 Reserved Notation "[ P | Γ ||- A ≅ B ]" (at level 0, P, Γ, A, B at level 50).
@@ -204,6 +208,10 @@ Reserved Notation "[ P | Γ ||- A ≅ B ]" (at level 0, P, Γ, A, B at level 50)
 Reserved Notation "[ P | Γ ||- t : A ]" (at level 0, P, Γ, t, A at level 50).
 (** The terms t and u are reducibly equal at type A in Γ, according to the pack P *)
 Reserved Notation "[ P | Γ ||- t ≅ u : A ]" (at level 0, P, Γ, t, u, A at level 50).
+(** The stacks π is reducible at type A in Γ, according to the pack P *)
+Reserved Notation "[ P | Γ ||- π <:> A ]" (at level 0, P, Γ, π, A at level 50).
+(** The stacks π and π' are reducibly equal at type A in Γ, according to the pack P *)
+Reserved Notation "[ P | Γ ||- π ≅ π' <:> A ]" (at level 0, P, Γ, π, π', A at level 50).
 
 (** Set level l is (strictly) smaller than type level l' *)
 Reserved Notation "l << l'" (at level 70, l' at next level).

--- a/theories/Stacks.v
+++ b/theories/Stacks.v
@@ -1,0 +1,117 @@
+(** * LogRel.Stacks: definition of stacks, representing evaluation contexts. *)
+From Coq Require Import List.
+From LogRel.AutoSubst Require Import core unscoped Ast Extra.
+From LogRel Require Import Utils BasicAst NormalForms.
+
+Lemma rev_rec :
+forall [A : Type] (P : list A -> Type),
+P nil ->
+(forall (x : A) (l : list A), P l -> P (l ++ x :: nil)) ->
+forall l : list A, P l.
+Proof.
+  intros.
+  rewrite <- rev_involutive.
+  induction (rev l) ; eauto.
+Qed.
+
+Variant ty_entry : term -> Type :=
+  | eSort s : ty_entry (tSort s)
+  | eProd A B : ty_entry (tProd A B)
+  | eNat : ty_entry tNat
+  | eEmpty : ty_entry tEmpty
+  | eSig A B : ty_entry (tSig A B).
+
+Variant nat_entry : term -> Type :=
+  | eZero : nat_entry tZero
+  | eSucc t : nat_entry (tSucc t).
+
+Variant dest_entry : Type :=
+  | eEmptyElim (P : term)
+  | eNatElim (P : term) (hs hz : term)
+  | eApp (u : term)
+  | eFst
+  | eSnd.
+
+Definition zip1 (t : term) (e : dest_entry) : term :=
+  match e with
+    | eEmptyElim P => (tEmptyElim P t)
+    | eNatElim P hs hz => (tNatElim P hs hz t) 
+    | eApp u => (tApp t u)
+    | eFst => tFst t
+    | eSnd => tSnd t
+  end.
+
+Definition stack := list dest_entry.
+
+Fixpoint zip t (π : stack) :=
+  match π with
+  | nil => t
+  | cons s π => zip (zip1 t s) π
+  end.
+
+Section NfEntries.
+
+Lemma zip_app t (π π' : stack) :
+  zip t (π ++ π')%list = zip (zip t π) π'.
+Proof.
+  induction π in t |- * ; cbn.
+  - reflexivity.
+  - apply IHπ.
+Qed.
+
+Lemma zip_whne n π :
+  whne n -> whne (zip n π).
+Proof.
+  intros Hne.
+  induction π as [|[]] in n, Hne |- * ; cbn.
+  1: eassumption.
+  all: eapply IHπ ; now econstructor.
+Qed.
+
+Lemma stack_whne t :
+  whne t <~> ∑ (s : stack) (n : nat), t = zip (tRel n) s.
+Proof.
+  split.
+  - induction 1.
+    1:
+    { exists nil.
+      eexists.
+      reflexivity.
+    }
+    all: destruct IHwhne as (?&?&?) ; subst.
+    1: eexists (_ ++ (eApp _ :: nil))%list.
+    2: eexists (_ ++ (eNatElim _ _ _ :: nil))%list.
+    3: eexists (_ ++ (eEmptyElim _ :: nil))%list.
+    4: eexists (_ ++ (eFst :: nil))%list.
+    5: eexists (_ ++ (eSnd :: nil))%list.
+    all: eexists.
+    all: rewrite zip_app ; cbn.
+    all: reflexivity.
+  - intros (π&n&->).
+    apply zip_whne.
+    now constructor.
+Qed.
+
+Lemma isType_entry t :
+  ty_entry t <~> (isType t × isCanonical t).
+Proof.
+  split.
+  - intros [].
+    all: split ; now constructor.
+  - intros [[] i] ; cycle -1.
+    1: now edestruct can_whne.
+    all: now constructor.
+Qed.
+
+Lemma isNat_entry t :
+  nat_entry t <~> (isNat t × isCanonical t).
+Proof.
+  split.
+  - intros [].
+    all: split ; now constructor.
+  - intros [[] i] ; cycle -1.
+    1: now edestruct can_whne.
+    all: now constructor.
+Qed.
+
+End NfEntries.


### PR DESCRIPTION
This PR moves stacks (which represent evaluation environments, ie "terms with a hole") earlier in the development, and develops a notion of reducible stacks, ie counters of a given type `A`.

This should let us define reducible neutrals as those consisting of a variable, with a reducible type, in a stack reducible at that type, and get more precise information on what "reducible neutrals" look like, including the fact that they always are (deep) normal forms. This should please @ppedrot!