### PR TITLE
simplify transitivity of reducibility

### DIFF
--- a/theories/Decidability/Completeness.v
+++ b/theories/Decidability/Completeness.v
@@ -221,9 +221,7 @@ Section RedImplemComplete.
   Proof.
     intros [|w]%well_formed_well_typed.
     all: eapply compute_domain.
-    Fail rewrite wh_red_equation_1.
-      (* weird, should work? probably the reason why simp also fails? *)
-    all: rewrite (wh_red_equation_1 t) ; cbn.
+    all: rewrite wh_red_equation_1; cbn.
     all: split ; [|easy].
     - eapply wh_red_stack_complete ; tea.
     - inversion w ; subst ; clear w.

--- a/theories/Decidability/Termination.v
+++ b/theories/Decidability/Termination.v
@@ -143,7 +143,7 @@ Proof.
   - intros ? ???? A B Hm [IHm []] ? [IHt] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [|m' t'| | | |].
-    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn; try exact I.
     split.
     + apply (IHm tt m') ; tea.
       destruct Hty as [? (?&(?&?&[])&?)%termGen'].
@@ -163,7 +163,7 @@ Proof.
   - intros * Hn [IHn] ? [IHP] ? [IHz] ? [IHs] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| |P'' hz'' hs'' n''| | |].
-    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try exact I.
     destruct Hty as [? (?&[]&?)%termGen'].
     split.
     1: apply (IHn tt n'') ; tea ; now eexists.
@@ -198,7 +198,7 @@ Proof.
   - intros * He [IHe] ? [IHP] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| | | P'' e'' | |].
-    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try exact I.
     destruct Hty as [? (?&[]&?)%termGen'].
     split.
     1: apply (IHe tt e'') ; tea ; now eexists.
@@ -212,7 +212,7 @@ Proof.
   - intros * h [ih []] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| | | | t |].
-    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try exact I.
     destruct Hty as [? hu'%termGen']; cbn in hu'; prod_hyp_splitter; subst.
     split.
     1: apply (ih tt t); tea; now eexists.
@@ -224,7 +224,7 @@ Proof.
   - intros * h [ih []] ??? ? u' wu' Hty.
     apply compute_domain.
     destruct wu' as [| | | | | t].
-    all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try exact I.
     destruct Hty as [? hu'%termGen']; cbn in hu'; prod_hyp_splitter; subst.
     split.
     1: apply (ih tt t); tea; now eexists.
@@ -282,7 +282,7 @@ Proof.
     eapply Uterm_isType in wu' ; tea.
     destruct wu' as [ | A'' B'' | | | | ? wu'] ; cycle -1.
     1: rewrite (whne_ty_view1 wu').
-    all: cbn ; try easy.
+    all: cbn ; try exact I.
     eapply termGen' in Hty as (?&[]&?) ; subst.
     split.
     2: intros [|] ; cbn ; [|easy] ; intros ?%implem_conv_sound%algo_conv_sound.

--- a/theories/DeclarativeSubst.v
+++ b/theories/DeclarativeSubst.v
@@ -42,19 +42,9 @@ Proof.
     2: unshelve eapply VA ; tea ; irrValid.
     cbn.
     unshelve eapply transEq.
-    6: now apply Vconv.
-    1-2: shelve.
-    + unshelve eapply validTy.
-      4: eapply VB.
-      1: eassumption.
-      irrValid.
-    + unshelve eapply validTy.
-      4: eapply VB.
-      1: eassumption.
-      irrValid.
-    + unshelve irrelevanceRefl.
-      2-3: unshelve eapply VB ; tea.
-      all: irrValid.
+    4: now apply Vconv.
+    2-3: unshelve eapply VB ; tea.
+    all: irrValid.
   - intros * Ht * HΔ Hσ.
     unshelve eapply Fundamental_subst_conv in Hσ as [].
     1,3: boundary.

--- a/theories/LogicalRelation/Induction.v
+++ b/theories/LogicalRelation/Induction.v
@@ -208,7 +208,7 @@ Section Inversions.
       exfalso.
       gen_typing.
     - intros * ? A' red whA.
-      enough ({w' & whA = NeType w'}) as [? ->] by easy.
+      enough (∑ w', whA = NeType w') as [? ->] by easy.
       destruct neA as [A'' redA neA''].
       apply convneu_whne in neA''.
       assert (A' = A'') as <-.

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -326,6 +326,7 @@ Section LRIrrelevantInductionStep.
 
 Universe i j k l i' j' k' l'.
 
+#[local]
 Definition IHStatement lA lA' :=
   (forall l0 (ltA : l0 << lA) (ltA' : l0 << lA'),
       prod@{v v}
@@ -337,6 +338,7 @@ Definition IHStatement lA lA' :=
             [ LogRelRec@{i j k} lA l0 ltA | Γ ||- t ≅ u | lr1 ] <≈>
             [ LogRelRec@{i' j' k'} lA' l0 ltA' | Γ ||- t ≅ u | lr2 ])).
 
+#[local]
 Lemma UnivIrrelevanceLRPack
   {Γ lA lA' A A'}
   (IH : IHStatement lA lA')
@@ -370,6 +372,7 @@ Qed.
 
 (** ** The main theorem *)
 
+#[local]
 Lemma LRIrrelevantPreds {lA lA'}
   (IH : IHStatement lA lA')
   (Γ : context) (A A' : term)
@@ -429,6 +432,7 @@ Proof.
 Qed.
 
 
+#[local]
 Lemma LRIrrelevantCumPolyRed {lA}
   (IH : IHStatement lA lA)
   (Γ : context) (shp pos : term)
@@ -467,6 +471,7 @@ Qed.
 
 
 Set Printing Universes.
+#[local]
 Lemma LRIrrelevantCumTy {lA}
   (IH : IHStatement lA lA)
   (Γ : context) (A : term)
@@ -491,6 +496,7 @@ Proof.
 Qed.
 
 
+#[local]
 Lemma IrrRec0 : IHStatement zero zero.
 Proof.
   intros ? ltA; inversion ltA.
@@ -508,6 +514,7 @@ Fail Fail Constraint l' < l.
 
 End LRIrrelevantInductionStep.
 
+#[local]
 Theorem IrrRec@{i j k l i' j' k' l'} {lA} {lA'} :
   IHStatement@{i j k l i' j' k' l'} lA lA'.
 Proof.
@@ -525,6 +532,7 @@ Proof.
     exact (tyEq u).
 Qed.
 
+#[local]
 Theorem LRIrrelevantCum@{i j k l i' j' k' l'}
   (Γ : context) (A A' : term) {lA lA'}
   {eqTyA redTmA : term -> Type@{k}}
@@ -540,6 +548,30 @@ Theorem LRIrrelevantCum@{i j k l i' j' k' l'}
 Proof.
   exact (LRIrrelevantPreds@{i j k l i' j' k' l'} IrrRec Γ A A' lrA lrA').
 Qed.
+
+Theorem LRIrrelevantPack@{i j k l} 
+  (Γ : context) (A A' : term) {lA lA'} 
+  (RA : [ LogRel@{i j k l} lA | Γ ||- A ])
+  (RA' : [ LogRel@{i j k l} lA' | Γ ||- A' ])
+  (RAA' : [Γ ||-<lA> A ≅ A' | RA]) :
+  equivLRPack@{v v v} RA RA'.
+Proof.
+  pose proof (LRIrrelevantCum@{i j k l i j k l} Γ A A' (LRAd.adequate RA) (LRAd.adequate RA') RAA') as [].
+  constructor; eauto.
+Defined.
+
+Theorem LRTransEq@{i j k l} 
+  (Γ : context) (A B C : term) {lA lB} 
+  (RA : [ LogRel@{i j k l} lA | Γ ||- A ])
+  (RB : [ LogRel@{i j k l} lB | Γ ||- B ])
+  (RAB : [Γ ||-<lA> A ≅ B | RA])
+  (RBC : [Γ ||-<lB> B ≅ C | RB]) :
+  [Γ ||-<lA> A ≅ C | RA].
+Proof.
+  pose proof (LRIrrelevantPack Γ A B RA RB RAB) as [h _ _].
+  now apply h.
+Defined.
+
 
 Theorem LRCumulative@{i j k l i' j' k' l'} {lA}
   {Γ : context} {A : term}
@@ -557,6 +589,7 @@ Qed.
 End LRIrrelevant.
 
 
+#[local]
 Corollary TyEqIrrelevantCum Γ A {lA eqTyA redTmA eqTmA lA' eqTyA' redTmA' eqTmA'}
   (lrA : LogRel lA Γ A eqTyA redTmA eqTmA) (lrA' : LogRel lA' Γ A eqTyA' redTmA' eqTmA') :
   forall B, eqTyA B -> eqTyA' B.
@@ -588,6 +621,7 @@ Proof.
   revert lrA'; rewrite <- e; now apply LRTyEqIrrelevantCum.
 Qed.
 
+#[local]
 Corollary RedTmIrrelevantCum Γ A {lA eqTyA redTmA eqTmA lA' eqTyA' redTmA' eqTmA'}
   (lrA : LogRel lA Γ A eqTyA redTmA eqTmA) (lrA' : LogRel lA' Γ A eqTyA' redTmA' eqTmA') :
   forall t, redTmA t -> redTmA' t.
@@ -620,6 +654,7 @@ Proof.
 Qed.
 
 
+#[local]
 Corollary TmEqIrrelevantCum Γ A {lA eqTyA redTmA eqTmA lA' eqTyA' redTmA' eqTmA'}
   (lrA : LogRel lA Γ A eqTyA redTmA eqTmA) (lrA' : LogRel lA' Γ A eqTyA' redTmA' eqTmA') :
   forall t u, eqTmA t u -> eqTmA' t u.
@@ -671,6 +706,7 @@ Proof.
   now eapply TyEqSym.
 Qed.
 
+#[local]
 Corollary RedTmConv Γ A A' {lA eqTyA redTmA eqTmA lA' eqTyA' redTmA' eqTmA'}
   (lrA : LogRel lA Γ A eqTyA redTmA eqTmA) (lrA' : LogRel lA' Γ A' eqTyA' redTmA' eqTmA') :
   eqTyA A' ->
@@ -701,6 +737,7 @@ Proof.
   Unshelve. all: tea.
 Qed.
 
+#[local]
 Corollary TmEqRedConv Γ A A' {lA eqTyA redTmA eqTmA lA' eqTyA' redTmA' eqTmA'}
   (lrA : LogRel lA Γ A eqTyA redTmA eqTmA) (lrA' : LogRel lA' Γ A' eqTyA' redTmA' eqTmA') :
   eqTyA A' ->

--- a/theories/Substitution/Introductions/Empty.v
+++ b/theories/Substitution/Introductions/Empty.v
@@ -154,7 +154,7 @@ Section EmptyElimRedEq.
   Proof.
     intros. eapply transEq; [| eapply LRTyEqSym ]; eapply RPQext; cycle 1; tea.
     now eapply LREqTermRefl_.
-    Unshelve. 3,4: eauto. tea.
+    Unshelve. 2,3: eauto.
   Qed.
 
   Lemma emptyElimRedAuxLeft : @emptyRedElimStmt _ _ P NN RPpt.
@@ -168,7 +168,7 @@ Section EmptyElimRedEq.
     eapply emptyElimRedAux; tea.
     + intros. eapply transEq; [eapply LRTyEqSym |]; eapply RPQext; cycle 1; tea.
       now eapply LREqTermRefl_.
-    Unshelve. 2: eauto. all:tea.
+    Unshelve. all:tea.
   Qed.
 
   Lemma emptyElimRedEqAux :
@@ -316,9 +316,6 @@ Proof.
     1,2: unshelve econstructor; [now bsimpl| now cbn].
     unshelve econstructor; [|now cbn].
     bsimpl. eapply reflSubst.
-    Unshelve. 1: tea.
-    eapply validTy; tea.
-    unshelve econstructor; [| now cbn]; now bsimpl.
 Qed.
 
 End Empty.

--- a/theories/Substitution/Introductions/Nat.v
+++ b/theories/Substitution/Introductions/Nat.v
@@ -272,7 +272,7 @@ Section NatElimRedEq.
   Proof.
     intros. eapply transEq; [| eapply LRTyEqSym ]; eapply RPQext; cycle 1; tea.
     now eapply LREqTermRefl_.
-    Unshelve. 3,4: eauto. tea.
+    Unshelve. 2,3: eauto.
   Qed.
 
   Lemma natElimRedAuxLeft : @natRedElimStmt _ _ P hs hz NN RPpt.
@@ -286,7 +286,7 @@ Section NatElimRedEq.
     eapply natElimRedAux; tea.
     + intros. eapply transEq; [eapply LRTyEqSym |]; eapply RPQext; cycle 1; tea.
       now eapply LREqTermRefl_.
-    Unshelve. 2: eauto. all:tea.
+    Unshelve. all:tea.
   Qed.
 
   Lemma natElimRedEqAux :
@@ -547,9 +547,6 @@ Proof.
     1,2: unshelve econstructor; [now bsimpl| now cbn].
     unshelve econstructor; [|now cbn].
     bsimpl. eapply reflSubst.
-    Unshelve. 1: tea.
-    eapply validTy; tea.
-    unshelve econstructor; [| now cbn]; now bsimpl.
 Qed.
 
 Lemma elimSuccHypTyCongValid {Γ l P P'}

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -134,7 +134,6 @@ Section SigInjValid.
     + unshelve eapply (PolyRed.posExt p wk_id wfΔ); tea.
       1: irrelevance0; [|exact (validHead Vσ)]; now rewrite wk_id_ren_on.
       irrelevance0; [|exact (eqHead Vσσ')]; now rewrite wk_id_ren_on.
-    Unshelve. 2: now eapply h.
   Qed.
   
 End SigInjValid.
@@ -602,7 +601,7 @@ Section PairRed.
       eapply LRTyEqSym.
       eapply transEq; tea.
       now eapply LRTyEqSym.
-      Unshelve. 1,4: tea.
+      Unshelve. 1: tea.
   Qed.
 
   Lemma subst_sig {A B σ} : (tSig A B)[σ] = (tSig A[σ] B[up_term_term σ]).
@@ -669,7 +668,6 @@ Section PairRed.
     eapply LRTmEqRedConv; cycle 1.
     + now eapply LRTmEqSym.
     + eapply LRTyEqSym; eapply transEq; cycle 1; tea.
-    Unshelve. 2: tea.
   Qed.
 
 

--- a/theories/Substitution/Irrelevance.v
+++ b/theories/Substitution/Irrelevance.v
@@ -145,11 +145,11 @@ Proof.
 Qed.
 
 Lemma transValidEq {Γ l A B C} {VΓ : [||-v Γ]}
-  {VA : [Γ ||-v<l> A | VΓ]} {VB : [Γ ||-v<l> B | VΓ]} (VC : [Γ ||-v<l> C | VΓ]):
+  {VA : [Γ ||-v<l> A | VΓ]} {VB : [Γ ||-v<l> B | VΓ]} :
   [Γ ||-v<l> A ≅ B | VΓ | VA] -> [Γ ||-v<l> B ≅ C | VΓ | VB] -> [Γ ||-v<l> A ≅ C | VΓ | VA].
 Proof.
   constructor; intros; eapply transEq; now eapply validTyEq.
-  Unshelve. all: tea. now eapply validTy.
+  Unshelve. all: tea.
 Qed.
 
 Lemma irrelevanceTm {Γ l t A} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) (VA' : [Γ||-v<l> A | VΓ']) :

--- a/theories/Substitution/SingleSubst.v
+++ b/theories/Substitution/SingleSubst.v
@@ -60,7 +60,6 @@ Proof.
     eapply validTmEq.
     now eapply convEq.
     Unshelve. all: tea.
-    now eapply validTy.
 Qed.
 
 


### PR DESCRIPTION
Transitivity of the reducibly convertible types is easily derivable from the main irrelevance lemma, so we can bypass a proof in `Transitivity.v` that is annoying to maintain.