### PR TITLE
Add Martin-Löf Identity types

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -35,6 +35,7 @@ theories/LogicalRelation/Reduction.v
 theories/LogicalRelation/NormalRed.v
 theories/LogicalRelation/Application.v
 theories/LogicalRelation/SimpleArr.v
+theories/LogicalRelation/Id.v
 
 theories/Validity.v
 theories/Substitution/Irrelevance.v
@@ -54,6 +55,7 @@ theories/Substitution/Introductions/Var.v
 theories/Substitution/Introductions/Nat.v
 theories/Substitution/Introductions/Empty.v
 theories/Substitution/Introductions/Sigma.v
+theories/Substitution/Introductions/Id.v
 theories/Fundamental.v
 
 theories/AlgorithmicTyping.v

--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -103,6 +103,9 @@ Section AlgoConvConv.
       eapply stability ; tea.
       destruct ihA.
       now boundary.
+    - intros * ? ihA ? ihx ? ihy ? h **.
+      econstructor; [now eapply ihA| eapply ihx | eapply ihy]; tea.
+      1,2: eapply stability; tea; now eapply lrefl.
     - intros * ? IHM **.
       edestruct IHM as [[? []]] ; tea.
       now econstructor.
@@ -182,6 +185,20 @@ Section AlgoConvConv.
       eapply TermConv; refold; [|now symmetry].
       econstructor; eapply lrefl.
       now eapply stability.
+    - intros * ? [ih [? ihm ihn]] ? [ihA] ? [ihx] ? [ihP] ? [ihhr] ? [ihy] ? hm hn **.
+      edestruct ih as [? [? [?[?[?[red]]]]%red_ty_compl_id_r isTy]]; tea.
+      pose proof hm as [? hm'].
+      eapply stability in hm' as [? [[-> ]]]%termGen'; tea.
+      pose proof (redty_whnf red (isType_whnf _ isTy)); subst.
+      assert [Γ' |-[de] A ≅ A] by (eapply stability; tea; now eapply lrefl).
+      assert [Γ' |-[de] x ≅ x : A] by (eapply stability; tea; now eapply lrefl). 
+      assert [|- (Γ',, A),, tId A⟨@wk1 Γ' A⟩ x⟨@wk1 Γ' A⟩ (tRel 0) ≅ (Γ,, A),, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)].
+      1: eapply idElimMotiveCtxConv; first [now econstructor| now symmetry| boundary].
+      assert [Γ' |-[ de ] P[tRefl A x .: x..] ≅ P[tRefl A x .: x..]].
+      1: eapply TypeRefl; refold; now boundary.
+      eexists; split.
+      1: econstructor; tea; eauto.
+      eapply TypeRefl; refold; now boundary.
     - intros * ? IHm **.
       edestruct IHm as [[A'' []] []]; tea.
       assert [Γ' |-[de] A' ≅ A''] as HconvA'.
@@ -291,6 +308,17 @@ Section AlgoConvConv.
       eapply TermConv; refold; [|now symmetry].
       eapply TermRefl, stability; tea.
       now econstructor.
+    - intros * ? [ihA] ? [ihx] ? [ihy] ? hm ? * ? r%red_ty_compl_univ_l wh%isType_whnf.
+      pose proof (redty_whnf r wh); subst.
+      assert [Γ' |-[de] A ≅ A] by (eapply stability; tea; eapply lrefl; now econstructor).
+      econstructor; tea.
+      + eapply ihA; tea; constructor; eapply stability; tea; now boundary.
+      + eapply ihx; tea.
+      + eapply ihy; tea.
+    - intros * ? [ihA] ? [ihx] ??? * ? [?[?[? [r]]]]%red_ty_compl_id_l wh%isType_whnf.
+      pose proof (redty_whnf r wh); subst.
+      econstructor; tea; eauto.
+      eapply ihx; tea; eapply stability; tea; now eapply lrefl.
     - intros * ? IHm HtyP ? ? ? * ? HconvN HtyA'.
       edestruct IHm as [[? []] ?] ; tea.
       unshelve eapply ty_conv_inj in HconvN.
@@ -372,6 +400,7 @@ Section TermTypeConv.
     - intros.
       congruence.
     - intros; congruence.
+    - intros; congruence.
     - intros. 
       now econstructor.
   Qed.
@@ -426,6 +455,27 @@ Section Symmetry.
       eapply ihB.
       econstructor; tea.
       now eapply ihA.
+    - intros * ? ihA ? [ihx] ? [ihy] ? [? []]%id_ty_inv [? []]%id_ty_inv * ?.
+      econstructor.
+      + now eapply ihA.
+      + eapply algo_conv_conv.
+        * eapply ihx; tea.
+        * now eapply conv_ctx_refl_r.
+        * pose proof H as ?%algo_conv_sound;try boundary.
+          now eapply stability.
+        * eapply stability; [| now symmetry].
+          eapply wfTermConv; refold; tea.
+          now symmetry.
+        * now eapply stability.
+      + eapply algo_conv_conv.
+        * eapply ihy; tea.
+        * now eapply conv_ctx_refl_r.
+        * pose proof H as ?%algo_conv_sound;try boundary.
+          now eapply stability.
+        * eapply stability; [| now symmetry].
+          eapply wfTermConv; refold; tea.
+          now symmetry.
+        * now eapply stability.
     - intros * ? IHM  **.
       edestruct IHM as [[U' [IHM' HconvM]] []] ; tea.
       now econstructor.
@@ -537,6 +587,42 @@ Section Symmetry.
       eapply typing_subst1; tea.
       eapply TermConv; refold; [|now symmetry].
       eapply stability; [now econstructor|now symmetry].
+    - intros * ? [ihe [? ihme]] ? [ihA] ? [ihx] ? [ihP] ? [ihhr] ? [ihy] ? hm hn * ?.
+      edestruct ihe as [? [hconv [? [? [? [r%redty_whnf]]]]%red_ty_compl_id_l]]; tea; subst.
+      2: now apply algo_conv_wh in hconv as [].
+      eexists; split.
+      1: econstructor; tea.
+      + now eapply ihA.
+      + eapply algo_conv_conv.
+        * now eapply ihx.
+        * now eapply conv_ctx_refl_r.
+        * now eapply stability.
+        * eapply stability; [| now symmetry]; now boundary.
+        * eapply stability; [| now symmetry]; now boundary.
+      + eapply ihP; symmetry.
+        eapply idElimMotiveCtxConv; tea; eapply idElimMotiveCtx; tea; try boundary.
+        all: eapply stability; [|now symmetry]; try boundary.
+        econstructor; tea; now boundary.
+      + eapply algo_conv_conv.
+        * now eapply ihhr.
+        * now eapply conv_ctx_refl_r.
+        * eapply stability; tea;[| now symmetry].
+          eapply typing_subst2; tea.
+          cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq; now econstructor.
+        * eapply stability; [| now symmetry]; now boundary.
+        * eapply stability; [| now symmetry]; now boundary.
+      + eapply algo_conv_conv.
+        * now eapply ihy.
+        * now eapply conv_ctx_refl_r.
+        * now eapply stability.
+        * eapply stability; [| now symmetry]; now boundary.
+        * eapply stability; [| now symmetry]; now boundary.
+      + eapply stability; tea;[| now symmetry].
+        eapply typing_subst2; tea.
+        cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq; tea.
+        econstructor; tea.
+        eapply ihme.
+        now destruct hm as [? [? [[]]]%termGen'].
     - intros * ? IHm  **.
       edestruct IHm as [[A'' [IHm' Hconv]] [Hwf]] ; tea ; clear IHm.
       assert [Δ |-[de] A' ≅ A''] as Hconv'.
@@ -602,6 +688,39 @@ Section Symmetry.
         2,3: now symmetry.
         now econstructor.
       * eapply stability; [now econstructor| now symmetry].
+    - intros * ? [ihA] ? [ihx] ? [ihy] ? [? [[->]]]%termGen' [? [[->]]]%termGen' * ?.
+      econstructor.
+      + now eapply ihA.
+      + eapply algo_conv_conv.
+        * eapply ihx; tea.
+        * now eapply conv_ctx_refl_r.
+        * constructor.
+          pose proof H as ?%algo_conv_sound;try boundary.
+          now eapply stability.
+        * eapply stability; [| now symmetry].
+          eapply wfTermConv; refold; tea.
+          symmetry; now econstructor.
+        * now eapply stability.
+      + eapply algo_conv_conv.
+        * eapply ihy; tea.
+        * now eapply conv_ctx_refl_r.
+        * pose proof H as ?%algo_conv_sound;try boundary.
+          econstructor; now eapply stability.
+        * eapply stability; [| now symmetry].
+          eapply wfTermConv; refold; tea.
+          econstructor; now symmetry.
+        * now eapply stability.
+    - intros* ? [ihA] ? [ihx] ? [? [[->]]]%termGen' [? [[->]]]%termGen' * ?.
+      econstructor.
+      + now eapply ihA.
+      + eapply algo_conv_conv.
+        * now eapply ihx.
+        * now eapply conv_ctx_refl_r.
+        * eapply stability; tea; now symmetry.
+        * eapply stability; [|now symmetry].
+          econstructor; tea.
+          now symmetry.
+        * now eapply stability.
     - intros * ? IH  **.
       edestruct IH as [[? []] []] ; tea.
       now econstructor.
@@ -688,11 +807,17 @@ Section Transitivity.
         + eapply IHA ; tea.
         + eapply IHB ; tea.
           now econstructor.
-    - intros * ? IH ? ? ? * ? Hconv.
-      inversion Hconv ; subst ; clear Hconv ; refold.
-      1-5: apply algo_conv_wh in H as [_ e] ; now inversion e.
+    - intros * ? [ihA] ? [ihx] ? [ihy] ??? * ? hconv.
+      inversion hconv; subst; clear hconv; refold.
+      2: apply algo_conv_wh in H6 as [e _]; now inversion e.
       econstructor.
-      now eapply IH.
+      + now eapply ihA.
+      + eapply ihx; tea; now symmetry.
+      + eapply ihy; tea; now symmetry.
+    - intros * ? IH ? ? ? * ? Hconv.
+      inversion Hconv ; subst ; clear Hconv ; refold; cycle -1.
+      1:econstructor; now eapply IH.
+      all: apply algo_conv_wh in H as [_ e] ; now inversion e.
     - intros * Hin ? _ _ * ? Hconv.
       inversion Hconv ; subst ; clear Hconv ; refold.
       split.
@@ -753,6 +878,27 @@ Section Transitivity.
       split; [now econstructor|].
       eapply typing_subst1; tea.
       eapply TermConv; refold; [now econstructor|now symmetry].
+    - intros * ? [ihe [? ihme]] ? [ihA] ? [ihx] ? [ihP] ? [ihhr] ? [ihy] ? hm ? * ? hconv.
+      inversion hconv; subst; clear hconv; refold.
+      edestruct ihe as [? []%id_ty_inj]; tea.
+      split.
+      + econstructor; tea; eauto.
+        * eapply ihx; tea; now symmetry.
+        * eapply ihP; tea; symmetry.
+          eapply idElimMotiveCtxConv; tea; eapply idElimMotiveCtx.
+          3,4: eapply stability;[|now symmetry].
+          4: econstructor; tea.
+          all: boundary.
+        * eapply ihhr; tea; symmetry.
+          eapply typing_subst2; tea.
+          cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq.
+          now econstructor.
+        * eapply ihy; tea; now symmetry.
+      + eapply typing_subst2; tea.
+        cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq.
+        econstructor; tea.
+        eapply ihme.
+        now pose proof hm as [? [? [[]]]%termGen'].
     - intros * ? IH ? ? ? ? ? * ? Hconv.
       inversion Hconv ; subst ; clear Hconv ; refold.
       edestruct IH as [[? HconvA] ?] ; tea.
@@ -879,9 +1025,24 @@ Section Transitivity.
       eapply ihSnd; tea.
       eapply typing_subst1; tea.
       now symmetry.
+    - intros * ? [ihA] ? [ihx] ? [ihy] ??? * ? r%red_ty_compl_univ_r hconv.
+      inversion hconv; subst; clear hconv.
+      1,2: unshelve epose proof (redty_whnf r _); try constructor; congruence.
+      2: refold; apply algo_conv_wh in H6 as [? _]; inv_whne.
+      econstructor; tea.
+      * eapply ihA; tea; do 2 econstructor; boundary.
+      * eapply ihx; tea; econstructor; now symmetry.
+      * eapply ihy; tea; econstructor; now symmetry.
+    - intros * ? [ihA] ? [ihx]  ??? * ? [? [? [? [r]]]]%red_ty_compl_id_r hconv.
+      inversion hconv; subst; clear hconv; refold.
+      1,2: unshelve epose proof (redty_whnf r _); try constructor; congruence.
+      2: refold; apply algo_conv_wh in H5 as [? _]; inv_whne.
+      econstructor.
+      * now eapply ihA.
+      * eapply ihx; tea; now symmetry.
     - intros * Hnconv IH ? ? ? ? * ? h Hconv.
       inversion Hconv ; subst ; clear Hconv ; refold.
-      1-5,7: now inversion Hnconv.
+      1-5,7,9,10: now inversion Hnconv.
       1,2: destruct H ;
           now unshelve eapply ty_conv_inj in h ; [now econstructor | now econstructor | cbn in *].
       econstructor ; tea.
@@ -945,6 +1106,14 @@ Module AlgorithmicConvProperties.
         * symmetry.
           now eapply algo_conv_sound in bun_conv_ty0.
       + now do 2 econstructor.
+    - intros * convA. 
+      pose proof convA as ?%bn_conv_sound.
+      revert convA; intros_bn.
+      + now econstructor.
+      + econstructor; tea; econstructor; tea.
+      + econstructor.
+        1,2: now reflexivity.
+        now econstructor.
 Qed.
 
   #[export, refine] Instance ConvTermAlgProperties : ConvTermProperties (ta := bn) := {}.
@@ -1040,6 +1209,24 @@ Qed.
     - intros_bn.
       1-3: gen_typing.
       now do 2 econstructor.
+    - intros * convA.
+      assert [Γ |-[de] A ≅ A'] by (econstructor; now pose proof convA as ?%bn_conv_sound).
+      revert convA; intros_bn.
+      + now econstructor.
+      + econstructor; tea; now econstructor.
+      + econstructor; try reflexivity.
+        now econstructor.
+    - intros * convA convx.
+      pose proof convA as ?%bn_conv_sound.
+      pose proof convx as ?%bn_conv_sound.
+      revert convA convx; intros_bn.
+      + now econstructor.
+      + now econstructor.
+      + econstructor.
+        1: econstructor; tea; now econstructor.
+        symmetry; econstructor; tea.
+      + econstructor; try reflexivity.
+        now econstructor.
   Qed.
 
   #[export, refine] Instance ConvNeuAlgProperties : ConvNeuProperties (ta := bn) := {}.
@@ -1209,6 +1396,43 @@ Qed.
       symmetry; econstructor; tea.
       1: boundary.
       now symmetry.
+  - intros * tyA tyx convA convx convP convhr convy [?????? conve conv].
+    pose proof convA as ?%bn_conv_sound.
+    pose proof convx as ?%bn_conv_sound.
+    pose proof convP as ?%bn_conv_sound.
+    pose proof convhr as ?%bn_conv_sound.
+    pose proof convy as ?%bn_conv_sound.
+    econstructor; tea.
+    2,4: now constructor.
+    + eexists; econstructor; try boundary.
+      apply algo_conv_sound in conve as [? h]; tea.
+      econstructor; [boundary|]; tea.
+    + eexists; econstructor; try boundary.
+      * econstructor; tea; boundary.
+      * eapply stability; [boundary|].
+        eapply idElimMotiveCtxConv; tea.
+        1: now eapply ctx_refl.
+        1,2: eapply idElimMotiveCtx.
+        4: econstructor; tea.
+        all: boundary.
+      * econstructor; [now boundary|].
+        eapply typing_subst2; tea.
+        cbn ; rewrite 2!wk1_ren_on, 2! shift_subst_eq.
+        now econstructor.
+      * econstructor; tea; boundary.
+      * apply algo_conv_sound in conve as [? ]; tea.
+        econstructor; [boundary|]; tea.
+        etransitivity; tea.
+        econstructor; tea.
+    + destruct convA, convx, convP, convhr, convy.
+      pose proof conv as [?[?[?[[]]]]]%red_ty_compl_id_r.
+      econstructor; tea.
+      econstructor; constructor + tea.
+    + eapply TypeRefl; refold; eapply typing_subst2; tea.
+      all: try boundary.
+      cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq.
+      apply algo_conv_sound in conve as [? ]; tea.
+      econstructor; [boundary|]; tea.
   Qed.
 
 End AlgorithmicConvProperties.
@@ -1233,6 +1457,9 @@ Module IntermediateTypingProperties.
   #[export, refine] Instance TypingIntProperties : TypingProperties (ta := bni) := {}.
   Proof.
     all: unfold_bni.
+    - gen_typing.
+    - gen_typing.
+    - gen_typing.
     - gen_typing.
     - gen_typing.
     - gen_typing.
@@ -1296,6 +1523,7 @@ Module IntermediateTypingProperties.
         symmetry.
         now eapply algo_conv_sound in bun_conv_ty.
       + now do 2 econstructor.
+    - intros. gen_typing.
   Qed.
 
   #[export, refine] Instance ConvTermIntProperties : ConvTermProperties (ta := bni) := {}.
@@ -1363,6 +1591,8 @@ Module IntermediateTypingProperties.
     - intros ? HΓ.
       eapply (convtm_empty (ta := bn)).
       now econstructor.
+    - intros; gen_typing.
+    - intros. gen_typing.
   Qed.
 
   #[export, refine] Instance ConvNeuIntProperties : ConvNeuProperties (ta := bni) := {}.
@@ -1388,6 +1618,44 @@ Module IntermediateTypingProperties.
     - gen_typing.
     - gen_typing.
     - gen_typing.
+    - (* Copy-paste of the proof above in ConvNeuAlgProperties but gen_typing fails (why ?) *)
+      intros * tyA tyx convA convx convP convhr convy [?????? conve conv].
+      pose proof convA as ?%bn_conv_sound.
+      pose proof convx as ?%bn_conv_sound.
+      pose proof convP as ?%bn_conv_sound.
+      pose proof convhr as ?%bn_conv_sound.
+      pose proof convy as ?%bn_conv_sound.
+      econstructor; tea.
+      2,4: now constructor.
+      + eexists; econstructor; try boundary.
+        apply algo_conv_sound in conve as [? h]; tea.
+        econstructor; [boundary|]; tea.
+      + eexists; econstructor; try boundary.
+        * econstructor; tea; boundary.
+        * eapply stability; [boundary|].
+          eapply idElimMotiveCtxConv; tea.
+          1: now eapply ctx_refl.
+          1,2: eapply idElimMotiveCtx.
+          4: econstructor; tea.
+          all: boundary.
+        * econstructor; [now boundary|].
+          eapply typing_subst2; tea.
+          cbn ; rewrite 2!wk1_ren_on, 2! shift_subst_eq.
+          now econstructor.
+        * econstructor; tea; boundary.
+        * apply algo_conv_sound in conve as [? ]; tea.
+          econstructor; [boundary|]; tea.
+          etransitivity; tea.
+          econstructor; tea.
+      + destruct convA, convx, convP, convhr, convy.
+        pose proof conv as [?[?[?[[]]]]]%red_ty_compl_id_r.
+        econstructor; tea.
+        econstructor; constructor + tea.
+      + eapply TypeRefl; refold; eapply typing_subst2; tea.
+        all: try boundary.
+        cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq.
+        apply algo_conv_sound in conve as [? ]; tea.
+        econstructor; [boundary|]; tea.
   Qed.
 
   #[export, refine] Instance RedTermIntProperties :
@@ -1465,6 +1733,22 @@ Module IntermediateTypingProperties.
       1: reflexivity.
       econstructor; eauto. 
       now constructor.
+    - intros * ??????? convA convxy convxz.
+      pose proof convA as ?%bn_conv_sound.
+      pose proof convxy as ?%bn_conv_sound.
+      pose proof convxz as ?%bn_conv_sound.
+      destruct convA, convxy, convxz.
+      econstructor; tea.
+      2: eapply redalg_one_step; constructor.
+      econstructor; tea.
+      econstructor.
+      1: econstructor; tea; now econstructor.
+      symmetry; econstructor; tea.
+      etransitivity; tea; now symmetry.
+    - intros * ????? []. 
+      econstructor; tea.
+      2: now eapply redalg_idElim.
+      now econstructor.
     - intros * [] [].
       econstructor ; tea.
       econstructor ; tea.

--- a/theories/AlgorithmicTyping.v
+++ b/theories/AlgorithmicTyping.v
@@ -232,7 +232,7 @@ Section Definitions.
       [Γ |- p ▹h tSig A B] ->
       [Γ |- tSnd p ▹ B[(tFst p)..]]
     | infId {Γ A x y} :
-      [Γ |- A ◃ U] ->
+      [Γ |- A ▹h U] ->
       [Γ |- x ◃ A] ->
       [Γ |- y ◃ A] ->
       [Γ |- tId A x y ▹ U]

--- a/theories/AlgorithmicTypingProperties.v
+++ b/theories/AlgorithmicTypingProperties.v
@@ -33,64 +33,10 @@ Proof.
     now eapply redty_red, red_ty_compl_univ_r.
   }
   eapply BundledTypingInduction.
-  all: try solve [econstructor].
-  - intros.
-    econstructor.
-    + intros Hcan ; inversion Hcan.
-    + econstructor.
-      1: now econstructor.
-      now eapply redty_red, red_ty_compl_univ_r.
-  - intros.
-    prod_hyp_splitter.
-    now econstructor.
-  - intros * ????? Hconv.
-    unshelve eapply ty_conv_inj in Hconv.
-    1-2: now econstructor.
-    now cbn in Hconv.
-  - intros.
-    econstructor.
-    + intros Hcan ; inversion Hcan.
-    + econstructor.
-      1: now econstructor.
-      now eapply redty_red, red_ty_compl_univ_r.
-  - intros * ? Hconv.
-    unshelve eapply ty_conv_inj in Hconv.
-    1-2: now econstructor.
-    now cbn in Hconv.
-  - intros * ??? Hconv.
-    unshelve eapply ty_conv_inj in Hconv.
-    1-2: now econstructor.
-    now cbn in Hconv.
-  - intros.
-    econstructor.
-    + intros Hcan ; inversion Hcan.
-    + econstructor.
-      1: now econstructor.
-      now eapply redty_red, red_ty_compl_univ_r.
-  - intros.
-    econstructor.
-    + intros Hcan ; inversion Hcan.
-    + econstructor.
-      1: now econstructor.
-      now eapply redty_red, red_ty_compl_univ_r.
-  - intros * ? [] ? [] **.
-    econstructor; eauto.
-  - intros * ????? ???? hconv.
-    unshelve eapply ty_conv_inj in hconv.
-    1,2: constructor.
-    cbn in hconv; destruct hconv.
-  - intros * ??? hconv.
-    econstructor.
-    + intros Hcan; inversion Hcan.
-    + econstructor.
-      1: now econstructor.
-      now eapply redty_red, red_ty_compl_univ_r.
-  - intros * ??? hconv.
-    econstructor.
-    + intros Hcan; inversion Hcan.
-    + econstructor.
-      1: now econstructor.
-      now eapply redty_red, red_ty_compl_univ_r.
+  all: try solve [
+    econstructor |
+    intros; econstructor; [intros Hcan; inversion Hcan| econstructor;[now econstructor|now eapply redty_red, red_ty_compl_univ_r]]|
+    intros; match goal with H : [_ |- _ ≅ _] |- _ => unshelve eapply ty_conv_inj in H; try now econstructor; now cbn in H end ].
   - intros * ? [IH] **; subst.
     eapply IH.
     eapply subject_reduction_type ; tea.
@@ -121,16 +67,11 @@ Module AlgorithmicTypingProperties.
 
   #[export, refine] Instance WfTypeAlgProperties : WfTypeProperties (ta := bn) := {}.
   Proof.
-    - intros_bn.
-      now eapply algo_typing_wk.
-    - intros_bn.
-      now econstructor.
-    - intros_bn.
-      now econstructor.
-    - intros_bn.
-      now econstructor.
-    - intros.
-      now eapply algo_typing_small_large.
+    all: cycle -1.
+    1: intros; now eapply algo_typing_small_large.
+    1: intros_bn; now eapply algo_typing_wk.
+    1-3: intros_bn; now econstructor.
+    intros_bn; econstructor; tea; econstructor; tea; now eapply algo_conv_complete.
   Qed.
 
   #[export, refine] Instance TypingAlgProperties : TypingProperties (ta := bn) := {}.
@@ -215,6 +156,29 @@ Module AlgorithmicTypingProperties.
       eapply TermConv; refold; [|now symmetry].
       econstructor. eapply TermRefl.
       now eapply inf_conv_decl.
+    - intros_bn.
+      + econstructor; tea.
+        2,3: econstructor ; tea; now eapply algo_conv_complete.
+        econstructor; tea; now eapply red_ty_compl_univ_r.
+      + now do 2 econstructor.
+    - intros * tyA tyx.
+      pose proof tyA as ?%bn_alg_typing_sound.
+      pose proof tyx as ?%bn_typing_sound.
+      destruct tyA, tyx.
+      do 3 (econstructor; tea); now eapply algo_conv_complete.
+    - intros * tyA tyx tyP tyhr tyy tye.
+      pose proof tyA as ?%bn_alg_typing_sound.
+      pose proof tyx as ?%bn_typing_sound.
+      pose proof tyP as ?%bn_alg_typing_sound.
+      pose proof tyhr as ?%bn_typing_sound.
+      pose proof tyy as ?%bn_typing_sound.
+      pose proof tye as ?%bn_typing_sound.
+      destruct tyA, tyx, tyP, tyhr, tyy, tye.
+      econstructor; tea.
+      + econstructor; tea; econstructor; tea.
+        all: now eapply algo_conv_complete.
+      + econstructor; eapply typing_subst2; tea.
+        cbn; now rewrite 2!wk1_ren_on, 2!shift_subst_eq.
     - intros_bn.
       1: eassumption.
       etransitivity ; tea.
@@ -353,6 +317,44 @@ Module AlgorithmicTypingProperties.
       2: now symmetry.
       eapply TermRefl; eapply wfTermConv; refold; [|now symmetry].
       econstructor; now eapply inf_conv_decl.
+    - intros * tyA tyx tyP tyhr tyy tyA' tyz convA convxy convxz.
+      pose proof tyA as ?%bn_alg_typing_sound.
+      pose proof tyx as ?%bn_typing_sound.
+      pose proof tyP as ?%bn_alg_typing_sound.
+      pose proof tyhr as ?%bn_typing_sound.
+      pose proof tyy as ?%bn_typing_sound.
+      pose proof convA as ?%bn_conv_sound.
+      pose proof convxy as ?%bn_conv_sound.
+      pose proof convxz as ?%bn_conv_sound.
+      destruct tyA, tyx, tyP, tyhr, tyy, tyA', tyz, convA, convxy, convxz.
+      econstructor; tea.
+      2: eapply redalg_one_step; constructor.
+      assert [Γ |-[ de ] tId A' z z ≅ tId A x y].
+      1:{
+        econstructor; symmetry; tea.
+        1,2: econstructor; tea.
+        etransitivity; tea; now symmetry.
+      }
+      econstructor; tea.
+      + econstructor; tea; econstructor; tea.
+        4: econstructor; tea; econstructor; tea.
+        all: eapply algo_conv_complete; tea.
+        now etransitivity.
+      + econstructor; eapply typing_subst2; tea.
+        cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq.
+        econstructor; [econstructor; tea|tea].
+        now econstructor.
+    - intros * tyA tyx tyP tyhr tyy [? tye].
+      pose proof tyP as ?%bn_alg_typing_sound.
+      pose proof tyy as ?%bn_typing_sound.
+      pose proof tye as ?%bn_typing_sound.
+      revert tyA tyx tyP tyhr tyy tye; intros_bn.
+      2: now eapply redalg_idElim.
+      econstructor; tea.
+      + econstructor; tea; econstructor; tea.
+        all: now eapply algo_conv_complete.
+      + econstructor; eapply typing_subst2; tea.
+        cbn; now rewrite 2!wk1_ren_on, 2!shift_subst_eq.
     - intros_bn.
       eapply algo_conv_sound in bun_conv_ty ; tea.
       econstructor ; tea.

--- a/theories/AutoSubst/Ast.v
+++ b/theories/AutoSubst/Ast.v
@@ -20,7 +20,10 @@ Inductive term : Type :=
   | tSig : term -> term -> term
   | tPair : term -> term -> term -> term -> term
   | tFst : term -> term
-  | tSnd : term -> term.
+  | tSnd : term -> term
+  | tId : term -> term -> term -> term
+  | tRefl : term -> term -> term
+  | tIdElim : term -> term -> term -> term -> term -> term -> term.
 
 Lemma congr_tSort {s0 : sort} {t0 : sort} (H0 : s0 = t0) :
   tSort s0 = tSort t0.
@@ -120,6 +123,42 @@ Proof.
 exact (eq_trans eq_refl (ap (fun x => tSnd x) H0)).
 Qed.
 
+Lemma congr_tId {s0 : term} {s1 : term} {s2 : term} {t0 : term} {t1 : term}
+  {t2 : term} (H0 : s0 = t0) (H1 : s1 = t1) (H2 : s2 = t2) :
+  tId s0 s1 s2 = tId t0 t1 t2.
+Proof.
+exact (eq_trans
+         (eq_trans (eq_trans eq_refl (ap (fun x => tId x s1 s2) H0))
+            (ap (fun x => tId t0 x s2) H1)) (ap (fun x => tId t0 t1 x) H2)).
+Qed.
+
+Lemma congr_tRefl {s0 : term} {s1 : term} {t0 : term} {t1 : term}
+  (H0 : s0 = t0) (H1 : s1 = t1) : tRefl s0 s1 = tRefl t0 t1.
+Proof.
+exact (eq_trans (eq_trans eq_refl (ap (fun x => tRefl x s1) H0))
+         (ap (fun x => tRefl t0 x) H1)).
+Qed.
+
+Lemma congr_tIdElim {s0 : term} {s1 : term} {s2 : term} {s3 : term}
+  {s4 : term} {s5 : term} {t0 : term} {t1 : term} {t2 : term} {t3 : term}
+  {t4 : term} {t5 : term} (H0 : s0 = t0) (H1 : s1 = t1) (H2 : s2 = t2)
+  (H3 : s3 = t3) (H4 : s4 = t4) (H5 : s5 = t5) :
+  tIdElim s0 s1 s2 s3 s4 s5 = tIdElim t0 t1 t2 t3 t4 t5.
+Proof.
+exact (eq_trans
+         (eq_trans
+            (eq_trans
+               (eq_trans
+                  (eq_trans
+                     (eq_trans eq_refl
+                        (ap (fun x => tIdElim x s1 s2 s3 s4 s5) H0))
+                     (ap (fun x => tIdElim t0 x s2 s3 s4 s5) H1))
+                  (ap (fun x => tIdElim t0 t1 x s3 s4 s5) H2))
+               (ap (fun x => tIdElim t0 t1 t2 x s4 s5) H3))
+            (ap (fun x => tIdElim t0 t1 t2 t3 x s5) H4))
+         (ap (fun x => tIdElim t0 t1 t2 t3 t4 x) H5)).
+Qed.
+
 Lemma upRen_term_term (xi : nat -> nat) : nat -> nat.
 Proof.
 exact (up_ren xi).
@@ -151,6 +190,13 @@ Fixpoint ren_term (xi_term : nat -> nat) (s : term) {struct s} : term :=
         (ren_term xi_term s2) (ren_term xi_term s3)
   | tFst s0 => tFst (ren_term xi_term s0)
   | tSnd s0 => tSnd (ren_term xi_term s0)
+  | tId s0 s1 s2 =>
+      tId (ren_term xi_term s0) (ren_term xi_term s1) (ren_term xi_term s2)
+  | tRefl s0 s1 => tRefl (ren_term xi_term s0) (ren_term xi_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      tIdElim (ren_term xi_term s0) (ren_term xi_term s1)
+        (ren_term (upRen_term_term (upRen_term_term xi_term)) s2)
+        (ren_term xi_term s3) (ren_term xi_term s4) (ren_term xi_term s5)
   end.
 
 Lemma up_term_term (sigma : nat -> term) : nat -> term.
@@ -190,6 +236,16 @@ term :=
         (subst_term sigma_term s3)
   | tFst s0 => tFst (subst_term sigma_term s0)
   | tSnd s0 => tSnd (subst_term sigma_term s0)
+  | tId s0 s1 s2 =>
+      tId (subst_term sigma_term s0) (subst_term sigma_term s1)
+        (subst_term sigma_term s2)
+  | tRefl s0 s1 =>
+      tRefl (subst_term sigma_term s0) (subst_term sigma_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      tIdElim (subst_term sigma_term s0) (subst_term sigma_term s1)
+        (subst_term (up_term_term (up_term_term sigma_term)) s2)
+        (subst_term sigma_term s3) (subst_term sigma_term s4)
+        (subst_term sigma_term s5)
   end.
 
 Lemma upId_term_term (sigma : nat -> term) (Eq : forall x, sigma x = tRel x)
@@ -241,6 +297,21 @@ subst_term sigma_term s = s :=
         (idSubst_term sigma_term Eq_term s3)
   | tFst s0 => congr_tFst (idSubst_term sigma_term Eq_term s0)
   | tSnd s0 => congr_tSnd (idSubst_term sigma_term Eq_term s0)
+  | tId s0 s1 s2 =>
+      congr_tId (idSubst_term sigma_term Eq_term s0)
+        (idSubst_term sigma_term Eq_term s1)
+        (idSubst_term sigma_term Eq_term s2)
+  | tRefl s0 s1 =>
+      congr_tRefl (idSubst_term sigma_term Eq_term s0)
+        (idSubst_term sigma_term Eq_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      congr_tIdElim (idSubst_term sigma_term Eq_term s0)
+        (idSubst_term sigma_term Eq_term s1)
+        (idSubst_term (up_term_term (up_term_term sigma_term))
+           (upId_term_term _ (upId_term_term _ Eq_term)) s2)
+        (idSubst_term sigma_term Eq_term s3)
+        (idSubst_term sigma_term Eq_term s4)
+        (idSubst_term sigma_term Eq_term s5)
   end.
 
 Lemma upExtRen_term_term (xi : nat -> nat) (zeta : nat -> nat)
@@ -298,6 +369,22 @@ ren_term xi_term s = ren_term zeta_term s :=
         (extRen_term xi_term zeta_term Eq_term s3)
   | tFst s0 => congr_tFst (extRen_term xi_term zeta_term Eq_term s0)
   | tSnd s0 => congr_tSnd (extRen_term xi_term zeta_term Eq_term s0)
+  | tId s0 s1 s2 =>
+      congr_tId (extRen_term xi_term zeta_term Eq_term s0)
+        (extRen_term xi_term zeta_term Eq_term s1)
+        (extRen_term xi_term zeta_term Eq_term s2)
+  | tRefl s0 s1 =>
+      congr_tRefl (extRen_term xi_term zeta_term Eq_term s0)
+        (extRen_term xi_term zeta_term Eq_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      congr_tIdElim (extRen_term xi_term zeta_term Eq_term s0)
+        (extRen_term xi_term zeta_term Eq_term s1)
+        (extRen_term (upRen_term_term (upRen_term_term xi_term))
+           (upRen_term_term (upRen_term_term zeta_term))
+           (upExtRen_term_term _ _ (upExtRen_term_term _ _ Eq_term)) s2)
+        (extRen_term xi_term zeta_term Eq_term s3)
+        (extRen_term xi_term zeta_term Eq_term s4)
+        (extRen_term xi_term zeta_term Eq_term s5)
   end.
 
 Lemma upExt_term_term (sigma : nat -> term) (tau : nat -> term)
@@ -356,6 +443,22 @@ subst_term sigma_term s = subst_term tau_term s :=
         (ext_term sigma_term tau_term Eq_term s3)
   | tFst s0 => congr_tFst (ext_term sigma_term tau_term Eq_term s0)
   | tSnd s0 => congr_tSnd (ext_term sigma_term tau_term Eq_term s0)
+  | tId s0 s1 s2 =>
+      congr_tId (ext_term sigma_term tau_term Eq_term s0)
+        (ext_term sigma_term tau_term Eq_term s1)
+        (ext_term sigma_term tau_term Eq_term s2)
+  | tRefl s0 s1 =>
+      congr_tRefl (ext_term sigma_term tau_term Eq_term s0)
+        (ext_term sigma_term tau_term Eq_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      congr_tIdElim (ext_term sigma_term tau_term Eq_term s0)
+        (ext_term sigma_term tau_term Eq_term s1)
+        (ext_term (up_term_term (up_term_term sigma_term))
+           (up_term_term (up_term_term tau_term))
+           (upExt_term_term _ _ (upExt_term_term _ _ Eq_term)) s2)
+        (ext_term sigma_term tau_term Eq_term s3)
+        (ext_term sigma_term tau_term Eq_term s4)
+        (ext_term sigma_term tau_term Eq_term s5)
   end.
 
 Lemma up_ren_ren_term_term (xi : nat -> nat) (zeta : nat -> nat)
@@ -422,6 +525,23 @@ Fixpoint compRenRen_term (xi_term : nat -> nat) (zeta_term : nat -> nat)
       congr_tFst (compRenRen_term xi_term zeta_term rho_term Eq_term s0)
   | tSnd s0 =>
       congr_tSnd (compRenRen_term xi_term zeta_term rho_term Eq_term s0)
+  | tId s0 s1 s2 =>
+      congr_tId (compRenRen_term xi_term zeta_term rho_term Eq_term s0)
+        (compRenRen_term xi_term zeta_term rho_term Eq_term s1)
+        (compRenRen_term xi_term zeta_term rho_term Eq_term s2)
+  | tRefl s0 s1 =>
+      congr_tRefl (compRenRen_term xi_term zeta_term rho_term Eq_term s0)
+        (compRenRen_term xi_term zeta_term rho_term Eq_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      congr_tIdElim (compRenRen_term xi_term zeta_term rho_term Eq_term s0)
+        (compRenRen_term xi_term zeta_term rho_term Eq_term s1)
+        (compRenRen_term (upRen_term_term (upRen_term_term xi_term))
+           (upRen_term_term (upRen_term_term zeta_term))
+           (upRen_term_term (upRen_term_term rho_term))
+           (up_ren_ren _ _ _ (up_ren_ren _ _ _ Eq_term)) s2)
+        (compRenRen_term xi_term zeta_term rho_term Eq_term s3)
+        (compRenRen_term xi_term zeta_term rho_term Eq_term s4)
+        (compRenRen_term xi_term zeta_term rho_term Eq_term s5)
   end.
 
 Lemma up_ren_subst_term_term (xi : nat -> nat) (tau : nat -> term)
@@ -490,6 +610,25 @@ subst_term tau_term (ren_term xi_term s) = subst_term theta_term s :=
       congr_tFst (compRenSubst_term xi_term tau_term theta_term Eq_term s0)
   | tSnd s0 =>
       congr_tSnd (compRenSubst_term xi_term tau_term theta_term Eq_term s0)
+  | tId s0 s1 s2 =>
+      congr_tId (compRenSubst_term xi_term tau_term theta_term Eq_term s0)
+        (compRenSubst_term xi_term tau_term theta_term Eq_term s1)
+        (compRenSubst_term xi_term tau_term theta_term Eq_term s2)
+  | tRefl s0 s1 =>
+      congr_tRefl (compRenSubst_term xi_term tau_term theta_term Eq_term s0)
+        (compRenSubst_term xi_term tau_term theta_term Eq_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      congr_tIdElim
+        (compRenSubst_term xi_term tau_term theta_term Eq_term s0)
+        (compRenSubst_term xi_term tau_term theta_term Eq_term s1)
+        (compRenSubst_term (upRen_term_term (upRen_term_term xi_term))
+           (up_term_term (up_term_term tau_term))
+           (up_term_term (up_term_term theta_term))
+           (up_ren_subst_term_term _ _ _
+              (up_ren_subst_term_term _ _ _ Eq_term)) s2)
+        (compRenSubst_term xi_term tau_term theta_term Eq_term s3)
+        (compRenSubst_term xi_term tau_term theta_term Eq_term s4)
+        (compRenSubst_term xi_term tau_term theta_term Eq_term s5)
   end.
 
 Lemma up_subst_ren_term_term (sigma : nat -> term) (zeta_term : nat -> nat)
@@ -578,6 +717,27 @@ ren_term zeta_term (subst_term sigma_term s) = subst_term theta_term s :=
   | tSnd s0 =>
       congr_tSnd
         (compSubstRen_term sigma_term zeta_term theta_term Eq_term s0)
+  | tId s0 s1 s2 =>
+      congr_tId
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s0)
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s1)
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s2)
+  | tRefl s0 s1 =>
+      congr_tRefl
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s0)
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      congr_tIdElim
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s0)
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s1)
+        (compSubstRen_term (up_term_term (up_term_term sigma_term))
+           (upRen_term_term (upRen_term_term zeta_term))
+           (up_term_term (up_term_term theta_term))
+           (up_subst_ren_term_term _ _ _
+              (up_subst_ren_term_term _ _ _ Eq_term)) s2)
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s3)
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s4)
+        (compSubstRen_term sigma_term zeta_term theta_term Eq_term s5)
   end.
 
 Lemma up_subst_subst_term_term (sigma : nat -> term) (tau_term : nat -> term)
@@ -668,6 +828,27 @@ subst_term tau_term (subst_term sigma_term s) = subst_term theta_term s :=
   | tSnd s0 =>
       congr_tSnd
         (compSubstSubst_term sigma_term tau_term theta_term Eq_term s0)
+  | tId s0 s1 s2 =>
+      congr_tId
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s0)
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s1)
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s2)
+  | tRefl s0 s1 =>
+      congr_tRefl
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s0)
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      congr_tIdElim
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s0)
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s1)
+        (compSubstSubst_term (up_term_term (up_term_term sigma_term))
+           (up_term_term (up_term_term tau_term))
+           (up_term_term (up_term_term theta_term))
+           (up_subst_subst_term_term _ _ _
+              (up_subst_subst_term_term _ _ _ Eq_term)) s2)
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s3)
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s4)
+        (compSubstSubst_term sigma_term tau_term theta_term Eq_term s5)
   end.
 
 Lemma renRen_term (xi_term : nat -> nat) (zeta_term : nat -> nat) (s : term)
@@ -793,6 +974,22 @@ Fixpoint rinst_inst_term (xi_term : nat -> nat) (sigma_term : nat -> term)
         (rinst_inst_term xi_term sigma_term Eq_term s3)
   | tFst s0 => congr_tFst (rinst_inst_term xi_term sigma_term Eq_term s0)
   | tSnd s0 => congr_tSnd (rinst_inst_term xi_term sigma_term Eq_term s0)
+  | tId s0 s1 s2 =>
+      congr_tId (rinst_inst_term xi_term sigma_term Eq_term s0)
+        (rinst_inst_term xi_term sigma_term Eq_term s1)
+        (rinst_inst_term xi_term sigma_term Eq_term s2)
+  | tRefl s0 s1 =>
+      congr_tRefl (rinst_inst_term xi_term sigma_term Eq_term s0)
+        (rinst_inst_term xi_term sigma_term Eq_term s1)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      congr_tIdElim (rinst_inst_term xi_term sigma_term Eq_term s0)
+        (rinst_inst_term xi_term sigma_term Eq_term s1)
+        (rinst_inst_term (upRen_term_term (upRen_term_term xi_term))
+           (up_term_term (up_term_term sigma_term))
+           (rinstInst_up_term_term _ _ (rinstInst_up_term_term _ _ Eq_term))
+           s2) (rinst_inst_term xi_term sigma_term Eq_term s3)
+        (rinst_inst_term xi_term sigma_term Eq_term s4)
+        (rinst_inst_term xi_term sigma_term Eq_term s5)
   end.
 
 Lemma rinstInst'_term (xi_term : nat -> nat) (s : term) :
@@ -1015,6 +1212,19 @@ Fixpoint allfv_term (p_term : nat -> Prop) (s : term) {struct s} : Prop :=
            (and (allfv_term p_term s2) (and (allfv_term p_term s3) True)))
   | tFst s0 => and (allfv_term p_term s0) True
   | tSnd s0 => and (allfv_term p_term s0) True
+  | tId s0 s1 s2 =>
+      and (allfv_term p_term s0)
+        (and (allfv_term p_term s1) (and (allfv_term p_term s2) True))
+  | tRefl s0 s1 =>
+      and (allfv_term p_term s0) (and (allfv_term p_term s1) True)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      and (allfv_term p_term s0)
+        (and (allfv_term p_term s1)
+           (and
+              (allfv_term (upAllfv_term_term (upAllfv_term_term p_term)) s2)
+              (and (allfv_term p_term s3)
+                 (and (allfv_term p_term s4)
+                    (and (allfv_term p_term s5) True)))))
   end.
 
 Lemma upAllfvTriv_term_term {p : nat -> Prop} (H : forall x, p x) :
@@ -1074,6 +1284,22 @@ Fixpoint allfvTriv_term (p_term : nat -> Prop) (H_term : forall x, p_term x)
               (conj (allfvTriv_term p_term H_term s3) I)))
   | tFst s0 => conj (allfvTriv_term p_term H_term s0) I
   | tSnd s0 => conj (allfvTriv_term p_term H_term s0) I
+  | tId s0 s1 s2 =>
+      conj (allfvTriv_term p_term H_term s0)
+        (conj (allfvTriv_term p_term H_term s1)
+           (conj (allfvTriv_term p_term H_term s2) I))
+  | tRefl s0 s1 =>
+      conj (allfvTriv_term p_term H_term s0)
+        (conj (allfvTriv_term p_term H_term s1) I)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      conj (allfvTriv_term p_term H_term s0)
+        (conj (allfvTriv_term p_term H_term s1)
+           (conj
+              (allfvTriv_term (upAllfv_term_term (upAllfv_term_term p_term))
+                 (upAllfvTriv_term_term (upAllfvTriv_term_term H_term)) s2)
+              (conj (allfvTriv_term p_term H_term s3)
+                 (conj (allfvTriv_term p_term H_term s4)
+                    (conj (allfvTriv_term p_term H_term s5) I)))))
   end.
 
 Lemma upAllfvImpl_term_term {p : nat -> Prop} {q : nat -> Prop}
@@ -1268,6 +1494,121 @@ allfv_term p_term s -> allfv_term q_term s :=
            match HP with
            | conj HP _ => HP
            end) I
+  | tId s0 s1 s2 =>
+      fun HP =>
+      conj
+        (allfvImpl_term p_term q_term H_term s0
+           match HP with
+           | conj HP _ => HP
+           end)
+        (conj
+           (allfvImpl_term p_term q_term H_term s1
+              match HP with
+              | conj _ HP => match HP with
+                             | conj HP _ => HP
+                             end
+              end)
+           (conj
+              (allfvImpl_term p_term q_term H_term s2
+                 match HP with
+                 | conj _ HP =>
+                     match HP with
+                     | conj _ HP => match HP with
+                                    | conj HP _ => HP
+                                    end
+                     end
+                 end) I))
+  | tRefl s0 s1 =>
+      fun HP =>
+      conj
+        (allfvImpl_term p_term q_term H_term s0
+           match HP with
+           | conj HP _ => HP
+           end)
+        (conj
+           (allfvImpl_term p_term q_term H_term s1
+              match HP with
+              | conj _ HP => match HP with
+                             | conj HP _ => HP
+                             end
+              end) I)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      fun HP =>
+      conj
+        (allfvImpl_term p_term q_term H_term s0
+           match HP with
+           | conj HP _ => HP
+           end)
+        (conj
+           (allfvImpl_term p_term q_term H_term s1
+              match HP with
+              | conj _ HP => match HP with
+                             | conj HP _ => HP
+                             end
+              end)
+           (conj
+              (allfvImpl_term (upAllfv_term_term (upAllfv_term_term p_term))
+                 (upAllfv_term_term (upAllfv_term_term q_term))
+                 (upAllfvImpl_term_term (upAllfvImpl_term_term H_term)) s2
+                 match HP with
+                 | conj _ HP =>
+                     match HP with
+                     | conj _ HP => match HP with
+                                    | conj HP _ => HP
+                                    end
+                     end
+                 end)
+              (conj
+                 (allfvImpl_term p_term q_term H_term s3
+                    match HP with
+                    | conj _ HP =>
+                        match HP with
+                        | conj _ HP =>
+                            match HP with
+                            | conj _ HP =>
+                                match HP with
+                                | conj HP _ => HP
+                                end
+                            end
+                        end
+                    end)
+                 (conj
+                    (allfvImpl_term p_term q_term H_term s4
+                       match HP with
+                       | conj _ HP =>
+                           match HP with
+                           | conj _ HP =>
+                               match HP with
+                               | conj _ HP =>
+                                   match HP with
+                                   | conj _ HP =>
+                                       match HP with
+                                       | conj HP _ => HP
+                                       end
+                                   end
+                               end
+                           end
+                       end)
+                    (conj
+                       (allfvImpl_term p_term q_term H_term s5
+                          match HP with
+                          | conj _ HP =>
+                              match HP with
+                              | conj _ HP =>
+                                  match HP with
+                                  | conj _ HP =>
+                                      match HP with
+                                      | conj _ HP =>
+                                          match HP with
+                                          | conj _ HP =>
+                                              match HP with
+                                              | conj HP _ => HP
+                                              end
+                                          end
+                                      end
+                                  end
+                              end
+                          end) I)))))
   end.
 
 Lemma upAllfvRenL_term_term (p : nat -> Prop) (xi : nat -> nat) :
@@ -1281,11 +1622,23 @@ exact (fun x => match x with
                 end).
 Qed.
 
+Lemma upAllfvRenL_term_term2 (p : nat -> Prop) (xi : nat -> nat) :
+  forall x,
+      upAllfv_term_term (upAllfv_term_term p) (upRen_term_term (upRen_term_term xi) x) ->
+      upAllfv_term_term (upAllfv_term_term (funcomp p xi)) x.
+Proof.
+   intros x.
+   refine (match x with S n' => fun H => upAllfvRenL_term_term p xi _ H | 0 => fun i => i end).
+Qed.
+
+
 Fixpoint allfvRenL_term (p_term : nat -> Prop) (xi_term : nat -> nat)
 (s : term) {struct s} :
 allfv_term p_term (ren_term xi_term s) ->
 allfv_term (funcomp p_term xi_term) s :=
-  match s with
+  match s as s return 
+      allfv_term p_term (ren_term xi_term s) ->
+      allfv_term (funcomp p_term xi_term) s  with
   | tRel s0 => fun H => H
   | tSort s0 => fun H => conj I I
   | tProd s0 s1 =>
@@ -1458,6 +1811,118 @@ allfv_term (funcomp p_term xi_term) s :=
         (allfvRenL_term p_term xi_term s0 match H with
                                           | conj H _ => H
                                           end) I
+  | tId s0 s1 s2 =>
+      fun H =>
+      conj
+        (allfvRenL_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
+        (conj
+           (allfvRenL_term p_term xi_term s1
+              match H with
+              | conj _ H => match H with
+                            | conj H _ => H
+                            end
+              end)
+           (conj
+              (allfvRenL_term p_term xi_term s2
+                 match H with
+                 | conj _ H =>
+                     match H with
+                     | conj _ H => match H with
+                                   | conj H _ => H
+                                   end
+                     end
+                 end) I))
+  | tRefl s0 s1 =>
+      fun H =>
+      conj
+        (allfvRenL_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
+        (conj
+           (allfvRenL_term p_term xi_term s1
+              match H with
+              | conj _ H => match H with
+                            | conj H _ => H
+                            end
+              end) I)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      fun H =>
+      conj
+        (allfvRenL_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
+        (conj
+           (allfvRenL_term p_term xi_term s1
+              match H with
+              | conj _ H => match H with
+                            | conj H _ => H
+                            end
+              end)
+           (conj
+              (allfvImpl_term _ _ (upAllfvRenL_term_term2 p_term xi_term) s2
+                 (allfvRenL_term
+                    (upAllfv_term_term (upAllfv_term_term p_term))
+                    (upRen_term_term (upRen_term_term xi_term)) s2
+                    match H with
+                    | conj _ H =>
+                        match H with
+                        | conj _ H => match H with
+                                      | conj H _ => H
+                                      end
+                        end
+                    end))
+              (conj
+                 (allfvRenL_term p_term xi_term s3
+                    match H with
+                    | conj _ H =>
+                        match H with
+                        | conj _ H =>
+                            match H with
+                            | conj _ H => match H with
+                                          | conj H _ => H
+                                          end
+                            end
+                        end
+                    end)
+                 (conj
+                    (allfvRenL_term p_term xi_term s4
+                       match H with
+                       | conj _ H =>
+                           match H with
+                           | conj _ H =>
+                               match H with
+                               | conj _ H =>
+                                   match H with
+                                   | conj _ H =>
+                                       match H with
+                                       | conj H _ => H
+                                       end
+                                   end
+                               end
+                           end
+                       end)
+                    (conj
+                       (allfvRenL_term p_term xi_term s5
+                          match H with
+                          | conj _ H =>
+                              match H with
+                              | conj _ H =>
+                                  match H with
+                                  | conj _ H =>
+                                      match H with
+                                      | conj _ H =>
+                                          match H with
+                                          | conj _ H =>
+                                              match H with
+                                              | conj H _ => H
+                                              end
+                                          end
+                                      end
+                                  end
+                              end
+                          end) I)))))
   end.
 
 Lemma upAllfvRenR_term_term (p : nat -> Prop) (xi : nat -> nat) :
@@ -1471,11 +1936,27 @@ exact (fun x => match x with
                 end).
 Qed.
 
+Lemma upAllfvRenR_term_term2 (p : nat -> Prop) (xi : nat -> nat) :
+  forall x,
+   upAllfv_term_term (upAllfv_term_term (funcomp p xi)) x ->
+   upAllfv_term_term (upAllfv_term_term p) (upRen_term_term (upRen_term_term xi) x).
+Proof.
+exact (fun x => match x with
+                | S n' => fun H => upAllfvRenR_term_term p xi _ H
+                | O => fun i => i
+                end).
+Qed.
+
+
 Fixpoint allfvRenR_term (p_term : nat -> Prop) (xi_term : nat -> nat)
 (s : term) {struct s} :
 allfv_term (funcomp p_term xi_term) s ->
 allfv_term p_term (ren_term xi_term s) :=
-  match s with
+  match s 
+   return 
+allfv_term (funcomp p_term xi_term) s ->
+allfv_term p_term (ren_term xi_term s)
+  with
   | tRel s0 => fun H => H
   | tSort s0 => fun H => conj I I
   | tProd s0 s1 =>
@@ -1650,6 +2131,118 @@ allfv_term p_term (ren_term xi_term s) :=
         (allfvRenR_term p_term xi_term s0 match H with
                                           | conj H _ => H
                                           end) I
+  | tId s0 s1 s2 =>
+      fun H =>
+      conj
+        (allfvRenR_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
+        (conj
+           (allfvRenR_term p_term xi_term s1
+              match H with
+              | conj _ H => match H with
+                            | conj H _ => H
+                            end
+              end)
+           (conj
+              (allfvRenR_term p_term xi_term s2
+                 match H with
+                 | conj _ H =>
+                     match H with
+                     | conj _ H => match H with
+                                   | conj H _ => H
+                                   end
+                     end
+                 end) I))
+  | tRefl s0 s1 =>
+      fun H =>
+      conj
+        (allfvRenR_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
+        (conj
+           (allfvRenR_term p_term xi_term s1
+              match H with
+              | conj _ H => match H with
+                            | conj H _ => H
+                            end
+              end) I)
+  | tIdElim s0 s1 s2 s3 s4 s5 =>
+      fun H =>
+      conj
+        (allfvRenR_term p_term xi_term s0 match H with
+                                          | conj H _ => H
+                                          end)
+        (conj
+           (allfvRenR_term p_term xi_term s1
+              match H with
+              | conj _ H => match H with
+                            | conj H _ => H
+                            end
+              end)
+           (conj
+              (allfvRenR_term (upAllfv_term_term (upAllfv_term_term p_term))
+                 (upRen_term_term (upRen_term_term xi_term)) s2
+                 (allfvImpl_term _ _ (upAllfvRenR_term_term2 p_term xi_term)
+                    s2
+                    match H with
+                    | conj _ H =>
+                        match H with
+                        | conj _ H => match H with
+                                      | conj H _ => H
+                                      end
+                        end
+                    end))
+              (conj
+                 (allfvRenR_term p_term xi_term s3
+                    match H with
+                    | conj _ H =>
+                        match H with
+                        | conj _ H =>
+                            match H with
+                            | conj _ H => match H with
+                                          | conj H _ => H
+                                          end
+                            end
+                        end
+                    end)
+                 (conj
+                    (allfvRenR_term p_term xi_term s4
+                       match H with
+                       | conj _ H =>
+                           match H with
+                           | conj _ H =>
+                               match H with
+                               | conj _ H =>
+                                   match H with
+                                   | conj _ H =>
+                                       match H with
+                                       | conj H _ => H
+                                       end
+                                   end
+                               end
+                           end
+                       end)
+                    (conj
+                       (allfvRenR_term p_term xi_term s5
+                          match H with
+                          | conj _ H =>
+                              match H with
+                              | conj _ H =>
+                                  match H with
+                                  | conj _ H =>
+                                      match H with
+                                      | conj _ H =>
+                                          match H with
+                                          | conj _ H =>
+                                              match H with
+                                              | conj H _ => H
+                                              end
+                                          end
+                                      end
+                                  end
+                              end
+                          end) I)))))
   end.
 
 End Allfv.

--- a/theories/AutoSubst/Extra.v
+++ b/theories/AutoSubst/Extra.v
@@ -89,4 +89,3 @@ Proof. now asimpl. Qed.
 
 Definition elimSuccHypTy P :=
   tProd tNat (arr P P[tSucc (tRel 0)]⇑).
-

--- a/theories/AutoSubst/PiUniv.sig
+++ b/theories/AutoSubst/PiUniv.sig
@@ -19,3 +19,7 @@ tSig : term -> (bind term in term) -> term
 tPair : term -> (bind term in term) -> term -> term -> term
 tFst : term -> term
 tSnd : term -> term
+
+tId : term -> term -> term -> term
+tRefl : term -> term -> term
+tIdElim : term -> term -> (bind term , term in term) -> term -> term -> term -> term

--- a/theories/BundledAlgorithmicTyping.v
+++ b/theories/BundledAlgorithmicTyping.v
@@ -967,7 +967,6 @@ Section BundledTyping.
       split;[eauto|now econstructor].
     - intros * ? ihA ? ihx ? ihy ?.
       edestruct ihA as []; tea.
-      1: now constructor.
       assert [Γ |-[de] A] by now econstructor.
       split; [eauto|].
       econstructor; tea; [now eapply ihx | now eapply ihy].

--- a/theories/Decidability/Completeness.v
+++ b/theories/Decidability/Completeness.v
@@ -629,7 +629,7 @@ Proof.
   all: unfold graph in *.
   all: simp typing typing_inf typing_wf_ty typing_inf_red typing_check ; cbn.
   (* Well formed types *)
-  1-5:repeat match goal with | |- orec_graph typing _ _ => econstructor ; try eauto ; cbn end.
+  1-5:repeat match goal with | |- orec_graph typing _ _ => patch_rec_ret ; econstructor ; try eauto ; cbn end.
   - cbn in *.
     econstructor.
     1: exact (g1 tt).

--- a/theories/Decidability/Functions.v
+++ b/theories/Decidability/Functions.v
@@ -169,20 +169,20 @@ Arguments rec {_ _ _ _ _ _}.
 Equations wh_red_stack : term × stack ⇀[empty_store] term :=
   wh_red_stack (t,π) with (build_tm_view1 t) :=
   wh_red_stack (?(tRel n)       ,π)                           (tm_view1_rel n) := ret (zip (tRel n) π) ;
-  wh_red_stack (?(zip1 t s)     ,π)                           (tm_view1_dest t s) := id <*> rec (t,cons s π) ;
+  wh_red_stack (?(zip1 t s)     ,π)                           (tm_view1_dest t s) := rec (t,cons s π) ;
   wh_red_stack (?(tLambda A t)  ,nil)                         (tm_view1_fun A t) := ret (tLambda A t) ;
-  wh_red_stack (?(tLambda A t)  ,cons (eApp u) π)             (tm_view1_fun A t) := id <*> rec (t[u..], π) ;
+  wh_red_stack (?(tLambda A t)  ,cons (eApp u) π)             (tm_view1_fun A t) := rec (t[u..], π) ;
   wh_red_stack (_               ,cons _ _)                    (tm_view1_fun _ _) := undefined ;
   wh_red_stack (t               ,nil)                         (tm_view1_nat _) := ret t ;
-  wh_red_stack (?(tZero)        ,cons (eNatElim _ hz _) π)    (tm_view1_nat eZero) := id <*> rec (hz,π) ;
-  wh_red_stack (?(tSucc t)      ,cons (eNatElim P hz hs) π)   (tm_view1_nat (eSucc t)) := id <*> rec (hs ,cons (eApp t) (cons (eApp (tNatElim P hz hs t)) π)) ;
+  wh_red_stack (?(tZero)        ,cons (eNatElim _ hz _) π)    (tm_view1_nat eZero) := rec (hz,π) ;
+  wh_red_stack (?(tSucc t)      ,cons (eNatElim P hz hs) π)   (tm_view1_nat (eSucc t)) := rec (hs ,cons (eApp t) (cons (eApp (tNatElim P hz hs t)) π)) ;
   wh_red_stack (t               ,cons _ _)                    (tm_view1_nat _) := undefined ;
   wh_red_stack (?(tPair A B a b),nil)                         (tm_view1_sig A B a b) := ret (tPair A B a b) ;
-  wh_red_stack (?(tPair A B a b),cons eFst π)                 (tm_view1_sig A B a b) := id <*> rec (a , π) ;
-  wh_red_stack (?(tPair A B a b),cons eSnd π)                 (tm_view1_sig A B a b) := id <*> rec (b , π) ;
+  wh_red_stack (?(tPair A B a b),cons eFst π)                 (tm_view1_sig A B a b) := rec (a , π) ;
+  wh_red_stack (?(tPair A B a b),cons eSnd π)                 (tm_view1_sig A B a b) := rec (b , π) ;
   wh_red_stack (?(tPair A B a b),cons _ π)                    (tm_view1_sig A B a b) := undefined ;
   wh_red_stack (?(tRefl A x)    ,nil)                         (tm_view1_id A x) := ret (tRefl A x) ;
-  wh_red_stack (?(tRefl A x)    ,cons (eIdElim _ _ _ hr _) π) (tm_view1_id A x) := id <*> rec (hr, π) ;
+  wh_red_stack (?(tRefl A x)    ,cons (eIdElim _ _ _ hr _) π) (tm_view1_id A x) := rec (hr, π) ;
   wh_red_stack (_               ,cons _ _)                    (tm_view1_id _ _) := undefined ;
   wh_red_stack (t               ,nil)                         (tm_view1_type _) := ret t ;
   wh_red_stack (t               ,cons s _)                    (tm_view1_type _) := undefined.
@@ -631,12 +631,12 @@ Equations typing_wf_ty : typing_stmt wf_ty_state :=
     | ty_view1_ty (eSort s) := success ;
     | ty_view1_ty (eProd A B) :=
         rA ← rec (wf_ty_state;Γ;tt;A) ;;
-        id <*> rec (wf_ty_state;Γ,,A;tt;B) ;
+        rec (wf_ty_state;Γ,,A;tt;B) ;
     | ty_view1_ty (eNat) := success ;
     | ty_view1_ty (eEmpty) := success ;
     | ty_view1_ty (eSig A B) :=
         rA ← rec (wf_ty_state;Γ;tt;A) ;;
-        id <*> rec (wf_ty_state;Γ,,A;tt;B) ;
+        rec (wf_ty_state;Γ,,A;tt;B) ;
     | ty_view1_ty (eId A x y) :=
         rA ← rec (wf_ty_state;Γ;tt;A) ;;
         rec (check_state;Γ;A;x) ;;

--- a/theories/Decidability/Functions.v
+++ b/theories/Decidability/Functions.v
@@ -43,7 +43,8 @@ Variant ty_entry : term -> Type :=
   | eProd A B : ty_entry (tProd A B)
   | eNat : ty_entry tNat
   | eEmpty : ty_entry tEmpty
-  | eSig A B : ty_entry (tSig A B).
+  | eSig A B : ty_entry (tSig A B)
+  | eId A x y : ty_entry (tId A x y).
 
 Variant nat_entry : term -> Type :=
   | eZero : nat_entry tZero
@@ -54,7 +55,8 @@ Variant dest_entry : Type :=
   | eNatElim (P : term) (hs hz : term)
   | eApp (u : term)
   | eFst
-  | eSnd.
+  | eSnd
+  | eIdElim (A x P hr y : term).
 
 Definition zip1 (t : term) (e : dest_entry) : term :=
   match e with
@@ -63,6 +65,7 @@ Definition zip1 (t : term) (e : dest_entry) : term :=
     | eApp u => (tApp t u)
     | eFst => tFst t
     | eSnd => tSnd t
+    | eIdElim A x P hr y => tIdElim A x P hr y t
   end.
 
 Variant tm_view1 : term -> Type :=
@@ -71,6 +74,7 @@ Variant tm_view1 : term -> Type :=
   | tm_view1_rel n : tm_view1 (tRel n)
   | tm_view1_nat {t} : nat_entry t -> tm_view1 t
   | tm_view1_sig A B a b : tm_view1 (tPair A B a b)
+  | tm_view1_id A x : tm_view1 (tRefl A x)
   | tm_view1_dest t (s : dest_entry) : tm_view1 (zip1 t s).
 
 Definition build_tm_view1 t : tm_view1 t :=
@@ -90,6 +94,9 @@ Definition build_tm_view1 t : tm_view1 t :=
   | tPair A B a b => tm_view1_sig A B a b
   | tFst t => tm_view1_dest t eFst
   | tSnd t => tm_view1_dest t eSnd
+  | tId A x y => tm_view1_type (eId A x y)
+  | tRefl A x => tm_view1_id A x
+  | tIdElim A x P hr y e => tm_view1_dest e (eIdElim A x P hr y)
   end.
 
 Variant ne_view1 : term -> Type :=
@@ -101,6 +108,7 @@ Variant nf_view1 : term -> Type :=
   | nf_view1_fun A t : nf_view1 (tLambda A t)
   | nf_view1_nat {t} : nat_entry t -> nf_view1 t
   | nf_view1_sig A B a b : nf_view1 (tPair A B a b)
+  | nf_view1_id A x : nf_view1 (tRefl A x)
   | nf_view1_ne {t} : ne_view1 t -> nf_view1 t.
 
 Definition build_nf_view1 t : nf_view1 t :=
@@ -120,6 +128,9 @@ Definition build_nf_view1 t : nf_view1 t :=
   | tPair A B a b => nf_view1_sig A B a b
   | tFst t => nf_view1_ne (ne_view1_dest t eFst)
   | tSnd t => nf_view1_ne (ne_view1_dest t eSnd)
+  | tId A x y => nf_view1_type (eId A x y)
+  | tRefl A x => nf_view1_id A x
+  | tIdElim A x P hr y e => nf_view1_ne (ne_view1_dest e (eIdElim A x P hr y))
   end.
 
 Variant ty_view1 : term -> Type :=
@@ -132,7 +143,10 @@ Definition build_ty_view1 t : ty_view1 t :=
   | tm_view1_type e => ty_view1_ty e
   | tm_view1_rel n => ty_view1_small (ne_view1_rel n)
   | tm_view1_dest t s => ty_view1_small (ne_view1_dest t s)
-  | tm_view1_fun _ _ | tm_view1_nat _ | tm_view1_sig _ _ _ _ => ty_view1_anomaly
+  | tm_view1_fun _ _ 
+  | tm_view1_nat _ 
+  | tm_view1_sig _ _ _ _ 
+  | tm_view1_id _ _ => ty_view1_anomaly
   end.
 
 Definition stack := list dest_entry.
@@ -154,21 +168,24 @@ Arguments rec {_ _ _ _ _ _}.
 
 Equations wh_red_stack : term × stack ⇀[empty_store] term :=
   wh_red_stack (t,π) with (build_tm_view1 t) :=
-  wh_red_stack (?(tRel n)       ,π)                         (tm_view1_rel n) := ret (zip (tRel n) π) ;
-  wh_red_stack (?(zip1 t s)     ,π)                         (tm_view1_dest t s) := id <*> rec (t,cons s π) ;
-  wh_red_stack (?(tLambda A t)  ,nil)                       (tm_view1_fun A t) := ret (tLambda A t) ;
-  wh_red_stack (?(tLambda A t)  ,cons (eApp u) π)           (tm_view1_fun A t) := id <*> rec (t[u..], π) ;
-  wh_red_stack (_               ,cons _ _)                  (tm_view1_fun _ _) := undefined ;
-  wh_red_stack (t               ,nil)                       (tm_view1_nat _) := ret t ;
-  wh_red_stack (?(tZero)        ,cons (eNatElim _ hz _) π)  (tm_view1_nat eZero) := id <*> rec (hz,π) ;
-  wh_red_stack (?(tSucc t)      ,cons (eNatElim P hz hs) π) (tm_view1_nat (eSucc t)) := id <*> rec (hs ,cons (eApp t) (cons (eApp (tNatElim P hz hs t)) π)) ;
-  wh_red_stack (t               ,cons _ _)                  (tm_view1_nat _) := undefined ;
-  wh_red_stack (?(tPair A B a b),nil)                       (tm_view1_sig A B a b) := ret (tPair A B a b) ;
-  wh_red_stack (?(tPair A B a b),cons eFst π)               (tm_view1_sig A B a b) := id <*> rec (a , π) ;
-  wh_red_stack (?(tPair A B a b),cons eSnd π)               (tm_view1_sig A B a b) := id <*> rec (b , π) ;
-  wh_red_stack (?(tPair A B a b),cons _ π)                  (tm_view1_sig A B a b) := undefined ;
-  wh_red_stack (t               ,nil)                       (tm_view1_type _) := ret t ;
-  wh_red_stack (t               ,cons s _)                  (tm_view1_type _) := undefined.
+  wh_red_stack (?(tRel n)       ,π)                           (tm_view1_rel n) := ret (zip (tRel n) π) ;
+  wh_red_stack (?(zip1 t s)     ,π)                           (tm_view1_dest t s) := id <*> rec (t,cons s π) ;
+  wh_red_stack (?(tLambda A t)  ,nil)                         (tm_view1_fun A t) := ret (tLambda A t) ;
+  wh_red_stack (?(tLambda A t)  ,cons (eApp u) π)             (tm_view1_fun A t) := id <*> rec (t[u..], π) ;
+  wh_red_stack (_               ,cons _ _)                    (tm_view1_fun _ _) := undefined ;
+  wh_red_stack (t               ,nil)                         (tm_view1_nat _) := ret t ;
+  wh_red_stack (?(tZero)        ,cons (eNatElim _ hz _) π)    (tm_view1_nat eZero) := id <*> rec (hz,π) ;
+  wh_red_stack (?(tSucc t)      ,cons (eNatElim P hz hs) π)   (tm_view1_nat (eSucc t)) := id <*> rec (hs ,cons (eApp t) (cons (eApp (tNatElim P hz hs t)) π)) ;
+  wh_red_stack (t               ,cons _ _)                    (tm_view1_nat _) := undefined ;
+  wh_red_stack (?(tPair A B a b),nil)                         (tm_view1_sig A B a b) := ret (tPair A B a b) ;
+  wh_red_stack (?(tPair A B a b),cons eFst π)                 (tm_view1_sig A B a b) := id <*> rec (a , π) ;
+  wh_red_stack (?(tPair A B a b),cons eSnd π)                 (tm_view1_sig A B a b) := id <*> rec (b , π) ;
+  wh_red_stack (?(tPair A B a b),cons _ π)                    (tm_view1_sig A B a b) := undefined ;
+  wh_red_stack (?(tRefl A x)    ,nil)                         (tm_view1_id A x) := ret (tRefl A x) ;
+  wh_red_stack (?(tRefl A x)    ,cons (eIdElim _ _ _ hr _) π) (tm_view1_id A x) := id <*> rec (hr, π) ;
+  wh_red_stack (_               ,cons _ _)                    (tm_view1_id _ _) := undefined ;
+  wh_red_stack (t               ,nil)                         (tm_view1_type _) := ret t ;
+  wh_red_stack (t               ,cons s _)                    (tm_view1_type _) := undefined.
 
 Set Printing Universes.
 
@@ -197,6 +214,7 @@ Inductive nf_ty_view2 : term -> term -> Type :=
   | ty_nats : nf_ty_view2 tNat tNat
   | ty_emptys : nf_ty_view2 tEmpty tEmpty
   | ty_sigs (A A' B B' : term) : nf_ty_view2 (tSig A B) (tSig A' B')
+  | ty_ids A A' x x' y y' : nf_ty_view2 (tId A x y) (tId A' x' y')
   | ty_neutrals (n n' : term) : nf_ty_view2 n n'
   | ty_mismatch (t u : term) : nf_ty_view2 t u
   | ty_anomaly (t u : term) : nf_ty_view2 t u.
@@ -214,6 +232,8 @@ Equations build_nf_ty_view2 (A A' : term) : nf_ty_view2 A A' :=
         ty_emptys;
     | ty_view1_ty (eSig A B), ty_view1_ty (eSig A' B') :=
         ty_sigs A A' B B'
+    | ty_view1_ty (eId A x y), ty_view1_ty (eId A' x' y') :=
+        ty_ids A A' x x' y y'
     | ty_view1_small _, ty_view1_small _ :=
         ty_neutrals _ _ ;
     (** Mismatching sorts *)
@@ -234,6 +254,7 @@ Inductive nf_view3 : term -> term -> term -> Type :=
 | zeros : nf_view3 tNat tZero tZero
 | succs t t' : nf_view3 tNat (tSucc t) (tSucc t')
 | pairs A B t t' : nf_view3 (tSig A B) t t'
+| refls A x y A' x' A'' x'' : nf_view3 (tId A x y) (tRefl A' x') (tRefl A'' x'')
 | neutrals (A n n' : term) : nf_view3 A n n'
 | mismatch (A t u : term) : nf_view3 A t u
 | anomaly (A t u : term) : nf_view3 A t u.
@@ -269,6 +290,17 @@ Equations build_nf_view3 T t t' : nf_view3 T t t' :=
   }
   (** Pairs *)
   | ty_view1_ty (eSig A B) := pairs A B _ _ ;
+  (** Identity witnesses *)
+  | ty_view1_ty (eId A x y) with (build_nf_view1 t), (build_nf_view1 t') :=
+    {
+      | nf_view1_id A' x', nf_view1_id A'' x'' := refls A x y A' x' A'' x'' ;
+      | nf_view1_ne _, nf_view1_ne _ := neutrals _ _ _ ;
+      | nf_view1_ne _, nf_view1_id _ _ :=
+          mismatch _ _ _ ;
+      | nf_view1_id _ _, nf_view1_ne _ :=
+          mismatch _ _ _ ;
+      | _, _ := anomaly _ _ _ ;
+    }
   (** Neutral type *)
   | ty_view1_small _ := neutrals _ _ _ ;
   (** The type is not a type *)
@@ -344,6 +376,10 @@ Equations conv_ty_red : conv_stmt ty_red_state :=
         rec (ty_state;(Γ,,A);tt;B;B') (* ::: (ty_red_state;Γ;inp;tSig A B;tSig A' B') ;*) ;
       | ty_neutrals _ _ :=
           rec (ne_state;Γ;tt;T;T') ;; success (M:=irec _ _ _) ;
+    | ty_ids A A' x x' y y' :=
+      rec (ty_state;Γ;tt;A;A') ;;
+      rec (tm_state;Γ;A;x;x') ;;
+      rec (tm_state;Γ;A;y;y')
     | ty_mismatch _ _ := raise (head_mismatch None T T') ;
     | ty_anomaly _ _ := undefined ;
   }.
@@ -367,6 +403,10 @@ Equations conv_tm_red : conv_stmt tm_red_state :=
     | types s (ty_sigs A A' B B') :=
         rec (tm_state;Γ;tSort s;A;A') ;;
         rec (tm_state;Γ,,A;tSort s;B;B') (* ::: (tm_red_state;Γ;tSort s;tSig A B;tSig A' B') ;*) ;
+    | types s (ty_ids A A' x x' y y') :=
+        rec (tm_state;Γ;tSort s;A;A') ;;
+        rec (tm_state;Γ;A;x;x') ;;
+        rec (tm_state;Γ;A;y;y')
     | types _ (ty_neutrals _ _) :=
         rec (ne_state;Γ;tt;t;u) ;; success (M:=M0) ;
     | types s (ty_mismatch _ _) := raise (head_mismatch (Some (tSort s)) t u) ;
@@ -379,6 +419,9 @@ Equations conv_tm_red : conv_stmt tm_red_state :=
     | pairs A B t u :=
         rec (tm_state;Γ;A;tFst t; tFst u) ;;
         rec (tm_state;Γ; B[(tFst t)..]; tSnd t; tSnd u) (* ::: (tm_red_state;Γ;tSig A B;t;u) ;*) ;
+    | refls A x y A' x' A'' x'' := 
+      rec (ty_state;Γ;tt;A';A'') ;;
+      rec (tm_state;Γ;A';x';x'')
     | neutrals _ _ _ :=
       rec (ne_state;Γ;tt;t;u) ;; success (M:=M0) ;
     | mismatch _ _ _ := raise (head_mismatch (Some A) t u) ;
@@ -440,11 +483,23 @@ Time Equations conv_ne : conv_stmt ne_state :=
       | tSig A B => ret B[(tFst n)..]
       | _ => undefined (** the whnf of the type of a projected neutral must be a Σ type!*)
       end ; 
+    | _, _, Some (ne_view1_dest n (eIdElim A x P hr y), ne_view1_dest n' (eIdElim A' x' P' hr' y')) =>
+      T ← rec (ne_red_state;Γ;tt;n;n') ;;
+      match T with
+      | tId _ _ _ =>
+        rec (ty_state;Γ;tt;A;A') ;;
+        rec (tm_state;Γ;A;x;x') ;;
+        rec (ty_state;Γ,,A,,tId A⟨↑⟩ x⟨↑⟩ (tRel 0);tt;P;P') ;;
+        rec (tm_state;Γ;P[tRefl A x.: x..];hr;hr') ;;
+        rec (tm_state;Γ;A;y;y') ;;
+        ret P[n .: y..]
+      | _ => undefined
+      end ;
     | w, w', _ => raise (destructor_mismatch w w')
   }.
   
 
-Time Equations conv_ne_alt : conv_stmt ne_state :=
+(*Time Equations conv_ne_alt : conv_stmt ne_state :=
   | (Γ;inp;tRel n;tRel n')
     with n =? n' :=
     { | false := raise (variable_mismatch n n') ;
@@ -495,7 +550,7 @@ Time Equations conv_ne_alt : conv_stmt ne_state :=
       (* ret (B[(tFst n)..]) ::: (ne_state;Γ; inp; tSnd n; tSnd n') *)
     | _ => undefined (** the whnf of the type of a projected neutral must be a Σ type!*)
     end ; 
-  | (Γ;_;n;n') := raise (destructor_mismatch n n').
+  | (Γ;_;n;n') := raise (destructor_mismatch n n'). *)
 
 Equations conv_ne_red : conv_stmt ne_red_state :=
   | (Γ;inp;t;u) :=
@@ -582,6 +637,10 @@ Equations typing_wf_ty : typing_stmt wf_ty_state :=
     | ty_view1_ty (eSig A B) :=
         rA ← rec (wf_ty_state;Γ;tt;A) ;;
         id <*> rec (wf_ty_state;Γ,,A;tt;B) ;
+    | ty_view1_ty (eId A x y) :=
+        rA ← rec (wf_ty_state;Γ;tt;A) ;;
+        rec (check_state;Γ;A;x) ;;
+        rec (check_state;Γ;A;y)
     | ty_view1_small _ :=
         r ← rec (inf_red_state;Γ;tt;T) ;;[M]
         match r with
@@ -678,6 +737,27 @@ Equations typing_wf_ty : typing_stmt wf_ty_state :=
       | tSig A B => ret (B[(tFst u)..])
       | _ => raise (M:=M0) type_error
       end ;
+    | tId A x y :=
+      rA ← rec (inf_red_state;Γ;tt;A) ;;
+      match rA with
+      | tSort sA =>
+        rec (check_state;Γ;A;x) ;;
+        rec (check_state;Γ;A;y) ;;
+        ret (tSort sA)
+      | _ => raise (M:=M0) type_error
+      end ;
+    | tRefl A x :=
+      rec (wf_ty_state;Γ;tt;A) ;;
+      rec (check_state;Γ;A;x) ;;
+      ret (tId A x x) ;
+    | tIdElim A x P hr y e :=
+      rec (wf_ty_state;Γ;tt;A) ;;
+      rec (check_state;Γ;A;x) ;;
+      rec (wf_ty_state;Γ,,A,,tId A⟨↑⟩ x⟨↑⟩ (tRel 0);tt;P) ;;
+      rec (check_state;Γ;P[tRefl A x.: x..];hr) ;;
+      rec (check_state;Γ;A;y) ;;
+      rec (check_state;Γ;tId A x y;e) ;;
+      ret P[e.:y..] ;
   }.
 
   Equations typing_inf_red : typing_stmt inf_red_state :=

--- a/theories/Decidability/Soundness.v
+++ b/theories/Decidability/Soundness.v
@@ -195,6 +195,7 @@ Section ConversionSound.
     - econstructor ; tea.
       destruct H ; simp build_nf_view3 build_ty_view1 in Heq ; try solve [inversion Heq].
       all: try now econstructor.
+    - econstructor; tea; [intuition| now rewrite 2!Weakening.wk1_ren_on].
     - eapply convne_meta_conv.
       2: reflexivity.
       + econstructor.
@@ -267,7 +268,8 @@ Section TypingCorrect.
       | H : (build_ty_view1 _ = ty_view1_small _) |- _ => eapply ty_view1_small_can in H
       | H : (_;_;_) = (_;_;_) |- _ => injection H; clear H; intros; subst 
       end).
-    all: now econstructor.
+    all: try now econstructor.
+    econstructor; tea; now rewrite 2!Weakening.wk1_ren_on.
   Qed.
 
   Lemma implem_typing_sound x r:

--- a/theories/Decidability/Termination.v
+++ b/theories/Decidability/Termination.v
@@ -75,7 +75,7 @@ Proof.
   - intros * ? [IHA] ? [IHB] ? []%prod_ty_inv []%prod_ty_inv ? B' wB' HtyB'.
     apply compute_domain.
     simp conv conv_ty_red.
-    destruct wB' as [|A'' B''| | | |? wB'].
+    destruct wB' as [|A'' B''| | | | |? wB'].
     all: simp build_nf_ty_view2 ; cbn ; try easy.
     2: now rewrite (whne_ty_view1 wB') ; cbn.
     apply prod_ty_inv in HtyB' as [].
@@ -107,7 +107,7 @@ Proof.
   - intros * ? [IHA] ? [IHB] ? []%sig_ty_inv []%sig_ty_inv ? B' wB' HtyB'.
     apply compute_domain.
     simp conv conv_ty_red.
-    destruct wB' as [| | | | A'' B'' |? wB'].
+    destruct wB' as [| | | | A'' B'' | | ? wB'].
     all: simp build_nf_ty_view2 ; cbn ; try easy.
     2: now rewrite (whne_ty_view1 wB') ; cbn.
     apply sig_ty_inv in HtyB' as [].
@@ -118,23 +118,42 @@ Proof.
     + apply (IHB tt B'').
       now eapply stability1.
     + intros x; destruct x; cbn; easy.
+  - intros * ? [ihA] ? [ihx] ? [ihy] ? [? []]%id_ty_inv [? []]%id_ty_inv * wB' htyB'.
+    apply compute_domain.
+    simp conv conv_ty_red.
+    destruct wB' as [| | | | |A'' x'' y''| ? wB'].
+    all: simp build_nf_ty_view2 ; cbn.
+    1-5: easy.
+    2: now rewrite (whne_ty_view1 wB') ; cbn.
+    apply id_ty_inv in htyB' as [? []].
+    split; cycle -1.
+    1: intros []; cbn;[|easy].
+    1: intros HconvA%implem_conv_sound%algo_conv_sound; tea; split; cycle -1.
+    1: intros []; cbn;[|easy].
+    1: intros Hconvx%implem_conv_sound%algo_conv_sound; tea.
+    1: split; cycle -1.
+    1: intros []; cbn;easy.
+    + apply (ihy y''); now econstructor.
+    + now econstructor.
+    + apply (ihx x''); now econstructor.
+    + now apply (ihA tt A'').
   - intros * HM [IHM []] ??? ? ? wB' Hty.
     apply compute_domain.
     simp conv conv_ty_red.
     eapply algo_conv_wh in HM as [].
     destruct wB'.
-    1-5: simp build_nf_ty_view2 ; cbn.
-    1-5: now unshelve erewrite whne_ty_view1 ; cbn.
+    1-6: simp build_nf_ty_view2 ; cbn.
+    1-6: now unshelve erewrite whne_ty_view1 ; cbn.
     erewrite whne_ty_view2 ; tea.
     split.
     2: intros [|] ; cbn ; easy.
     eapply (IHM tt A) ; tea.
     inversion Hty ; subst ; tea.
-    1-5:  inv_whne.
+    1-6:  inv_whne.
     now exists U.
   - intros * ???? ? ? wu' ?.
     apply compute_domain.
-    destruct wu' as [n'| | | | |].
+    destruct wu' as [n'| | | | | |].
     all: simp conv conv_ne to_neutral_diag ; cbn ; try easy.
     destruct (Nat.eqb_spec n n') ; cbn.
     2: easy.
@@ -142,7 +161,7 @@ Proof.
     now econstructor.
   - intros ? ???? A B Hm [IHm []] ? [IHt] ??? ? u' wu' Hty.
     apply compute_domain.
-    destruct wu' as [|m' t'| | | |].
+    destruct wu' as [|m' t'| | | | |].
     all: simp conv conv_ne to_neutral_diag ; cbn; try exact I.
     split.
     + apply (IHm tt m') ; tea.
@@ -162,7 +181,7 @@ Proof.
       gen_typing.
   - intros * Hn [IHn] ? [IHP] ? [IHz] ? [IHs] ??? ? u' wu' Hty.
     apply compute_domain.
-    destruct wu' as [| |P'' hz'' hs'' n''| | |].
+    destruct wu' as [| |P'' hz'' hs'' n''| | | |].
     all: simp conv conv_ne to_neutral_diag ; cbn ; try exact I.
     destruct Hty as [? (?&[]&?)%termGen'].
     split.
@@ -197,7 +216,7 @@ Proof.
     now intros [|] ; cbn.
   - intros * He [IHe] ? [IHP] ??? ? u' wu' Hty.
     apply compute_domain.
-    destruct wu' as [| | | P'' e'' | |].
+    destruct wu' as [| | | P'' e'' | | |].
     all: simp conv conv_ne to_neutral_diag ; cbn ; try exact I.
     destruct Hty as [? (?&[]&?)%termGen'].
     split.
@@ -211,7 +230,7 @@ Proof.
     intros [|] ; cbn ; easy.
   - intros * h [ih []] ??? ? u' wu' Hty.
     apply compute_domain.
-    destruct wu' as [| | | | t |].
+    destruct wu' as [| | | | t | |].
     all: simp conv conv_ne to_neutral_diag ; cbn ; try exact I.
     destruct Hty as [? hu'%termGen']; cbn in hu'; prod_hyp_splitter; subst.
     split.
@@ -223,7 +242,7 @@ Proof.
     now cbn.
   - intros * h [ih []] ??? ? u' wu' Hty.
     apply compute_domain.
-    destruct wu' as [| | | | | t].
+    destruct wu' as [| | | | | t | ].
     all: simp conv conv_ne to_neutral_diag ; cbn ; try exact I.
     destruct Hty as [? hu'%termGen']; cbn in hu'; prod_hyp_splitter; subst.
     split.
@@ -233,6 +252,55 @@ Proof.
     eapply algo_conv_det in Hconv as ->.
     2: now eapply h.
     now cbn.
+  - intros * he [ihe []] ? [ihA] ? [ihx] ? [ihP] ? [ihhr] ? [ihy] ??? ?? wu' Hu'.
+    apply compute_domain.
+    destruct wu' as [| | | | | | A0 x0 P0 hr0 y0 e0].
+    all: simp conv conv_ne to_neutral_diag ; cbn ; try exact I.
+    destruct Hu' as [? hu'%termGen']; cbn in hu'; prod_hyp_splitter; subst.
+    split.
+    1: apply (ihe tt e0); tea; now eexists.
+    intros [T|]; cbn ; [|easy].
+    intros [Hconve ?]%implem_conv_sound.
+    eapply algo_conv_det in Hconve as ->.
+    2: now eapply he.
+    split.
+    1: apply (ihA tt A0); tea; now eexists.
+    intros [|]; cbn ; [|easy].
+    intros HconvA%implem_conv_sound%algo_conv_sound.
+    2,3: boundary.
+    split.
+    1: apply (ihx x0); try now econstructor.
+    intros [|]; cbn ; [|easy].
+    intros Hconvx%implem_conv_sound%algo_conv_sound.
+    rewrite <- !(Weakening.wk1_ren_on Γ A).
+    assert [(Γ,, A),, tId A⟨@Weakening.wk1 Γ A⟩ x⟨@Weakening.wk1 Γ A⟩ (tRel 0) |-[ de ] P0].
+    1:{
+      eapply stability; tea; symmetry; eapply idElimMotiveCtxConv; tea.
+      1: now eapply ctx_refl.
+      1,2: eapply idElimMotiveCtx; tea; boundary.
+    }
+    split.
+    1: apply (ihP tt P0); tea.
+    2: boundary.
+    2: econstructor; tea; now symmetry.
+    intros [|]; cbn; [|easy].
+    intros HconvP%implem_conv_sound%algo_conv_sound; tea.
+    2: boundary.
+    assert [Γ |-[ de ] hr0 : P[tRefl A x .: x..]].
+    1:{
+      econstructor; tea; symmetry.
+      eapply typing_subst2; tea.
+      cbn; rewrite 2!Weakening.wk1_ren_on, 2!shift_subst_eq.
+      now econstructor.
+    }
+    split.
+    1: apply (ihhr hr0); tea.
+    intros [|]; cbn; [|easy].
+    intros Hconvhr%implem_conv_sound%algo_conv_sound; tea.
+    2: boundary.
+    split.
+    1: apply (ihy y0); try now econstructor.
+    intros [|]; cbn; easy.
   - intros * ? [IHm] ?? ??? ? u' wu' Hty.
     apply compute_domain.
     simp conv conv_ne_red ; cbn.
@@ -280,7 +348,7 @@ Proof.
     apply compute_domain.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
-    destruct wu' as [ | A'' B'' | | | | ? wu'] ; cycle -1.
+    destruct wu' as [ | A'' B'' | | | | | ? wu'] ; cycle -1.
     1: rewrite (whne_ty_view1 wu').
     all: cbn ; try exact I.
     eapply termGen' in Hty as (?&[]&?) ; subst.
@@ -298,7 +366,7 @@ Proof.
     apply compute_domain.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
-    destruct wu' as [ | | | | | ? wu'] ; cycle -1.
+    destruct wu' as [ | | | | | | ? wu'] ; cycle -1.
     1: rewrite (whne_ty_view1 wu').
     all: now cbn.
   - intros * ??? u' wu' Hty.
@@ -323,7 +391,7 @@ Proof.
     apply compute_domain.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
-    destruct wu' as [ | | | | | ? wu'] ; cycle -1.
+    destruct wu' as [ | | | | | | ? wu'] ; cycle -1.
     1: rewrite (whne_ty_view1 wu').
     all: now cbn.
   - intros * ?? ? [IHf] ??? u' wu' Hty.
@@ -338,7 +406,7 @@ Proof.
     apply compute_domain.
     simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
     eapply Uterm_isType in wu' ; tea.
-    destruct wu' as [ |  | | | A'' B'' | ? wu'] ; cycle -1.
+    destruct wu' as [ |  | | | A'' B'' | | ? wu'] ; cycle -1.
     1: rewrite (whne_ty_view1 wu').
     all: cbn ; try easy.
     eapply termGen' in Hty as (?&[]&?) ; subst.
@@ -366,17 +434,49 @@ Proof.
     symmetry. eapply typing_subst1; tea.
     apply boundary in Hty as []%sig_ty_inv.
     now apply TypeRefl.
+  - intros * ? [ihA] ? [ihx] ? [ihy] ? [? [[->]]]%termGen' [? [[->]]]%termGen' ? wu' Hu'.
+    apply compute_domain.
+    simp conv conv_tm_red build_nf_view3 build_nf_ty_view2 .
+    eapply Uterm_isType in wu' ; tea.
+    destruct wu' as [ |  | | | | A'' x'' y'' | ? wu'] ; cycle -1.
+    1: rewrite (whne_ty_view1 wu').
+    all: cbn ; try easy.
+    pose proof Hu' as [? [[->]]]%termGen'.
+    split.
+    1: apply (ihA A''); tea.
+    intros [|]; cbn; [|easy].
+    intros HconvA%implem_conv_sound%algo_conv_sound; tea.
+    assert [Γ |- A'' ≅ A] by (symmetry; now econstructor).
+    split.
+    1: apply (ihx x''); now econstructor.
+    intros [|]; cbn; [|easy].
+    intros Hconvx%implem_conv_sound%algo_conv_sound; tea.
+    2: now econstructor.
+    split; [|easy].
+    apply (ihy y''); now econstructor.
+  - intros * ? [ihA] ? [ihx] ? [? [[->]]]%termGen' [? [[->]]]%termGen' ? wu' Hu'.
+    apply compute_domain.
+    simp conv conv_tm_red build_nf_view3 build_nf_ty_view2.
+    eapply id_isId in wu' as [wu' | [A0 [x0 ->]] ]; tea.
+    1: rewrite (whne_nf_view1 wu'); now cbn.
+    pose proof Hu' as [? [[->]]]%termGen'.
+    cbn; split.
+    1: eapply (ihA tt A0); tea.
+    intros [|]; cbn; [|easy].
+    intros HconvA%implem_conv_sound%algo_conv_sound; tea.
+    split; [| easy].
+    eapply ihx; econstructor; tea; now symmetry.
   - intros * Hm [IHm []] Hpos ??? u' wu' Hu'.
     apply compute_domain.
     simp conv conv_tm_red build_nf_view3.
     eapply algo_conv_wh in Hm as [].
-    destruct Hpos as [[]| | | ].
+    destruct Hpos as [[]| | | |].
     + cbn.
       simp build_nf_ty_view2.
       unshelve erewrite whne_ty_view1 ; tea.
       cbn.
       eapply Uterm_isType in wu' ; tea.
-      destruct wu' as [ | | | | | u' wu'] ; cbn ; try easy.
+      destruct wu' as [|  | | | | | u' wu'] ; cbn ; try easy.
       rewrite (whne_ty_view1 wu').
       cbn.
       split.
@@ -399,6 +499,16 @@ Proof.
       unshelve erewrite whne_nf_view1 ; tea.
       cbn.
       eapply empty_isEmpty in wu' ; tea.
+      rewrite (whne_nf_view1 wu').
+      cbn.
+      split.
+      2: now intros [] ; cbn.
+      apply (IHm tt u') ; tea.
+      now eexists.
+    + cbn.
+      unshelve erewrite whne_nf_view1 ; tea.
+      cbn.
+      eapply  id_isId in wu' as [wu'| [? [? ->]]] ; cbn; try easy.
       rewrite (whne_nf_view1 wu').
       cbn.
       split.
@@ -602,6 +712,46 @@ Proof.
   - split.
     1: apply IH; cbn; try easy; left; cbn; now do 2 econstructor.
     intros [[]|]; cbn; easy.
+  - split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hA%implem_typing_sound%algo_typing_sound; tea.
+    1: destruct t; cbn; try easy.
+    1: assert [Γ0 |-[de] A] by (destruct s; now econstructor).
+    1: split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hx%implem_typing_sound%algo_typing_sound; tea.
+    1: split; cycle -1.
+    1: intros [|]; cbn; easy.
+    all: eapply IH; cbn; tea; try easy.
+    all: left; cbn; do 2 constructor.
+  - split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hA%implem_typing_sound%algo_typing_sound; tea.
+    1: split; cycle -1.
+    1: intros [|]; cbn; easy.
+    all: eapply IH; cbn; tea; try easy.
+    all: left; cbn; do 2 constructor.
+  - split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hA%implem_typing_sound%algo_typing_sound; tea.
+    1: split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hx%implem_typing_sound%algo_typing_sound; tea.
+    1: rewrite <- !(Weakening.wk1_ren_on Γ0 A).
+    1: assert [ |-[ de ] (Γ0,, A),, tId A⟨@Weakening.wk1 Γ0 A⟩ x⟨@Weakening.wk1 Γ0 A⟩ (tRel 0)]
+      by now eapply idElimMotiveCtx.
+    1: split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hP%implem_typing_sound%algo_typing_sound; tea.
+    1: assert [Γ0 |-[ de ] P[tRefl A x .: x..]].
+    1:{ 
+      eapply typing_subst2; tea; cbn.
+      rewrite 2!Weakening.wk1_ren_on, 2!shift_subst_eq.
+      now econstructor.
+    }
+    1: split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hhr%implem_typing_sound%algo_typing_sound; tea.
+    1: split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hy%implem_typing_sound%algo_typing_sound; tea.
+    1: assert [Γ0 |-[ de ] tId A x y] by now econstructor.
+    1: split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros he%implem_typing_sound%algo_typing_sound; tea.
+    1: split; cycle -1.
+    all: eapply IH; cbn; tea; try easy; left; cbn; do 2 constructor.
   - split.
     + apply IH ; cbn ; try easy.
       1: now right ; cbn.
@@ -642,12 +792,17 @@ Proof.
     apply IH ; cbn ; try easy.
     1: left ; cbn ; now do 2 econstructor.
     now econstructor.
-  - split.
-    1:{
-      apply IH ; cbn ; try easy.
-      right ; now cbn.
-    }
-    intros [[]|] ; now cbn.
+  - split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hA%implem_typing_sound%algo_typing_sound; tea.
+    1: split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hx%implem_typing_sound%algo_typing_sound; tea.
+    1: split; [|easy].
+    all: eapply IH; cbn; tea; try easy.
+    all: left; do 2 constructor.
+  - split; cycle -1.
+    1: intros [|]; cbn; [|easy]; intros hA%implem_typing_sound%algo_typing_sound; tea.
+    1: destruct t; cbn; try easy.
+    eapply IH; cbn; tea; try easy; right; now cbn.
 Qed.
 
 End TypingTerminates.

--- a/theories/DeclarativeInstance.v
+++ b/theories/DeclarativeInstance.v
@@ -40,7 +40,7 @@ Definition termGenData (Γ : context) (t T : term) : Type :=
     | tId A x y => [× T = U, [Γ |- A : U], [Γ |- x : A] & [Γ |- y : A]]
     | tRefl A x => [× T = tId A x x, [Γ |- A] & [Γ |- x : A]]
     | tIdElim A x P hr y e => 
-      [× T = P[e .: y..], [Γ |- A], [Γ |- x : A], [Γ,, A,, tId A⟨↑⟩ x⟨↑⟩ (tRel 0) |- P], [Γ |- y : A] & [Γ |- e : tId A x y]]
+      [× T = P[e .: y..], [Γ |- A], [Γ |- x : A], [Γ,, A,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P], [Γ |- hr : P[tRefl A x .: x..]], [Γ |- y : A] & [Γ |- e : tId A x y]]
   end.
 
 Lemma termGen Γ t A :
@@ -49,9 +49,6 @@ Lemma termGen Γ t A :
 Proof.
   induction 1.
   all: try (eexists ; split ; [..|left ; reflexivity] ; cbn ; by_prod_splitter).
-  + eexists ; split ; [..|left ; reflexivity].
-    cbn; prod_splitter; split; reflexivity + tea.
-    now rewrite <- 2!(wk1_ren_on Γ A).
   + destruct IHTypingDecl as [? [? [-> | ]]].
     * prod_splitter; tea; now right.
     * prod_splitter; tea; right; now eapply TypeTrans.

--- a/theories/DeclarativeSubst.v
+++ b/theories/DeclarativeSubst.v
@@ -276,3 +276,40 @@ Proof.
       rewrite <- rinstInst'_term; do 2 erewrite <- wk1_ren_on.
       now eapply typing_wk.
 Qed.
+
+(* Stability and symmetry with redundant hypothesis on the well-formed contexts *)
+
+Section Stability0.
+
+  Let PCon (Γ : context) := True.
+  Let PTy (Γ : context) (A : term) := forall Δ,
+    [|-Δ] -> [|- Δ ≅ Γ] -> [Δ |- A].
+  Let PTm (Γ : context) (A t : term) := forall Δ,
+    [|-Δ] -> [|- Δ ≅ Γ] -> [Δ |- t : A].
+  Let PTyEq (Γ : context) (A B : term) := forall Δ,
+    [|-Δ] -> [|- Δ ≅ Γ] -> [Δ |- A ≅ B].
+  Let PTmEq (Γ : context) (A t u : term) := forall Δ,
+    [|-Δ] -> [|- Δ ≅ Γ] -> [Δ |- t ≅ u : A].
+
+  Theorem stability0 : WfDeclInductionConcl PCon PTy PTm PTyEq PTmEq.
+  Proof.
+    red; prod_splitter; intros Γ * Hty; red.
+    1: easy.
+    all: intros ?? Hconv; eapply (conv_well_subst _) in Hconv ; tea.
+    all: pose proof (Hconv' := Hconv); apply  subst_refl in Hconv'.
+    all: eapply typing_subst in Hty; tea.
+    all: repeat (rewrite idSubst_term in Hty ; [..|reflexivity]).
+    all: eassumption.
+  Qed.
+
+  Definition convCtxSym0 {Γ Δ} : [|- Δ] -> [|-Γ] -> [|- Δ ≅ Γ] -> [|- Γ ≅ Δ].
+  Proof.
+    induction 3.
+    all: constructor; inversion H; inversion H0; subst; refold.
+    1: now eauto.
+    eapply stability0 ; tea.
+    1: now symmetry.
+    now eauto.
+  Qed.
+
+End Stability0.

--- a/theories/DeclarativeTyping.v
+++ b/theories/DeclarativeTyping.v
@@ -47,6 +47,11 @@ Section Definitions.
           [ Γ |- A ] -> 
           [Γ ,, A |- B ] -> 
           [ Γ |- tSig A B ]
+      | wftTypeId {Γ} {A x y} :
+          [Γ |- A] ->
+          [Γ |- x : A] ->
+          [Γ |- y : A] ->
+          [Γ |- tId A x y]
       | wfTypeUniv {Γ} {A} :
           [ Γ |- A : U ] -> 
           [ Γ |- A ]
@@ -106,6 +111,23 @@ Section Definitions.
       | wfTermSnd {Γ A B p} :
         [Γ |- p : tSig A B] ->
         [Γ |- tSnd p : B[(tFst p)..]]
+      | wfTermId {Γ} {A x y} :
+          [Γ |- A : U] ->
+          [Γ |- x : A] ->
+          [Γ |- y : A] ->
+          [Γ |- tId A x y : U]
+      | wfTermRefl {Γ A x} :
+          [Γ |- A] ->
+          [Γ |- x : A] ->
+          [Γ |- tRefl A x : tId A x x]
+      | wfTermIdElim {Γ A x P hr y e} :
+          [Γ |- A] ->
+          [Γ |- x : A] ->
+          [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P] ->
+          [Γ |- hr : P[tRefl A x .: x..]] ->
+          [Γ |- y : A] ->
+          [Γ |- e : tId A x y] ->
+          [Γ |- tIdElim A x P hr y e : P[e .: y..]]
       | wfTermConv {Γ} {t A B} :
           [ Γ |- t : A ] -> 
           [ Γ |- A ≅ B ] -> 
@@ -122,6 +144,12 @@ Section Definitions.
           [ Γ |- A ≅ B] ->
           [ Γ ,, A |- C ≅ D] ->
           [ Γ |- tSig A C ≅ tSig B D]
+      | TypeIdCong {Γ A A' x x' y y'} :
+          (* [Γ |- A] -> ?  *)
+          [Γ |- A ≅ A'] ->
+          [Γ |- x ≅ x' : A] ->
+          [Γ |- y ≅ y' : A] ->
+          [Γ |- tId A x y ≅ tId A' x' y' ]
       | TypeRefl {Γ} {A} : 
           [ Γ |- A ] ->
           [ Γ |- A ≅ A]
@@ -212,6 +240,41 @@ Section Definitions.
         [Γ |- a : A] ->
         [Γ |- b : B[a..]] ->
         [Γ |- tSnd (tPair A B a b) ≅ b : B[(tFst (tPair A B a b))..]]
+      | TermIdCong {Γ A A' x x' y y'} :
+        (* [Γ |- A] -> ?  *)
+        [Γ |- A ≅ A' : U] ->
+        [Γ |- x ≅ x' : A] ->
+        [Γ |- y ≅ y' : A] ->
+        [Γ |- tId A x y ≅ tId A' x' y' : U ]
+      | TermReflCong {Γ A A' x x'} :
+        [Γ |- A ≅ A'] ->
+        [Γ |- x ≅ x' : A] ->
+        [Γ |- tRefl A x ≅ tRefl A' x' : tId A x x]
+      | TermIdElim {Γ A A' x x' P P' hr hr' y y' e e'} :
+        (* Parameters well formed: required for stability by weakening,
+          in order to show that the context Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)
+          remains well-formed under weakenings *)
+        [Γ |- A] ->
+        [Γ |- x : A] ->
+        [Γ |- A ≅ A'] ->
+        [Γ |- x ≅ x' : A] ->
+        [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P ≅ P'] ->
+        [Γ |- hr ≅ hr' : P[tRefl A x .: x..]] ->
+        [Γ |- y ≅ y' : A] ->
+        [Γ |- e ≅ e' : tId A x y] ->
+        [Γ |- tIdElim A x P hr y e ≅ tIdElim A' x' P' hr' y' e' : P[e .: y..]]
+      | TermIdElimRefl {Γ A x P hr y A' z} :
+        [Γ |- A] ->
+        [Γ |- x : A] ->
+        [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P] ->
+        [Γ |- hr : P[tRefl A x .: x..]] ->
+        [Γ |- y : A] ->
+        [Γ |- A'] ->
+        [Γ |- z : A] ->
+        [Γ |- A ≅ A'] ->
+        [Γ |- x ≅ y : A] ->
+        [Γ |- x ≅ z : A] ->
+        [Γ |- tIdElim A x P hr y (tRefl A' z) ≅ hr : P[tRefl A' z .: y..]]
       | TermRefl {Γ} {t A} :
           [ Γ |- t : A ] -> 
           [ Γ |- t ≅ t : A ]

--- a/theories/Fundamental.v
+++ b/theories/Fundamental.v
@@ -797,13 +797,12 @@ Section Fundamental.
     Unshelve. all: tea; try irrValid.
     3,4: eapply IdValid; irrValid.
     1: eapply validSnoc; now eapply idElimMotiveCtxIdValid.
-    assert (h : forall t, t⟨@wk1 Γ A'⟩ = t⟨@wk1 Γ A⟩) by reflexivity.
-      eapply convCtx2'; tea.
-      1: eapply convCtx1; tea; [eapply symValidEq; irrValid| ].
-      1,3: now eapply idElimMotiveCtxIdValid.
-      eapply idElimMotiveCtxIdCongValid; tea; irrValid.
-      Unshelve.
-      3: eapply idElimMotiveCtxIdValid. all: irrValid.
+    eapply convCtx2'; tea.
+    1: eapply convCtx1; tea; [eapply symValidEq; irrValid| ].
+    1,3: now eapply idElimMotiveCtxIdValid.
+    eapply idElimMotiveCtxIdCongValid; tea; irrValid.
+    Unshelve.
+    3: eapply idElimMotiveCtxIdValid. all: irrValid.
   Qed.
 
   Lemma FundTmEqIdElimRefl : forall (Γ : context) (A x P hr y A' z : term),

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -1192,7 +1192,7 @@ Section GenericConsequences.
     intros ? ?%whnf_whne; now eapply redtywf_whnf.
   Qed.
 
-  Lemma redtmwf_det Γ t u u' A A' :
+  Lemma redtmwf_det {Γ t u u' A A'} :
     whnf u -> whnf u' ->
     [Γ |- t :⇒*: u : A] -> [Γ |- t :⇒*: u' : A'] ->
     u = u'.
@@ -1202,7 +1202,7 @@ Section GenericConsequences.
     all: now eapply redtm_sound.
   Qed.
 
-  Lemma redtywf_det Γ A B B' :
+  Lemma redtywf_det {Γ A B B'} :
     whnf B -> whnf B' ->
     [Γ |- A :⇒*: B] -> [Γ |- A :⇒*: B'] ->
     B = B'.
@@ -1212,6 +1212,7 @@ Section GenericConsequences.
     all: now eapply redty_sound.
   Qed.
 
+  (* Unused, consider removing*)
   Lemma whredtm_det Γ t u u' A A' :
     [Γ |- t ↘ u : A] -> [Γ |- t ↘ u' : A'] ->
     u = u'.
@@ -1221,6 +1222,7 @@ Section GenericConsequences.
     all: now eapply redtm_sound.
   Qed.
 
+  (* Unused, consider removing*)
   Lemma whredty_det Γ A B B' :
     [Γ |- A ↘ B] -> [Γ |- A ↘ B'] ->
     B = B'.

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -869,6 +869,8 @@ Section IdRedTm.
 
   Inductive IdProp : term ->  Type:=
   | reflR {A x} : 
+    [Γ |- A] ->
+    [Γ |- x : A] ->
     [IA.(IdRedTyPack.tyRed) | _ ||- _ ≅ A] ->
     [IA.(IdRedTyPack.tyRed) | _ ||- IA.(IdRedTyPack.lhs) ≅ x : _ ] ->
     (* Should the index only be conversion ? *)
@@ -902,6 +904,10 @@ Section IdRedTmEq.
   
   Inductive IdPropEq : term -> term -> Type :=
   | reflReq {A A' x x'} : 
+    [Γ |- A] ->
+    [Γ |- A'] ->
+    [Γ |- x : A] ->
+    [Γ |- x' : A'] ->
     [IA.(IdRedTyPack.tyRed) | _ ||- _ ≅ A] ->
     [IA.(IdRedTyPack.tyRed) | _ ||- _ ≅ A'] ->
     [IA.(IdRedTyPack.tyRed) | _ ||- IA.(IdRedTyPack.lhs) ≅ x : _ ] -> 
@@ -924,7 +930,7 @@ Section IdRedTmEq.
 
 End IdRedTmEq.
 Arguments IdRedTmEq {_ _ _ _ _ _ _ _ _ _ _}.
-Arguments IdPropEq {_ _ _ _ _ _ _ _}.
+Arguments IdPropEq {_ _ _ _ _ _ _ _ _}.
 End IdRedTmEq.
 
 Export IdRedTmEq(IdRedTmEq,Build_IdRedTmEq, IdPropEq).

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -812,11 +812,12 @@ Module IdRedTyPack.
     rhsRedRefl : [ tyRed | Γ ||- rhs ≅ rhs : _ ] ;
     tyPER : PER (fun t u => [tyRed | _ ||- t ≅ u : _]) ;
     tyKripke : forall {Δ} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), LRPack@{i} Δ ty⟨ρ⟩ ;
-    tyKripkeAct : forall {Δ} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]),
-      and3@{i i i} 
-        (forall B, [tyKripke ρ wfΔ | _ ||- _ ≅ B] -> [tyKripke ρ wfΔ | _ ||- _ ≅ B⟨ρ⟩])
-        (forall t, [tyKripke ρ wfΔ | _ ||- t : _] -> [tyKripke ρ wfΔ | _ ||- t⟨ρ⟩ : _])
-        (forall t u, [tyKripke ρ wfΔ | _ ||- t ≅ u : _] -> [tyKripke ρ wfΔ | _ ||- t⟨ρ⟩ ≅ u⟨ρ⟩ : _])
+    tyKripkeEq : forall {Δ Ξ} (ρ : Δ ≤ Γ) (ρ' : Ξ ≤ Γ) (ρ'' : Ξ ≤ Δ) (wfΔ : [|-Δ]) (wfΞ : [|-Ξ]) B,
+      ρ' =1 ρ'' ∘w ρ -> [tyKripke ρ wfΔ | _ ||- _ ≅ B] -> [tyKripke ρ' wfΞ | _ ||- _ ≅ B⟨ρ''⟩];
+    tyKripkeTm : forall {Δ Ξ} (ρ : Δ ≤ Γ) (ρ' : Ξ ≤ Γ) (ρ'' : Ξ ≤ Δ) (wfΔ : [|-Δ]) (wfΞ : [|-Ξ]) t,
+      ρ' =1 ρ'' ∘w ρ -> [tyKripke ρ wfΔ | _ ||- t : _] -> [tyKripke ρ' wfΞ | _ ||- t⟨ρ''⟩ : _];
+    tyKripkeTmEq : forall {Δ Ξ} (ρ : Δ ≤ Γ) (ρ' : Ξ ≤ Γ) (ρ'' : Ξ ≤ Δ) (wfΔ : [|-Δ]) (wfΞ : [|-Ξ]) t u,
+      ρ' =1 ρ'' ∘w ρ -> [tyKripke ρ wfΔ | _ ||- t ≅ u : _] -> [tyKripke ρ' wfΞ | _ ||- t⟨ρ''⟩ ≅ u⟨ρ''⟩ : _];
   }.
 
   Record IdRedTyAdequate@{i j} `{ta : tag} `{WfContext ta} `{WfType ta} `{RedType ta} `{ConvType ta}
@@ -1384,11 +1385,12 @@ Section IdRedTy.
     rhsRedRefl : [ tyRed | Γ ||- rhs ≅ rhs : _ ] ;
     tyPER : PER (fun t u => [tyRed | _ ||- t ≅ u : _]) ;
     tyKripke : forall {Δ} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [ LogRel@{i j k l} l | Δ ||- ty⟨ρ⟩ ] ;
-    tyKripkeAct : forall {Δ} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]),
-      and3@{k k k} 
-        (forall B, [tyKripke ρ wfΔ | _ ||- _ ≅ B] -> [tyKripke ρ wfΔ | _ ||- _ ≅ B⟨ρ⟩])
-        (forall t, [tyKripke ρ wfΔ | _ ||- t : _] -> [tyKripke ρ wfΔ | _ ||- t⟨ρ⟩ : _])
-        (forall t u, [tyKripke ρ wfΔ | _ ||- t ≅ u : _] -> [tyKripke ρ wfΔ | _ ||- t⟨ρ⟩ ≅ u⟨ρ⟩ : _])
+    tyKripkeEq : forall {Δ Ξ} (ρ : Δ ≤ Γ) (ρ' : Ξ ≤ Γ) (ρ'' : Ξ ≤ Δ) (wfΔ : [|-Δ]) (wfΞ : [|-Ξ]) B,
+      ρ' =1 ρ'' ∘w ρ -> [tyKripke ρ wfΔ | _ ||- _ ≅ B] -> [tyKripke ρ' wfΞ | _ ||- _ ≅ B⟨ρ''⟩];
+    tyKripkeTm : forall {Δ Ξ} (ρ : Δ ≤ Γ) (ρ' : Ξ ≤ Γ) (ρ'' : Ξ ≤ Δ) (wfΔ : [|-Δ]) (wfΞ : [|-Ξ]) t,
+      ρ' =1 ρ'' ∘w ρ -> [tyKripke ρ wfΔ | _ ||- t : _] -> [tyKripke ρ' wfΞ | _ ||- t⟨ρ''⟩ : _];
+    tyKripkeTmEq : forall {Δ Ξ} (ρ : Δ ≤ Γ) (ρ' : Ξ ≤ Γ) (ρ'' : Ξ ≤ Δ) (wfΔ : [|-Δ]) (wfΞ : [|-Ξ]) t u,
+      ρ' =1 ρ'' ∘w ρ -> [tyKripke ρ wfΔ | _ ||- t ≅ u : _] -> [tyKripke ρ' wfΞ | _ ||- t⟨ρ''⟩ ≅ u⟨ρ''⟩ : _];
  }.
 
 
@@ -1404,8 +1406,9 @@ Section IdRedTy.
     - exact IA.(IdRedTyPack.lhsRedRefl).
     - exact IA.(IdRedTyPack.rhsRedRefl).
     - exact IA.(IdRedTyPack.tyPER).
-    - intros; refine (Times3@{k k k} _ _ _ _ _ _). (* split/ constructor leave unbound universes *)
-      all: intros; now apply IA.(IdRedTyPack.tyKripkeAct).
+    - intros; now eapply IA.(IdRedTyPack.tyKripkeEq).
+    - intros; now eapply IA.(IdRedTyPack.tyKripkeTm).
+    - intros; now eapply IA.(IdRedTyPack.tyKripkeTmEq).
   Defined.
 
   Definition toPack@{i j k l} {Γ l A} (IA : @IdRedTy@{i j k l} Γ l A) : IdRedTyPack@{k} Γ A.
@@ -1419,8 +1422,9 @@ Section IdRedTy.
     - exact IA.(IdRedTy.lhsRedRefl).
     - exact IA.(IdRedTy.rhsRedRefl).
     - exact IA.(IdRedTy.tyPER).
-    - intros; refine (Times3@{k k k} _ _ _ _ _ _). (* split/ constructor leave unbound universes *)
-      all: intros; now apply IA.(IdRedTy.tyKripkeAct).
+    - intros; now eapply IA.(IdRedTy.tyKripkeEq).
+    - intros; now eapply IA.(IdRedTy.tyKripkeTm).
+    - intros; now eapply IA.(IdRedTy.tyKripkeTmEq).
   Defined.
   
   Definition to@{i j k l} {Γ l A} (IA : @IdRedTy@{i j k l} Γ l A) : IdRedTyAdequate@{k l} (LogRel@{i j k l} l) (toPack IA).
@@ -1428,17 +1432,16 @@ Section IdRedTy.
     econstructor; [apply IA.(tyRed)| intros; now apply IA.(tyKripke)]. 
   Defined.
 
-  (* Do not hold anymore because of the packing in tyKripkeAct; a simple solution if needs be is to unpack into 3 fields *)
-  (* Lemma beta_pack@{i j k l} {Γ l A} {IA : IdRedTyPack@{k} Γ A} (IAad : IdRedTyAdequate@{k l} (LogRel@{i j k l} l) IA) :
+  Lemma beta_pack@{i j k l} {Γ l A} {IA : IdRedTyPack@{k} Γ A} (IAad : IdRedTyAdequate@{k l} (LogRel@{i j k l} l) IA) :
     toPack (from IAad) = IA.
-  Proof. destruct IA, IAad; cbn. reflexivity. Qed.
+  Proof. reflexivity. Qed.
   
   Lemma beta_ad@{i j k l} {Γ l A} {IA : IdRedTyPack@{k} Γ A} (IAad : IdRedTyAdequate@{k l} (LogRel@{i j k l} l) IA) :
     to (from IAad) = IAad.
   Proof. reflexivity. Qed.
 
   Lemma eta@{i j k l} {Γ l A} (IA : @IdRedTy@{i j k l} Γ l A) : from  (to IA) = IA. 
-  Proof. reflexivity. Qed. *)
+  Proof. reflexivity. Qed.
 
   Definition IdRedTyEq {Γ l A} (IA : @IdRedTy Γ l A) := IdRedTyEq (toPack IA).
   Definition IdRedTm {Γ l A} (IA : @IdRedTy Γ l A) := IdRedTm (toPack IA).

--- a/theories/LogicalRelation/Escape.v
+++ b/theories/LogicalRelation/Escape.v
@@ -45,7 +45,7 @@ Section Escapes.
     + intros ??? [] []; gen_typing.
     + intros ??? [] * ? ? []; cbn in *.
       eapply convty_exp. all: gen_typing.
-    + intros ??? [???? red] ? [???? red']; cbn in *. 
+    + intros ??? [???? red] ?? [???? red']; cbn in *. 
       eapply convty_exp; tea;[eapply red | eapply red'].
   Qed.
 
@@ -64,7 +64,7 @@ Section Escapes.
     - intros ??? [] []; gen_typing.
     - intros ??? [] * ?? [] ; cbn in *.
       gen_typing.
-    - intros ??? IA _ []. 
+    - intros ??? IA _ _ []. 
       unfold_id_outTy; destruct IA; cbn in *; gen_typing.
   Qed.
 
@@ -89,7 +89,7 @@ Section Escapes.
     - intros ??? [] * ?? [[termL] [termR]] ; cbn in *.
       eapply convtm_exp ; tea.
       all: gen_typing.
-    - intros ??? [] _ []; unfold_id_outTy; cbn in *.
+    - intros ??? [] _ _ []; unfold_id_outTy; cbn in *.
       eapply convtm_exp; tea; gen_typing.
   Qed.
 
@@ -105,7 +105,7 @@ Section Escapes.
     - intros * []; gen_typing.
     - intros * []; gen_typing.
     - intros * ??? []; gen_typing.
-    - intros * _ ? []; gen_typing.
+    - intros * _ _ ? []; gen_typing.
   Qed.
   
 End Escapes.

--- a/theories/LogicalRelation/Escape.v
+++ b/theories/LogicalRelation/Escape.v
@@ -25,6 +25,7 @@ Section Escapes.
     - intros ??? []; gen_typing.
     - intros ??? []; gen_typing.
     - intros ??? [] **; gen_typing.
+    - intros ??? [] **; gen_typing.
   Qed.
 
   Lemma escapeEq {l Γ A B} (lr : [Γ ||-< l > A]) :
@@ -44,8 +45,9 @@ Section Escapes.
     + intros ??? [] []; gen_typing.
     + intros ??? [] * ? ? []; cbn in *.
       eapply convty_exp. all: gen_typing.
+    + intros ??? [???? red] ? [???? red']; cbn in *. 
+      eapply convty_exp; tea;[eapply red | eapply red'].
   Qed.
-
 
   Definition escapeTerm {l Γ t A} (lr : [Γ ||-< l > A ]) :
     [Γ ||-< l > t : A | lr ] ->
@@ -62,6 +64,8 @@ Section Escapes.
     - intros ??? [] []; gen_typing.
     - intros ??? [] * ?? [] ; cbn in *.
       gen_typing.
+    - intros ??? IA _ []. 
+      unfold_id_outTy; destruct IA; cbn in *; gen_typing.
   Qed.
 
   Definition escapeEqTerm {l Γ t u A} (lr : [Γ ||-< l > A ]) :
@@ -85,6 +89,8 @@ Section Escapes.
     - intros ??? [] * ?? [[termL] [termR]] ; cbn in *.
       eapply convtm_exp ; tea.
       all: gen_typing.
+    - intros ??? [] _ []; unfold_id_outTy; cbn in *.
+      eapply convtm_exp; tea; gen_typing.
   Qed.
 
   Lemma escapeConv {l Γ A} (RA : [Γ ||-<l> A]) :
@@ -99,6 +105,7 @@ Section Escapes.
     - intros * []; gen_typing.
     - intros * []; gen_typing.
     - intros * ??? []; gen_typing.
+    - intros * _ ? []; gen_typing.
   Qed.
   
 End Escapes.

--- a/theories/LogicalRelation/Id.v
+++ b/theories/LogicalRelation/Id.v
@@ -1,0 +1,136 @@
+From LogRel.AutoSubst Require Import core unscoped Ast Extra.
+From LogRel Require Import Notations Utils BasicAst Context NormalForms Weakening GenericTyping LogicalRelation.
+From LogRel.LogicalRelation Require Import Induction Irrelevance Weakening Neutral Escape Reflexivity NormalRed Reduction Transitivity Universe.
+
+Set Universe Polymorphism.
+Set Printing Primitive Projection Parameters.
+
+Section IdRed.
+  Context `{GenericTypingProperties}.
+
+  Lemma mkIdRedTy {Γ l A} :
+    forall (ty lhs rhs  : term)
+      (tyRed : [Γ ||-<l> ty]),
+      [Γ |- A :⇒*: tId ty lhs rhs] ->
+      [tyRed | Γ ||- lhs : _] ->
+      [tyRed | Γ ||- rhs : _] ->
+      [Γ ||-Id<l> A].
+  Proof.
+    intros; unshelve econstructor; cycle 3; tea.
+    1: intros; now eapply wk.
+    2,3: now eapply reflLRTmEq.
+    2: apply perLRTmEq.
+    - eapply  convty_Id. 
+      1: eapply escapeEq; now eapply reflLRTyEq.
+      1,2: eapply escapeEqTerm; now eapply reflLRTmEq.
+    - cbn; intros; irrelevance0; [|now eapply wkEq].
+      bsimpl; rewrite H11; now bsimpl.
+      Unshelve. all:tea.
+    - cbn; intros; irrelevance0; [| now eapply wkTerm].
+      bsimpl; rewrite H11; now bsimpl.
+      Unshelve. all:tea.
+    - cbn; intros; irrelevance0; [| now eapply wkTermEq].
+      bsimpl; rewrite H11; now bsimpl.
+      Unshelve. all:tea.
+  Defined.
+
+  Lemma IdRed0 {Γ l A t u} (RA : [Γ ||-<l> A]) :
+      [RA | Γ ||- t : _] ->
+      [RA | Γ ||- u : _] ->
+      [Γ ||-Id<l> tId A t u].
+  Proof.
+    intros; eapply mkIdRedTy.
+    1: eapply redtywf_refl; escape; gen_typing.
+    all: tea.
+  Defined.
+  
+  Lemma IdRed {Γ l A t u} (RA : [Γ ||-<l> A]) :
+      [RA | Γ ||- t : _] ->
+      [RA | Γ ||- u : _] ->
+      [Γ ||-<l> tId A t u].
+  Proof. intros; apply LRId'; now eapply IdRed0. Defined.
+  
+  Lemma IdRedTy_inv {Γ l A t u} (RIA : [Γ ||-Id<l> tId A t u]) :
+    [× A = RIA.(IdRedTy.ty), t = RIA.(IdRedTy.lhs) & u = RIA.(IdRedTy.rhs)].
+  Proof.
+    pose proof (redtywf_whnf RIA.(IdRedTy.red) whnf_tId) as e; injection e; now split.
+  Qed.
+
+  Lemma IdCongRed {Γ l A A' t t' u u'} 
+    (RA : [Γ ||-<l> A])
+    (RIA : [Γ ||-<l> tId A t u]) :
+    [Γ |- tId A' t' u'] ->
+    [RA | _ ||- _ ≅ A'] ->
+    [RA | _ ||- t ≅ t' : _] ->
+    [RA | _ ||- u ≅ u' : _] ->
+    [RIA | _ ||- _ ≅ tId A' t' u'].
+  Proof.
+    intros.
+    enough [LRId' (invLRId RIA) | _ ||- _ ≅ tId A' t' u'] by irrelevance.
+    pose proof (IdRedTy_inv (invLRId (RIA))) as [ety elhs erhs].
+    econstructor.
+    + now eapply redtywf_refl.
+    + unfold_id_outTy; rewrite <- ety, <- elhs, <- erhs; eapply convty_Id; now escape.
+    + irrelevance.
+    + cbn; rewrite <- elhs; irrelevance.
+    + cbn; rewrite <- erhs; irrelevance.
+  Qed. 
+    
+  Lemma IdRedU@{i j k l} {Γ l A t u}
+      (RU : [LogRel@{i j k l} l | Γ ||- U])
+      (RU' := invLRU RU)
+      (RA : [LogRel@{i j k l} (URedTy.level RU') | Γ ||- A]) :
+      [RU | Γ ||- A : U] ->
+      [RA | Γ ||- t : _] ->
+      [RA | Γ ||- u : _] ->
+      [RU | Γ ||- tId A t u : U].
+  Proof.
+    intros RAU Rt Ru.
+    enough [LRU_ RU' | _ ||- tId A t u : U] by irrelevance.
+    econstructor.
+    - eapply redtmwf_refl; escape; now eapply ty_Id.
+    - constructor.
+    - eapply convtm_Id; eapply escapeEq + eapply escapeEqTerm; now eapply reflLRTmEq + eapply reflLRTyEq.
+    - eapply RedTyRecBwd. eapply IdRed; irrelevanceCum.
+    Unshelve. irrelevanceCum.
+  Qed.
+  
+  Lemma IdCongRedU@{i j k l} {Γ l A A' t t' u u'} 
+      (RU : [LogRel@{i j k l} l | Γ ||- U])
+      (RU' := invLRU RU)
+      (RA : [LogRel@{i j k l} (URedTy.level RU') | Γ ||- A])
+      (RA' : [LogRel@{i j k l} (URedTy.level RU') | Γ ||- A']) :
+    [RU | Γ ||- A : U] ->
+    [RU | Γ ||- A' : U] ->
+    [RU | _ ||- A ≅ A' : U] ->
+    [RA | _ ||- t : _] ->
+    [RA' | _ ||- t' : _] ->
+    [RA | _ ||- t ≅ t' : _] ->
+    [RA | _ ||- u : _] ->
+    [RA' | _ ||- u' : _] ->
+    [RA | _ ||- u ≅ u' : _] ->
+    [RU | _ ||- tId A t u ≅ tId A' t' u' : U].
+  Proof.
+    intros RAU RAU' RAAU' Rt Rt' Rtt' Ru Ru' Ruu'.
+    enough [LRU_ RU' | _ ||- tId A t u ≅ tId A' t' u': U] by irrelevance.
+    opector.
+    - change [LRU_ RU' | _ ||- tId A t u : _].
+      enough [RU | _ ||- tId A t u : _] by irrelevance. 
+      now unshelve eapply IdRedU.
+    - change [LRU_ RU' | _ ||- tId A' t' u' : _]. 
+      enough [RU | _ ||- tId A' t' u' : _] by irrelevance. 
+      now unshelve eapply IdRedU.
+    - eapply RedTyRecBwd. eapply IdRed; irrelevanceCum.
+      Unshelve. clear dependent RA'; irrelevanceCum.
+    - pose proof (redtmwf_whnf (URedTm.red u0) whnf_tId) as <-.
+      pose proof (redtmwf_whnf (URedTm.red u1) whnf_tId) as <-.
+      eapply convtm_Id; now escape.
+    - eapply RedTyRecBwd. eapply IdRed; irrelevanceCum.
+      Unshelve. irrelevanceCum.
+    - eapply TyEqRecFwd.
+      eapply LRTyEqIrrelevantCum.
+      unshelve eapply IdCongRed; tea.
+      + escape; gen_typing.
+      + now eapply UnivEqEq.
+      Unshelve. now eapply IdRed.
+  Qed.

--- a/theories/LogicalRelation/Id.v
+++ b/theories/LogicalRelation/Id.v
@@ -134,3 +134,52 @@ Section IdRed.
       + now eapply UnivEqEq.
       Unshelve. now eapply IdRed.
   Qed.
+
+
+
+Lemma reflRed {Γ l A x} (RA : [Γ ||-<l> A]) (Rx : [RA | _ ||- x : _]) (RIA : [Γ ||-<l> tId A x x]) :
+  [RIA | _ ||- tRefl A x : _].
+Proof.
+  set (RIA' := invLRId RIA).
+  enough [LRId' RIA' | _ ||- tRefl A x : _] by irrelevance.
+  pose proof (IdRedTy_inv RIA') as [eA ex ex'].
+  assert (e : tId (IdRedTy.ty RIA') (IdRedTy.lhs RIA') (IdRedTy.rhs RIA') = tId A x x).
+  1: f_equal; now symmetry.
+  econstructor; unfold_id_outTy; cbn; rewrite ?e.
+  + eapply redtmwf_refl; eapply ty_refl; now escape.
+  + eapply convtm_refl; [eapply escapeEq; eapply reflLRTyEq|eapply escapeEqTerm; now eapply reflLRTmEq].
+  + constructor; cbn; irrelevance0; tea.
+    1: eapply reflLRTyEq.
+    * rewrite <- ex; now eapply reflLRTmEq.
+    * rewrite <- ex'; now eapply reflLRTmEq.
+  Unshelve.  all: tea.
+Qed.
+
+Lemma reflCongRed {Γ l A A' x x'} 
+  (RA : [Γ ||-<l> A])
+  (TA' : [Γ |- A'])
+  (RAA' : [RA | _ ||- _ ≅ A'])
+  (Rx : [RA | _ ||- x : _]) 
+  (Tx' : [Γ |- x' : A'])
+  (Rxx' : [RA | _ ||- x ≅ x' : _]) 
+  (RIA : [Γ ||-<l> tId A x x]) :
+  [RIA | _ ||- tRefl A x ≅ tRefl A' x' : _].
+Proof.
+  set (RIA' := invLRId RIA).
+  enough [LRId' RIA' | _ ||- tRefl A x ≅ tRefl A' x' : _] by irrelevance.
+  pose proof (IdRedTy_inv RIA') as [eA ex ex'].
+  assert (e : tId (IdRedTy.ty RIA') (IdRedTy.lhs RIA') (IdRedTy.rhs RIA') = tId A x x).
+  1: f_equal; now symmetry.
+  assert [Γ |- tId A x x ≅ tId A' x' x'] by (escape ; gen_typing).
+  econstructor; unfold_id_outTy; cbn; rewrite ?e.
+  1,2: eapply redtmwf_refl.
+  1: escape; gen_typing.
+  - eapply ty_conv; [| now symmetry]; now eapply ty_refl.
+  - eapply convtm_refl; now escape.
+  - constructor; cbn; irrelevance0; tea.
+    1: apply reflLRTyEq.
+    1,2: rewrite <- ex; tea; now eapply reflLRTmEq.
+    1,2: rewrite <- ex'; tea; now eapply reflLRTmEq.
+  Unshelve. all: tea.
+Qed.
+

--- a/theories/LogicalRelation/Induction.v
+++ b/theories/LogicalRelation/Induction.v
@@ -50,6 +50,7 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     | LRNat _ NA => LRNat _ NA
     | LREmpty _ NA => LREmpty _ NA
     | LRSig _ PA PAad => LRSig _ PA (embedPolyAd PAad)
+    | LRId _ IA IAad => LRId _ IA (LR_embedding l_ IAad)
     end.
 
   (** A basic induction principle, that handles only the first point in the list above *)
@@ -82,12 +83,16 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     (forall (Γ : context) (A : term) (ΠA : SigRedTy@{j} Γ A) (HAad : SigRedTyAdequate (LR rec) ΠA),
       PolyHyp P Γ ΠA HAad (P (LRSig rec ΠA HAad))) ->
 
+    (forall Γ A (IA : IdRedTyPack@{j} Γ A) (IAad : IdRedTyAdequate (LR rec) IA), 
+      P IAad ->
+      P (LRId rec IA IAad)) ->
+
     forall (Γ : context) (t : term) (rEq rTe : term -> Type@{j})
       (rTeEq  : term -> term -> Type@{j}) (lr : LR@{i j k} rec Γ t rEq rTe rTeEq),
       P lr.
   Proof.
     cbn.
-    intros HU Hne HPi HNat HEmpty HSig.
+    intros HU Hne HPi HNat HEmpty HSig HId.
     fix HRec 6.
     destruct lr.
     - eapply HU.
@@ -98,6 +103,7 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     - eapply HEmpty.
     - eapply HSig.
       all: intros; eapply HRec.
+    - eapply HId; eapply HRec.
   Defined.
 
   Definition LR_rec@{i j k} := LR_rect@{i j k Set}.
@@ -128,15 +134,18 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     
     (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
       PolyHypLogRel P Γ ΠA (P (LRSig' ΠA).(LRAd.adequate ))) ->
+    
+    (forall l Γ A (IA :  [Γ ||-Id<l> A]), P (IA.(IdRedTy.tyRed).(LRAd.adequate)) -> P (LRId' IA).(LRAd.adequate)) ->
 
     forall (l : TypeLevel) (Γ : context) (t : term) (rEq rTe : term -> Type@{k})
       (rTeEq  : term -> term -> Type@{k}) (lr : LR@{j k l} (LogRelRec@{i j k} l) Γ t rEq rTe rTeEq),
       P lr.
   Proof.
-    intros ?? HPi ?? HSig **; eapply LR_rect@{j k l o}.
+    intros ?? HPi ?? HSig HId **; eapply LR_rect@{j k l o}.
     1,2,4,5: auto.
     - intros; eapply (HPi _ _ _ (ParamRedTy.from HAad)); eauto.
     - intros; eapply (HSig _ _ _ (ParamRedTy.from HAad)); eauto.
+    - intros; eapply (HId _ _ _ (IdRedTy.from IAad)); eauto.
   Defined.
 
   Notation PolyHypTyUr P Γ ΠA G :=
@@ -163,13 +172,75 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     
     (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
       PolyHypTyUr P Γ ΠA (P (LRSig' ΠA))) ->
+    
+    (forall l Γ A (IA :  [Γ ||-Id<l> A]), P (IA.(IdRedTy.tyRed)) -> P (LRId' IA)) ->
 
     forall (l : TypeLevel) (Γ : context) (A : term) (lr : [LogRel@{i j k l} l | Γ ||- A]),
       P lr.
   Proof.
-    intros HU Hne HPi HNat HEmpty HSig l Γ A lr.
+    intros HU Hne HPi HNat HEmpty HSig HId l Γ A lr.
     apply (LR_rect_LogRelRec@{i j k l o} (fun l Γ A _ _ _ lr => P l Γ A (LRbuild lr))).
     all: auto.
+  Defined.
+
+  (* Specialized version for level 0, used in the general version *)
+
+  Theorem LR_rect_TyUr0@{i j k l o} (l:=zero)
+    (P : forall {Γ A}, [LogRel@{i j k l} l | Γ ||- A] -> Type@{o}) :
+
+    (forall (Γ : context) (A : term) (neA : [Γ ||-ne A]), P (LRne_ l neA)) ->
+
+    (forall (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tProd Γ l A),
+      PolyHypTyUr P Γ ΠA (P (LRPi' ΠA))) ->
+
+    (forall Γ A (NA : [Γ ||-Nat A]), P (LRNat_ l NA)) ->
+
+    (forall Γ A (NA : [Γ ||-Empty A]), P (LREmpty_ l NA)) ->
+    
+    (forall (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
+      PolyHypTyUr P Γ ΠA (P (LRSig' ΠA))) ->
+    
+    (forall Γ A (IA :  [Γ ||-Id<l> A]), P (IA.(IdRedTy.tyRed)) -> P (LRId' IA)) ->
+
+    forall (Γ : context) (A : term) (lr : [LogRel@{i j k l} l | Γ ||- A]),
+      P lr.
+  Proof.
+    intros HU Hne HPi HNat HEmpty HSig Γ A lr.
+    change _ with (match l as l return [Γ ||-<l> A] -> Type@{o} with zero => P Γ A | one => fun _ => unit end lr).
+    generalize l Γ A lr.
+    eapply LR_rect_TyUr; intros [] *; constructor + auto.
+    exfalso. pose (x := URedTy.lt h). inversion x.
+  Defined. 
+
+  (* Induction principle with inductive hypothesis for the universe at lower levels *)
+    
+  Theorem LR_rect_TyUrGen@{i j k l o}
+    (P : forall {l Γ A}, [LogRel@{i j k l} l | Γ ||- A] -> Type@{o}) :
+
+    (forall l (Γ : context) A (h : [Γ ||-U<l> A]),
+     (forall X (RX : [Γ ||-< URedTy.level h > X ]), P RX) -> P (LRU_ h)) ->
+
+    (forall (l : TypeLevel) (Γ : context) (A : term) (neA : [Γ ||-ne A]),
+      P (LRne_ l neA)) ->
+
+    (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tProd Γ l A),
+      PolyHypTyUr P Γ ΠA (P (LRPi' ΠA))) ->
+
+    (forall l Γ A (NA : [Γ ||-Nat A]), P (LRNat_ l NA)) ->
+
+    (forall l Γ A (NA : [Γ ||-Empty A]), P (LREmpty_ l NA)) ->
+    
+    (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
+      PolyHypTyUr P Γ ΠA (P (LRSig' ΠA))) ->
+    
+    (forall l Γ A (IA :  [Γ ||-Id<l> A]), P (IA.(IdRedTy.tyRed)) -> P (LRId' IA)) ->
+
+    forall (l : TypeLevel) (Γ : context) (A : term) (lr : [LogRel@{i j k l} l | Γ ||- A]),
+      P lr.
+  Proof.
+    intros HU Hne HPi HNat HEmpty HSig HId.
+    apply LR_rect_TyUr; tea; intros l Γ A h ; pose proof (x :=URedTy.lt h); inversion x ; subst.
+    eapply HU. rewrite <- H0. clear h H0 x. revert Γ. eapply LR_rect_TyUr0; auto.
   Defined.
 
 End Inductions.
@@ -190,6 +261,7 @@ Section Inversions.
     | NatType => [Γ ||-Nat A]
     | EmptyType => [Γ ||-Empty A]
     | SigType => [Γ ||-Σ<l> A]
+    | IdType => [Γ||-Id<l> A]
     | NeType _ => [Γ ||-ne A]
     end.
 
@@ -254,6 +326,12 @@ Section Inversions.
         eapply whred_det.
         1-3: gen_typing.
         eapply redty_red, redA.
+    - intros ??? IA _ A' red whA'.
+      enough (∑ B x y, A' = tId B x y) as [?[?[? ->]]].
+      + dependent inversion whA'; tea; inv_whne.
+      + destruct IA; do 3 eexists; eapply whred_det.
+        1-3: gen_typing.
+        now eapply redtywf_red.
   Qed.
 
   Lemma invLRU {Γ l} : [Γ ||-<l> U] -> [Γ ||-U<l> U].
@@ -278,6 +356,12 @@ Section Inversions.
   Proof.
     intros.
     now unshelve eapply  (invLR _ redIdAlg SigType).
+  Qed.
+
+  Lemma invLRId {Γ l A x y} : [Γ ||-<l> tId A x y] -> [Γ ||-Id<l> tId A x y].
+  Proof.
+    intros.
+    now unshelve eapply (invLR _ redIdAlg IdType).
   Qed.
 
   (* invLRNat is useless *)

--- a/theories/LogicalRelation/Induction.v
+++ b/theories/LogicalRelation/Induction.v
@@ -156,7 +156,7 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     1,2,4,5: auto.
     - intros; eapply (HPi _ _ _ (ParamRedTy.from HAad)); eauto.
     - intros; eapply (HSig _ _ _ (ParamRedTy.from HAad)); eauto.
-    - intros. eapply (HId _ _ _ (IdRedTy.from IAad)). ; eauto.
+    - intros; eapply (HId _ _ _ (IdRedTy.from IAad)) ; eauto.
   Defined.
 
   Notation PolyHypTyUr P Γ ΠA G :=
@@ -184,7 +184,11 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
       PolyHypTyUr P Γ ΠA (P (LRSig' ΠA))) ->
     
-    (forall l Γ A (IA :  [Γ ||-Id<l> A]), P (IA.(IdRedTy.tyRed)) -> P (LRId' IA)) ->
+    (forall l Γ A (IA :  [Γ ||-Id<l> A]), 
+      P (IA.(IdRedTy.tyRed)) -> 
+      (forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), P (IA.(IdRedTy.tyKripke) ρ wfΔ)) ->
+      
+      P (LRId' IA)) ->
 
     forall (l : TypeLevel) (Γ : context) (A : term) (lr : [LogRel@{i j k l} l | Γ ||- A]),
       P lr.
@@ -211,7 +215,10 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     (forall (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
       PolyHypTyUr P Γ ΠA (P (LRSig' ΠA))) ->
     
-    (forall Γ A (IA :  [Γ ||-Id<l> A]), P (IA.(IdRedTy.tyRed)) -> P (LRId' IA)) ->
+    (forall Γ A (IA :  [Γ ||-Id<l> A]), 
+      P (IA.(IdRedTy.tyRed)) ->
+      (forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), P (IA.(IdRedTy.tyKripke) ρ wfΔ)) ->
+      P (LRId' IA)) ->
 
     forall (Γ : context) (A : term) (lr : [LogRel@{i j k l} l | Γ ||- A]),
       P lr.
@@ -244,7 +251,10 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
       PolyHypTyUr P Γ ΠA (P (LRSig' ΠA))) ->
     
-    (forall l Γ A (IA :  [Γ ||-Id<l> A]), P (IA.(IdRedTy.tyRed)) -> P (LRId' IA)) ->
+    (forall l Γ A (IA :  [Γ ||-Id<l> A]),
+       P (IA.(IdRedTy.tyRed)) -> 
+      (forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), P (IA.(IdRedTy.tyKripke) ρ wfΔ)) ->
+      P (LRId' IA)) ->
 
     forall (l : TypeLevel) (Γ : context) (A : term) (lr : [LogRel@{i j k l} l | Γ ||- A]),
       P lr.
@@ -337,7 +347,7 @@ Section Inversions.
         eapply whred_det.
         1-3: gen_typing.
         eapply redty_red, redA.
-    - intros ??? IA _ A' red whA'.
+    - intros ??? IA _ _ A' red whA'.
       enough (∑ B x y, A' = tId B x y) as [?[?[? ->]]].
       + dependent inversion whA'; tea; inv_whne.
       + destruct IA; do 3 eexists; eapply whred_det.

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -518,9 +518,10 @@ Proof.
     pose (IA := IdRedTy.from IAad); pose (IA' := IdRedTy.from IAad').
     assert (IA'.(IdRedTy.outTy) = he.(IdRedTyEq.outTy)) as eId.
     1: eapply whredty_det; constructor; try constructor; [apply IA'.(IdRedTy.red)| apply he.(IdRedTyEq.red)].
-    inversion eId; destruct he, IAP'; cbn in *; subst; clear eId.
+    inversion eId; destruct he, IAP'; cbn in *. subst; clear eId.
     eapply (IdIrrelevanceLRPack IA IA'); tea.
-    now eapply IHPar.
+    eapply IHPar; tea.
+    apply IA'.(IdRedTy.tyRed).
 Qed.
 
 
@@ -587,13 +588,17 @@ Proof.
     unshelve eapply LRIrrelevantCumPolyRed; tea.
     + intros; now eapply IHdom.
     + intros; now eapply IHcod.
-  - intros [] IHPar IH. specialize (IHPar IH).
+  - intros [] IHPar IHKripke IH. 
+    specialize (IHPar IH). pose (IHK Δ ρ wfΔ := IHKripke Δ ρ wfΔ IH).
     cbn in *; eapply LRId'.
     assert (eqv: equivLRPack tyRed IHPar).
     1: eapply LRIrrelevantPreds; tea; try eapply reflLRTyEq; now eapply LRAd.adequate.
+    assert (eqvK : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]), equivLRPack (tyKripke Δ ρ wfΔ) (IHK Δ ρ wfΔ)).
+    1: intros; eapply LRIrrelevantPreds; tea; try eapply reflLRTyEq; now eapply LRAd.adequate.
     unshelve econstructor.
-    4-6: tea.
+    4-7: tea.
     1-4: now apply eqv.
+    2-4: intros * ? ?%eqvK; apply eqvK; eauto.
     econstructor.
     + intros ?? ?%eqv; apply eqv; now symmetry.
     + intros ??? ?%eqv ?%eqv; apply eqv; now etransitivity.
@@ -907,7 +912,7 @@ Proof.
       eapply LRTmEqRedConv.
       2: eapply eqSnd.
       now eapply PolyRed.posExt.
-  - intros ??? [] ??? [????? hprop]; unshelve econstructor; unfold_id_outTy; cbn in *.
+  - intros ??? [] ???? [????? hprop]; unshelve econstructor; unfold_id_outTy; cbn in *.
     3,4: tea.
     1: now symmetry.
     destruct hprop; econstructor; tea.

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -227,6 +227,7 @@ Section IdIrrelevance.
     (RA' := LRId' IA')
     (eqId : [Γ |- IA.(IdRedTy.outTy) ≅ IA'.(IdRedTy.outTy)])
     (eqv : equivLRPack@{k k' v} IA.(IdRedTy.tyRed) IA'.(IdRedTy.tyRed))
+    (* (eqty : [Γ |- IA.(IdRedTy.ty) ≅  IA'.(IdRedTy.ty)]) *)
     (lhsconv : [IA.(IdRedTy.tyRed) | Γ ||- IA.(IdRedTy.lhs) ≅  IA'.(IdRedTy.lhs) : _ ])
     (rhsconv : [IA.(IdRedTy.tyRed) | Γ ||- IA.(IdRedTy.rhs) ≅  IA'.(IdRedTy.rhs) : _]).
 
@@ -522,6 +523,7 @@ Proof.
     eapply (IdIrrelevanceLRPack IA IA'); tea.
     eapply IHPar; tea.
     apply IA'.(IdRedTy.tyRed).
+    (* unshelve eapply escapeEq.  2: apply IdRedTy.tyRed.  now cbn. *)
 Qed.
 
 

--- a/theories/LogicalRelation/Neutral.v
+++ b/theories/LogicalRelation/Neutral.v
@@ -144,7 +144,7 @@ intros l Γ A ΠA0 ihdom ihcod; split.
     * intros; apply complete_reflect_simpl; [apply ihcod| |..].
       1: escape ; now eapply ty_app_ren.
       eapply convneu_app_ren. 1,2: eassumption.
-      eapply LREqTermRefl_ in ha.
+      eapply reflLRTmEq in ha.
       now escape.
     * intros. apply ihcod.
       + apply escapeTerm in ha; now eapply ty_app_ren.
@@ -164,7 +164,7 @@ intros l Γ A ΠA0 ihdom ihcod; split.
     + apply escapeTerm in ha; now eapply ty_app_ren.
     + apply escapeTerm in ha; now eapply ty_app_ren.
     + eapply convneu_app_ren. 1,2: eassumption.
-    eapply escapeEqTerm; eapply LREqTermRefl_; eassumption.
+    eapply escapeEqTerm; eapply reflLRTmEq; eassumption.
 Qed.
 
 Arguments ParamRedTy.outTy /.
@@ -314,7 +314,7 @@ Proof.
   apply var0conv.
   rewrite eq.
   unshelve eapply escapeEq; tea.
-  eapply LRTyEqRefl_.
+  eapply reflLRTyEq.
 Qed.
 
 End Neutral.

--- a/theories/LogicalRelation/Neutral.v
+++ b/theories/LogicalRelation/Neutral.v
@@ -269,6 +269,19 @@ Proof.
     all: try first [assumption|now eapply lrefl].
 Qed.
 
+Lemma complete_Id {l Γ A} (IA : [Γ ||-Id<l> A]) :
+  complete (LRId' IA).
+Proof.
+  split; intros.
+  assert [Γ |- A ≅ IA.(IdRedTy.outTy)] by (destruct IA; unfold IdRedTy.outTy; cbn; gen_typing).
+  assert [Γ |- n : IA.(IdRedTy.outTy)] by now eapply ty_conv.
+  split; econstructor.
+  1,4,5: eapply redtmwf_refl; tea; now eapply ty_conv.
+  2,4: do 2 constructor; tea.
+  1,4: eapply convtm_convneu.
+  all: eapply convneu_conv; tea; now eapply lrefl.
+Qed.
+
 Lemma completeness {l Γ A} (RA : [Γ ||-<l> A]) : complete RA.
 Proof.
 revert l Γ A RA; eapply LR_rect_TyUr; cbn; intros.
@@ -278,6 +291,7 @@ revert l Γ A RA; eapply LR_rect_TyUr; cbn; intros.
 - now apply complete_Nat.
 - now apply complete_Empty.
 - now apply complete_Sig.
+- now apply complete_Id.
 Qed.
 
 Lemma neuTerm {l Γ A} (RA : [Γ ||-<l> A]) {n} :

--- a/theories/LogicalRelation/NormalRed.v
+++ b/theories/LogicalRelation/NormalRed.v
@@ -93,6 +93,7 @@ Definition invLRcan {Γ l A} (lr : [Γ ||-<l> A]) (w : isType A) : [Γ ||-<l> A]
   | NatType => fun _ x => LRNat_ _ x
   | EmptyType => fun _ x => LREmpty_  _ x
   | SigType => fun _ x => LRSig' (normRedΣ0 x)
+  | IdType => fun _ x => LRId' x
   | NeType wh => fun _ x => LRne_ _ (normRedNe0 x wh)
   end lr (invLR lr (reflexivity A) w).
   

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -28,7 +28,7 @@ Proof.
     + apply LRPi'; unshelve eexists dom cod; tea; etransitivity; tea.
       constructor; tea; gen_typing.
     + unshelve eexists dom cod; tea; cbn.
-      unshelve econstructor;intros; apply LRTyEqRefl_.
+      unshelve econstructor;intros; apply reflLRTyEq.
   - intros B [red] A ?; unshelve eexists.
     + apply LRNat_; constructor; tea; etransitivity; tea.
       constructor; tea; gen_typing.
@@ -41,7 +41,7 @@ Proof.
     + apply LRSig'; unshelve eexists dom cod; tea; etransitivity; tea.
       constructor; tea; gen_typing.
     + unshelve eexists dom cod; tea; cbn.
-      unshelve econstructor;intros; apply LRTyEqRefl_.
+      unshelve econstructor;intros; apply reflLRTyEq.
 Qed.
 
 
@@ -95,7 +95,7 @@ Proof.
     1: exists f; tea; constructor; destruct red; tea; etransitivity; tea.
     split; tea; exists rt ru; tea.
     intros; cbn. apply eq; tea.
-    now apply LREqTermRefl_.
+    now apply reflLRTmEq.
   - intros ? NA t ? Ru red; inversion Ru; subst.
     assert [Γ |- A ≅ tNat] by (destruct NA; gen_typing).
     assert [Γ |- t :⇒*: nf : tNat]. 1:{
@@ -126,7 +126,7 @@ Proof.
     assert [Γ |-[ ta ] t : PA.(outTy)] by (eapply ty_conv; gen_typing).
     unshelve refine (let rt : [LRSig' PA | Γ ||- t : A] := _ in _).
     1: unshelve eexists p _; tea; constructor; destruct red; tea; etransitivity; tea.
-    split; tea; exists rt ru; tea; intros; cbn; now apply LREqTermRefl_.
+    split; tea; exists rt ru; tea; intros; cbn; now apply reflLRTmEq.
 Qed.
 
 Lemma redSubstTerm' {Γ A t u l} (RA : [Γ ||-<l> A]) :

--- a/theories/LogicalRelation/ShapeView.v
+++ b/theories/LogicalRelation/ShapeView.v
@@ -23,6 +23,7 @@ Section ShapeViews.
       | LRNat _ _, LRNat _ _ => True
       | LREmpty _ _, LREmpty _ _ => True
       | LRSig _ _ _, LRSig _ _ _ => True
+      | LRId _ _ _, LRId _ _ _ => True
       | _, _ => False
     end.
 
@@ -56,6 +57,7 @@ when showing symmetry or transitivity of the logical relation. *)
     pattern lA, Γ, A, eqTyA, redTmA, eqTmA, lrA.
     eapply LR_rect_LogRelRec@{i j k l k}; intros ??? [].
     3,6: intros ??.
+    7: intros ?.
     all: intros []; eexists; split; tea; constructor; tea.
     eapply convneu_whne; now symmetry.
   Defined.
@@ -77,14 +79,15 @@ when showing symmetry or transitivity of the logical relation. *)
   Qed.
 
 (** ** More properties *)
+(* KM: looks like it is not used anywhere anymore *)
 
+(*
   Corollary ShapeViewRefl@{i j k l i' j' k' l'} {Γ A lA eqTyA redTmA eqTmA lA' eqTyA' redTmA' eqTmA'}
     (lrA : LogRel@{i j k l} lA Γ A eqTyA redTmA eqTmA) (lrA' : LogRel@{i' j' k' l'} lA' Γ A eqTyA' redTmA' eqTmA') :
     ShapeView@{i j k l i' j' k' l'} Γ A A lrA lrA'.
   Proof.
     now eapply ShapeViewConv, LRTyEqRefl.
   Qed.
-
 
   Definition ShapeView3 Γ
     A {lA eqTyA redTmA redTyA}
@@ -101,6 +104,7 @@ when showing symmetry or transitivity of the logical relation. *)
       | LRNat _ _, LRNat _ _, LRNat _ _ => True
       | LREmpty _ _, LREmpty _ _, LREmpty _ _ => True
       | LRSig _ _ _, LRSig _ _ _, LRSig _ _ _ => True
+      | LRId _ _ _, LRId _ _ _, LRId _ _ _ => True
       | _, _, _ => False
     end.
 
@@ -117,5 +121,5 @@ when showing symmetry or transitivity of the logical relation. *)
     (lrC : LogRel lC Γ C eqTyC redTmC redTyC) :
     ShapeView Γ A B lrA lrB -> ShapeView Γ B C lrB lrC -> ShapeView3 Γ A B C lrA lrB lrC.
   Proof.  destruct lrA, lrB, lrC; easy. Qed.
-
+*)
 End ShapeViews.

--- a/theories/LogicalRelation/ShapeView.v
+++ b/theories/LogicalRelation/ShapeView.v
@@ -56,8 +56,7 @@ when showing symmetry or transitivity of the logical relation. *)
   Proof.
     pattern lA, Γ, A, eqTyA, redTmA, eqTmA, lrA.
     eapply LR_rect_LogRelRec@{i j k l k}; intros ??? [].
-    3,6: intros ??.
-    7: intros ?.
+    3,6,7: intros ??.
     all: intros []; eexists; split; tea; constructor; tea.
     eapply convneu_whne; now symmetry.
   Defined.
@@ -70,10 +69,9 @@ when showing symmetry or transitivity of the logical relation. *)
     intros eqAB.
     pose (x := eqTy_red_whnf lrA eqAB).
     pose (y:= red_whnf lrB).
-    pose proof (h := redtywf_det _ _ _ _ (snd x.π2) (snd y.π2) (fst x.π2) (fst y.π2)).
+    pose proof (h := redtywf_det (snd x.π2) (snd y.π2) (fst x.π2) (fst y.π2)).
     revert eqAB x y h. 
     destruct lrA; destruct lrB; intros []; cbn; try easy; try discriminate.
-
     all: try now (intros e; destruct neA as [? ? ne]; subst; apply convneu_whne in ne; inversion ne).
     all: try now (intros e; subst; symmetry in eq; apply convneu_whne in eq; inversion eq).
   Qed.

--- a/theories/LogicalRelation/SimpleArr.v
+++ b/theories/LogicalRelation/SimpleArr.v
@@ -30,7 +30,7 @@ Section SimpleArrow.
     - eapply redtywf_refl.
       now eapply wft_simple_arr.
     - eapply convty_simple_arr; tea.
-      all: now unshelve eapply escapeEq, LRTyEqRefl_.
+      all: now unshelve eapply escapeEq, reflLRTyEq.
     - now eapply shiftPolyRed.
   Qed.
 
@@ -122,7 +122,7 @@ Section SimpleArrow.
     [Γ ||-<l> idterm A : arr A A | ArrRedTy RA RA].
   Proof.
     normRedΠ ΠAA.
-    pose proof (LRTyEqRefl_ RA).
+    pose proof (reflLRTyEq RA).
     escape.
     assert (h : forall Δ a (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) RA (ha : [Δ ||-<l> a : A⟨ρ⟩ | RA]),
       [Δ ||-<l> tApp (idterm A)⟨ρ⟩ a : A⟨ρ⟩| RA] ×
@@ -250,7 +250,7 @@ Section SimpleArrow.
     1:{
       intros.
       eapply simple_appcongTerm; [| | |eapply simple_appcongTerm; tea].
-      1,4: eapply LREqTermRefl_; eapply wkRedArr; irrelevance.
+      1,4: eapply reflLRTmEq; eapply wkRedArr; irrelevance.
       1,2: eapply simple_appTerm; tea; eapply wkRedArr; irrelevance.
       Unshelve. 1: eapply wk. all: tea.
     }
@@ -279,7 +279,7 @@ Section SimpleArrow.
     - cbn. eapply convtm_comp; cycle 3; tea.
       erewrite <- wk1_ren_on.
       eapply escapeEqTerm.
-      eapply LREqTermRefl_.
+      eapply reflLRTmEq.
       do 2 erewrite <- wk1_ren_on.
       eapply h.
       eapply var0; now bsimpl.

--- a/theories/LogicalRelation/SimpleArr.v
+++ b/theories/LogicalRelation/SimpleArr.v
@@ -17,7 +17,7 @@ Section SimpleArrow.
     - renToWk; eapply wft_wk; gen_typing.
     - intros; irrelevance0.
       2: replace (subst_term _ _) with B⟨ρ⟩.
-      2: eapply wkEq, LRTyEqRefl_.
+      2: eapply wkEq, reflLRTyEq.
       all: bsimpl; now rewrite rinstInst'_term.
       Unshelve. all: tea.
   Qed.

--- a/theories/LogicalRelation/Transitivity.v
+++ b/theories/LogicalRelation/Transitivity.v
@@ -1,6 +1,6 @@
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Notations Utils BasicAst Context NormalForms Weakening GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction ShapeView Reflexivity Irrelevance.
+From LogRel.LogicalRelation Require Import Induction ShapeView Reflexivity.
 
 Set Universe Polymorphism.
 
@@ -11,15 +11,15 @@ Set Printing Primitive Projection Parameters.
 
 Set Printing Universes.
 
-Lemma transEq@{i j k l} {Γ A B C lA lB} 
+(* Lemma transEq@{i j k l} {Γ A B C lA lB} 
   {RA : [LogRel@{i j k l} lA | Γ ||- A]}
   {RB : [LogRel@{i j k l} lB | Γ ||- B]}
   (RAB : [Γ ||-<lA> A ≅ B | RA])
    (RBC : [Γ ||-<lB> B ≅ C | RB]) :
   [Γ ||-<lA> A ≅ C | RA].
-Proof. now eapply LRTransEq. Qed.
+Proof. now eapply LRTransEq. Qed. *)
 
-Lemma transEqTermU@{h i j k} {Γ l UU t u v} {h : [Γ ||-U<l> UU]} :
+(* Lemma transEqTermU@{h i j k} {Γ l UU t u v} {h : [Γ ||-U<l> UU]} :
   [LogRelRec@{i j k} l | Γ ||-U t ≅ u : UU| h] ->
   [LogRelRec@{i j k} l | Γ ||-U u ≅ v : UU| h] ->
   [LogRelRec@{i j k} l | Γ ||-U t ≅ v : UU| h].
@@ -30,7 +30,7 @@ Proof.
     all: apply isType_whnf; apply URedTm.type.
   + apply TyEqRecFwd; unshelve eapply transEq@{h i j k}.
     4,5: now apply (TyEqRecFwd h). 
-Qed.
+Qed. *)
 
 Lemma transEqTermNeu {Γ A t u v} {RA : [Γ ||-ne A]} :
   [Γ ||-ne t ≅ u : A | RA] ->
@@ -89,7 +89,8 @@ Proof.
   + etransitivity; tea. now rewrite e.
   + intros; eapply ihdom ; [eapply eqfst| rewrite e; eapply eqfst'].
   + intros; eapply ihcod; [eapply eqsnd|].
-    rewrite e. eapply LRTmEqRedConv.
+    rewrite e. 
+    eapply LRTmEqRedConv.
     2: eapply eqsnd'.
     eapply PolyRed.posExt.
     1: eapply (SigRedTm.fstRed tL).

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -1,7 +1,7 @@
 From Coq Require Import ssrbool.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Notations Utils BasicAst Context NormalForms UntypedValues Weakening GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Irrelevance.
+From LogRel.LogicalRelation Require Import Induction Irrelevance Transitivity Escape.
 
 Set Universe Polymorphism.
 
@@ -58,6 +58,39 @@ Section Weakenings.
     gen_typing. 
   Qed.
 
+  Lemma wkId@{i j k l} {Γ l A Δ} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) :
+    IdRedTy@{i j k l} Γ l A -> IdRedTy@{i j k l} Δ l A⟨ρ⟩.
+    (* [Γ ||-Id<l> A] -> [Δ ||-Id<l> A⟨ρ⟩]. *)
+  Proof. 
+    intros []; unshelve econstructor.
+    6: erewrite wk_Id; now eapply redtywf_wk.
+    3: rewrite wk_Id; gen_typing.
+    - now apply tyKripke.
+    - intros; rewrite wk_comp_ren_on; now apply tyKripke.
+    - unshelve eapply tyKripkeTm; [eapply wk_id| gen_typing| now rewrite wk_comp_runit| irrelevance].
+    - unshelve eapply tyKripkeTm; [eapply wk_id| gen_typing| now rewrite wk_comp_runit| irrelevance].
+    (* could also employ reflexivity instead *)
+    - unshelve eapply tyKripkeTmEq; [eapply wk_id| gen_typing| now rewrite wk_comp_runit|irrelevance].
+    - unshelve eapply tyKripkeTmEq; [eapply wk_id| gen_typing| now rewrite wk_comp_runit|irrelevance].
+    - apply perLRTmEq.
+    - intros; irrelevance0.  
+      1: now rewrite wk_comp_ren_on.
+      unshelve eapply tyKripkeEq; tea.
+      3: irrelevance; now rewrite wk_comp_ren_on.
+      bsimpl; setoid_rewrite H10; now bsimpl.
+    - intros; irrelevance0.  
+      1: now rewrite wk_comp_ren_on.
+      unshelve eapply tyKripkeTm; tea.
+      3: irrelevance; now rewrite wk_comp_ren_on.
+      bsimpl; setoid_rewrite H10; now bsimpl.
+    - intros; irrelevance0.  
+      1: now rewrite wk_comp_ren_on.
+      unshelve eapply tyKripkeTmEq; tea.
+      3: irrelevance; now rewrite wk_comp_ren_on.
+      bsimpl; setoid_rewrite H10; now bsimpl.
+  Defined.
+
+
   Lemma wk@{i j k l} {Γ Δ A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) :
     [LogRel@{i j k l} l | Γ ||- A] -> [LogRel@{i j k l} l | Δ ||- A⟨ρ⟩].
   Proof.
@@ -72,6 +105,7 @@ Section Weakenings.
     - intros; eapply LRNat_; now eapply wkNat.
     - intros; eapply LREmpty_; now eapply wkEmpty.
     - intros; apply LRSig'; now eapply wkΣ.
+    - intros; apply LRId'; now eapply wkId.
   Defined.
 
   (* Sanity checks for Π and Σ: we do compute correctly with wk *)
@@ -100,6 +134,7 @@ Section Weakenings.
       now bsimpl.
   Qed.
 
+
   Lemma wkEq@{i j k l} {Γ Δ A B l} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (lrA : [Γ ||-<l> A]) : 
     [LogRel@{i j k l} l | Γ ||- A ≅ B | lrA] ->
     [LogRel@{i j k l} l | Δ ||- A⟨ρ⟩ ≅ B⟨ρ⟩ | wk ρ wfΔ lrA].
@@ -127,6 +162,12 @@ Section Weakenings.
       + rewrite wk_sig.
         replace (tSig _ _) with (ΠA.(outTy)⟨ρ⟩) by (cbn; now bsimpl).
         now eapply convty_wk.
+    - intros * _ _ * [] ; assert [|-Γ] by (escape; gen_typing); econstructor; cbn.
+      1: erewrite wk_Id; now eapply redtywf_wk.
+      1: unfold_id_outTy; cbn; rewrite 2!wk_Id; now eapply convty_wk.
+      2,3: eapply IA.(IdRedTy.tyKripkeTmEq); [now rewrite wk_comp_runit| irrelevance].
+      eapply IA.(IdRedTy.tyKripkeEq); [now rewrite wk_comp_runit| irrelevance].
+      Unshelve. all: tea.
   Qed.
 
   (* TODO: use program or equivalent to have only the first field non-opaque *)
@@ -213,6 +254,15 @@ Section Weakenings.
         change tEmpty with tEmpty⟨ρ⟩.
         now eapply wkNeNf.
     - intros; now apply wkΣTerm. 
+    - intros * _ _ * [??? prop]; econstructor; unfold_id_outTy; cbn; rewrite ?wk_Id.
+      1: now eapply redtmwf_wk.
+      1: now eapply convtm_wk.
+      destruct prop.
+      2: constructor; unfold_id_outTy; cbn; rewrite wk_Id; now eapply wkNeNf.
+      assert [|-Γ] by (escape; gen_typing); constructor; cbn.
+      2,3: eapply IA.(IdRedTy.tyKripkeTmEq); [now rewrite wk_comp_runit| irrelevance].
+      eapply IA.(IdRedTy.tyKripkeEq); [now rewrite wk_comp_runit| irrelevance].
+      Unshelve. all: tea.
   Qed.
 
   Lemma wkUTerm {Γ Δ l A t} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (h : [Γ ||-U<l> A]) :
@@ -290,5 +340,14 @@ Section Weakenings.
       + intros; cbn; irrelevance0.
         2: do 2 rewrite wk_comp_ren_on; now unshelve eapply eqSnd.
         rewrite wk_comp_ren_on; now rewrite <- wk_up_ren_subst.
+    - intros * _ _ * [????? prop]; econstructor; unfold_id_outTy; cbn; rewrite ?wk_Id.
+      1,2: now eapply redtmwf_wk.
+      1: now eapply convtm_wk.
+      destruct prop.
+      2: constructor; unfold_id_outTy; cbn; rewrite wk_Id; now eapply wkNeNfEq.
+      assert [|-Γ] by (escape; gen_typing); constructor; cbn.
+      1,2:eapply IA.(IdRedTy.tyKripkeEq); [now rewrite wk_comp_runit| irrelevance].
+      all: eapply IA.(IdRedTy.tyKripkeTmEq); [now rewrite wk_comp_runit| irrelevance].
+      Unshelve. all: tea.
   Qed.
 End Weakenings.

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -260,6 +260,8 @@ Section Weakenings.
       destruct prop.
       2: constructor; unfold_id_outTy; cbn; rewrite wk_Id; now eapply wkNeNf.
       assert [|-Γ] by (escape; gen_typing); constructor; cbn.
+      1: now eapply wft_wk.
+      1: now eapply ty_wk.
       2,3: eapply IA.(IdRedTy.tyKripkeTmEq); [now rewrite wk_comp_runit| irrelevance].
       eapply IA.(IdRedTy.tyKripkeEq); [now rewrite wk_comp_runit| irrelevance].
       Unshelve. all: tea.
@@ -346,6 +348,8 @@ Section Weakenings.
       destruct prop.
       2: constructor; unfold_id_outTy; cbn; rewrite wk_Id; now eapply wkNeNfEq.
       assert [|-Γ] by (escape; gen_typing); constructor; cbn.
+      1,2: now eapply wft_wk.
+      1,2: now eapply ty_wk.
       1,2:eapply IA.(IdRedTy.tyKripkeEq); [now rewrite wk_comp_runit| irrelevance].
       all: eapply IA.(IdRedTy.tyKripkeTmEq); [now rewrite wk_comp_runit| irrelevance].
       Unshelve. all: tea.

--- a/theories/NormalForms.v
+++ b/theories/NormalForms.v
@@ -60,6 +60,7 @@ Inductive isType : term -> Type :=
   | NatType : isType tNat
   | EmptyType : isType tEmpty
   | SigType {A B} : isType (tSig A B)
+  | IdType {A x y} : isType (tId A x y)
   | NeType {A}  : whne A -> isType A.
 
 Inductive isPosType : term -> Type :=

--- a/theories/NormalForms.v
+++ b/theories/NormalForms.v
@@ -124,6 +124,8 @@ Inductive isCanonical : term -> Type :=
   | can_tSucc {n} : isCanonical (tSucc n)
   | can_tEmpty : isCanonical tEmpty
   | can_tSig {A B} : isCanonical (tSig A B)
-  | can_tPair {A B a b}: isCanonical (tPair A B a b).
+  | can_tPair {A B a b}: isCanonical (tPair A B a b)
+  | can_tId {A x y}: isCanonical (tId A x y)
+  | can_tRefl {A x}: isCanonical (tRefl A x).
 
 #[global] Hint Constructors isCanonical : gen_typing.

--- a/theories/NormalForms.v
+++ b/theories/NormalForms.v
@@ -67,6 +67,7 @@ Inductive isPosType : term -> Type :=
   | UnivPos {s} : isPosType (tSort s)
   | NatPos : isPosType tNat
   | EmptyPos : isPosType tEmpty
+  | IdPos {A x y} : isPosType (tId A x y)
   | NePos {A}  : whne A -> isPosType A.
 
 Inductive isFun : term -> Type :=

--- a/theories/NormalForms.v
+++ b/theories/NormalForms.v
@@ -15,6 +15,8 @@ Inductive whnf : term -> Type :=
   | whnf_tEmpty : whnf tEmpty
   | whnf_tSig {A B} : whnf (tSig A B)
   | whnf_tPair {A B a b} : whnf (tPair A B a b)
+  | whnf_tId {A x y} : whnf (tId A x y)
+  | whnf_tRefl {A x} : whnf (tRefl A x)
   | whnf_whne {n} : whne n -> whnf n
 with whne : term -> Type :=
   | whne_tRel {v} : whne (tRel v)
@@ -22,7 +24,8 @@ with whne : term -> Type :=
   | whne_tNatElim {P hz hs n} : whne n -> whne (tNatElim P hz hs n)
   | whne_tEmptyElim {P e} : whne e -> whne (tEmptyElim P e)
   | whne_tFst {p} : whne p -> whne (tFst p)
-  | whne_tSnd {p} : whne p -> whne (tSnd p).
+  | whne_tSnd {p} : whne p -> whne (tSnd p)
+  | whne_tIdElim {A x P hr y e} : whne e -> whne (tIdElim A x P hr y e).
 
 #[global] Hint Constructors whne whnf : gen_typing.
 

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -308,7 +308,7 @@ Section NeutralConversion.
       1: eapply redtywf_refl; eapply (ParamRedTy.red ΣA).
       econstructor; tea;
       eapply LogicalRelation.Escape.escapeEq;
-      eapply LRTyEqRefl_.
+      eapply reflLRTyEq.
     }
     assert [Γ |-[ de ] tFst m : (ParamRedTy.dom ΣA)⟨@wk_id Γ⟩].
     1: rewrite wk_id_ren_on; now econstructor.

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -337,8 +337,11 @@ Section NeutralConversion.
         split; tea; now econstructor.
       * rewrite Sigma.wk_id_shift; now econstructor.
     Unshelve. 2,4: tea.
-  - admit.
-  Admitted.
-  (* Qed. *)
+  - intros ??? [???? red] IH _ m n tym hconv; cbn in *.
+    econstructor.
+    1: apply red.
+    1,2: reflexivity.
+    econstructor; tea; constructor.
+  Qed.
 
 End NeutralConversion.

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -114,6 +114,7 @@ Proof.
 + intros * ? []; split; now constructor.
 + intros * []; split; now constructor.
 + intros * []; split; now constructor.
++ intros * ??????? []; split; now constructor.
 Qed.
 
 #[export, refine] Instance RedTermDeclProperties : RedTermProperties (ta := nf) := {}.
@@ -127,6 +128,7 @@ all: try now (intros; apply redalg_one_step; constructor).
 + intros; now apply redalg_natEmpty.
 + intros; now apply redalg_fst.
 + intros; now apply redalg_snd.
++ intros; now eapply redalg_idElim.
 + intros; assumption.
 + intros; reflexivity.
 Qed.
@@ -334,7 +336,9 @@ Section NeutralConversion.
         eapply neuTerm; tea.
         split; tea; now econstructor.
       * rewrite Sigma.wk_id_shift; now econstructor.
-    Unshelve. 2,4: tea. 
-  Qed.
+    Unshelve. 2,4: tea.
+  - admit.
+  Admitted.
+  (* Qed. *)
 
 End NeutralConversion.

--- a/theories/Notations.v
+++ b/theories/Notations.v
@@ -237,6 +237,12 @@ Reserved Notation "[ Γ ||-<0>  t : A | R ]" (at level 0, Γ, t, A, R at level 5
 (** The terms t and u are reducibly convertible at type A and level 0 in Γ, given the proof R that A is reducible *)
 Reserved Notation "[ Γ ||-<0> t ≅ u : A | R ]" (at level 0, Γ, t, u, A, R at level 50).
 
+(** Reducibility notations for identity types *)
+Reserved Notation "[ Γ ||-Id< l > A ]" (at level 0, Γ, l,  A at level 50).
+Reserved Notation "[ Γ ||-Id< l > A ≅ B | RA ]" (at level 0, Γ, l, A, B, RA at level 50).
+Reserved Notation "[ Γ ||-Id< l > t : A | RA ]" (at level 0, Γ, l, t, A, RA at level 50).
+Reserved Notation "[ Γ ||-Id< l > t ≅ u : A | RA ]" (at level 0, Γ, l, t, u, A, RA at level 50).
+
 
 
 

--- a/theories/Substitution/Conversion.v
+++ b/theories/Substitution/Conversion.v
@@ -1,6 +1,7 @@
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
 From LogRel.LogicalRelation Require Import Irrelevance Escape Reflexivity Weakening Neutral.
+From LogRel.Substitution Require Import Properties Irrelevance.
 
 Set Universe Polymorphism.
 
@@ -46,5 +47,277 @@ Proof.
   1: now unshelve now eapply validTyEq.
   now eapply validTmEq.
 Qed.
+
+
+Lemma convSubstCtx1 {Γ Δ A B l σ} 
+  (VΓ : [||-v Γ])
+  (wfΔ : [|- Δ])
+  (VΓA : [||-v Γ ,, A]) 
+  (VΓB : [||-v Γ ,, B]) 
+  (VA : [_ ||-v<l> A | VΓ])
+  (VB : [_ ||-v<l> B | VΓ])
+  (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
+  (Vσ : [_ ||-v σ : _ | VΓA | wfΔ]) :
+  [_ ||-v σ : _ | VΓB | wfΔ].
+Proof.
+  pose proof (invValiditySnoc VΓA) as [? [? [?]]]; subst.
+  pose proof (invValiditySnoc VΓB) as [? [? [?]]]; subst.
+  eapply irrelevanceSubstExt.
+  1: rewrite <- scons_eta'; reflexivity.
+  unshelve eapply consSubstS.
+  1: epose (validTail Vσ); irrValid.
+  eapply LRTmRedConv.
+  2: irrelevanceRefl; eapply validHead.
+  now eapply validTyEq.
+  Unshelve. 6: tea.
+    2: eapply irrelevanceSubst; now eapply validTail.
+    tea.
+Qed.
+
+Lemma convSubstEqCtx1 {Γ Δ A B l σ σ'} 
+  (VΓ : [||-v Γ])
+  (wfΔ : [|- Δ])
+  (VΓA : [||-v Γ ,, A]) 
+  (VΓB : [||-v Γ ,, B]) 
+  (VA : [_ ||-v<l> A | VΓ])
+  (VB : [_ ||-v<l> B | VΓ])
+  (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
+  (Vσ : [_ ||-v σ : _ | VΓA | wfΔ]) 
+  (Vσ' : [_ ||-v σ' : _ | VΓA | wfΔ]) 
+  (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA | wfΔ | Vσ]) 
+  (VσB : [_ ||-v σ : _ | VΓB | wfΔ]) :
+  [_ ||-v σ ≅ σ' : _ | VΓB | wfΔ | VσB].
+Proof.
+  pose proof (invValiditySnoc VΓA) as [? [? [?]]]; subst.
+  pose proof (invValiditySnoc VΓB) as [? [? [?]]]; subst.
+  eapply irrelevanceSubstEq.
+  eapply irrelevanceSubstEqExt.
+  1: rewrite <- scons_eta'; reflexivity.
+  unshelve eapply consSubstSEq'.
+  8: now eapply eqTail.
+  3: irrValid.
+  3: eapply LRTmEqRedConv.
+  4: now eapply eqHead.
+  2: irrelevanceRefl; eapply validTyEq; irrValid.
+  eapply LRTmRedConv.
+  2: irrelevanceRefl; eapply validHead.
+  eapply validTyExt.
+  1: now eapply validTail.
+  eapply reflSubst.
+  Unshelve.
+  1: now rewrite scons_eta'.
+  9: tea.
+  7: tea.
+  2,6: irrValid.
+  1,2: tea.
+  1,2: eapply irrelevanceSubst; now eapply validTail.
+Qed.
+
+
+Lemma convCtx1 {Γ A B P l} 
+  (VΓ : [||-v Γ])
+  (VΓA : [||-v Γ ,, A]) 
+  (VΓB : [||-v Γ ,, B]) 
+  (VA : [_ ||-v<l> A | VΓ])
+  (VB : [_ ||-v<l> B | VΓ])
+  (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
+  (VP : [_ ||-v<l> P | VΓA]) :
+  [_ ||-v<l> P | VΓB].
+Proof.
+  opector; intros.
+  - eapply validTy; tea; eapply convSubstCtx1; tea; now eapply symValidEq.
+  - irrelevanceRefl; unshelve eapply validTyExt.
+    3,4: tea. 
+    1,2:  eapply convSubstCtx1; tea; now eapply symValidEq.
+    eapply convSubstEqCtx1; cycle 2; tea; now eapply symValidEq.
+    Unshelve. all: tea.
+Qed.
+
+Lemma convEqCtx1 {Γ A B P Q l} 
+  (VΓ : [||-v Γ])
+  (VΓA : [||-v Γ ,, A]) 
+  (VΓB : [||-v Γ ,, B]) 
+  (VA : [_ ||-v<l> A | VΓ])
+  (VB : [_ ||-v<l> B | VΓ])
+  (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
+  (VP : [_ ||-v<l> P | VΓA])
+  (VPB : [_ ||-v<l> P | VΓB])
+  (VPQ : [_ ||-v<l> P ≅ Q | VΓA | VP]) :
+  [_ ||-v<l> P ≅ Q | VΓB | VPB].
+Proof.
+  constructor; intros; irrelevanceRefl.
+  eapply validTyEq; tea.
+  Unshelve. 1: tea. 
+  unshelve eapply convSubstCtx1; cycle 5; tea; now eapply symValidEq.
+Qed.
+
+Lemma convSubstCtx2 {Γ Δ A1 B1 A2 B2 l σ} 
+  (VΓ : [||-v Γ])
+  (wfΔ : [|- Δ])
+  (VA1 : [_ ||-v<l> A1 | VΓ])
+  (VB1 : [_ ||-v<l> B1 | VΓ])
+  (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
+  (VΓA1 := validSnoc VΓ VA1) 
+  (VΓB1 := validSnoc VΓ VB1) 
+  (VA2 : [_ ||-v<l> A2 | VΓA1])
+  (VB2 : [_ ||-v<l> B2 | VΓA1])
+  (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
+  (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VB1 VAB1 VB2)
+  (VΓA12 := validSnoc VΓA1 VA2) 
+  (VΓB12 := validSnoc VΓB1 VB2') 
+  (Vσ : [_ ||-v σ : _ | VΓA12 | wfΔ]) :
+  [_ ||-v σ : _ | VΓB12 | wfΔ].
+Proof.
+  eapply irrelevanceSubstExt.
+  1: rewrite <- scons_eta'; reflexivity.
+  unshelve eapply consSubstS.
+  + eapply convSubstCtx1; tea.
+    now eapply validTail.
+  + eapply LRTmRedConv.
+    2: now eapply validHead.
+    eapply validTyEq; tea.
+  Unshelve. all: tea.
+Qed.
+
+Lemma convSubstCtx2' {Γ Δ A1 B1 A2 B2 l σ} 
+  (VΓ : [||-v Γ])
+  (wfΔ : [|- Δ])
+  (VΓA1 : [||-v Γ ,, A1]) 
+  (VΓA12 : [||-v Γ ,, A1 ,, A2]) 
+  (VΓB12 : [||-v Γ ,, B1 ,, B2]) 
+  (VA1 : [_ ||-v<l> A1 | VΓ])
+  (VB1 : [_ ||-v<l> B1 | VΓ])
+  (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
+  (VA2 : [_ ||-v<l> A2 | VΓA1])
+  (VB2 : [_ ||-v<l> B2 | VΓA1])
+  (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
+  (Vσ : [_ ||-v σ : _ | VΓA12 | wfΔ]) :
+  [_ ||-v σ : _ | VΓB12 | wfΔ].
+Proof.
+  eapply irrelevanceSubst.
+  eapply convSubstCtx2; irrValid.
+  Unshelve. all: tea; irrValid.
+Qed.
+
+Lemma convSubstEqCtx2 {Γ Δ A1 B1 A2 B2 l σ σ'} 
+  (VΓ : [||-v Γ])
+  (wfΔ : [|- Δ])
+  (VA1 : [_ ||-v<l> A1 | VΓ])
+  (VB1 : [_ ||-v<l> B1 | VΓ])
+  (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
+  (VΓA1 := validSnoc VΓ VA1) 
+  (VΓB1 := validSnoc VΓ VB1) 
+  (VA2 : [_ ||-v<l> A2 | VΓA1])
+  (VB2 : [_ ||-v<l> B2 | VΓA1])
+  (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
+  (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VB1 VAB1 VB2)
+  (VΓA12 := validSnoc VΓA1 VA2) 
+  (VΓB12 := validSnoc VΓB1 VB2') 
+  (Vσ : [_ ||-v σ : _ | VΓA12 | wfΔ]) 
+  (Vσ' : [_ ||-v σ' : _ | VΓA12 | wfΔ]) 
+  (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA12 | wfΔ | Vσ]) 
+  (VσB : [_ ||-v σ : _ | VΓB12 | wfΔ]) :
+  [_ ||-v σ ≅ σ' : _ | VΓB12 | wfΔ | VσB].
+Proof.
+  eapply irrelevanceSubstEq.
+  eapply irrelevanceSubstEqExt.
+  1: rewrite <- scons_eta'; reflexivity.
+  unshelve eapply consSubstSEq'.
+  8:{ eapply convSubstEqCtx1; tea.
+    1: now eapply validTail.
+    now eapply eqTail.
+  }
+  3,4: irrValid.
+  2: eapply convSubstCtx1; tea; now eapply validTail. 
+  3: eapply LRTmEqRedConv.
+  4: now eapply eqHead.
+  2: irrelevanceRefl; eapply validTyEq; irrValid.
+  eapply LRTmRedConv.
+  2: irrelevanceRefl; eapply validHead.
+  eapply validTyExt.
+  1: now eapply validTail.
+  eapply reflSubst.
+  Unshelve.
+  1: now rewrite scons_eta'.
+  11: tea.
+  1,2,6: irrValid.
+  1: tea.
+  2: eapply convSubstCtx1; tea.
+  1,2: now eapply validTail.
+Qed. 
+
+Lemma convSubstEqCtx2' {Γ Δ A1 B1 A2 B2 l σ σ'} 
+  (VΓ : [||-v Γ])
+  (wfΔ : [|- Δ])
+  (VA1 : [_ ||-v<l> A1 | VΓ])
+  (VB1 : [_ ||-v<l> B1 | VΓ])
+  (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
+  (VΓA1 : [||-v Γ ,, A1]) 
+  (VΓB1 : [||-v Γ ,, B1]) 
+  (VA2 : [_ ||-v<l> A2 | VΓA1])
+  (VB2 : [_ ||-v<l> B2 | VΓA1])
+  (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
+  (VB2' : [_ ||-v<l> B2 | VΓB1])
+  (VΓA12 : [||-v Γ ,, A1 ,, A2]) 
+  (VΓB12 : [||-v Γ ,, B1,, B2]) 
+  (Vσ : [_ ||-v σ : _ | VΓA12 | wfΔ]) 
+  (Vσ' : [_ ||-v σ' : _ | VΓA12 | wfΔ]) 
+  (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA12 | wfΔ | Vσ]) 
+  (VσB : [_ ||-v σ : _ | VΓB12 | wfΔ]) :
+  [_ ||-v σ ≅ σ' : _ | VΓB12 | wfΔ | VσB].
+Proof.
+  eapply irrelevanceSubstEq.
+  eapply convSubstEqCtx2; irrValid.
+  Unshelve.  all: tea; irrValid.
+Qed.
+
+Lemma convCtx2 {Γ A1 B1 A2 B2 P l} 
+  (VΓ : [||-v Γ])
+  (VA1 : [_ ||-v<l> A1 | VΓ])
+  (VB1 : [_ ||-v<l> B1 | VΓ])
+  (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
+  (VΓA1 := validSnoc VΓ VA1) 
+  (VΓB1 := validSnoc VΓ VB1) 
+  (VA2 : [_ ||-v<l> A2 | VΓA1])
+  (VB2 : [_ ||-v<l> B2 | VΓA1])
+  (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
+  (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VB1 VAB1 VB2)
+  (VΓA12 := validSnoc VΓA1 VA2) 
+  (VΓB12 := validSnoc VΓB1 VB2') 
+  (VP : [_ ||-v<l> P | VΓA12]) :
+  [_ ||-v<l> P | VΓB12].
+Proof.
+  assert [_ ||-v<l> A2 | VΓB1] by now eapply convCtx1.
+  assert [_ ||-v<l> B1 ≅ A1 | _ | VB1] by now eapply symValidEq.
+  assert [_ ||-v<l> B2 ≅ A2 | _ | VB2'] by (eapply convEqCtx1; tea; now eapply symValidEq).
+  opector; intros.
+  - eapply validTy; tea; now eapply convSubstCtx2'.
+  - irrelevanceRefl; unshelve eapply validTyExt.
+    3,4: tea. 
+    1,2:  now eapply convSubstCtx2'.
+    eapply convSubstEqCtx2'; tea.
+    Unshelve. tea.
+Qed.
+
+Lemma convCtx2' {Γ A1 A2 B1 B2 P l} 
+  (VΓ : [||-v Γ])
+  (VA1 : [_ ||-v<l> A1 | VΓ])
+  (VB1 : [_ ||-v<l> B1 | VΓ])
+  (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
+  (VΓA1 : [||-v Γ ,, A1]) 
+  (VΓB1 : [||-v Γ ,, B1]) 
+  (VA2 : [_ ||-v<l> A2 | VΓA1])
+  (VB2 : [_ ||-v<l> B2 | VΓA1])
+  (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
+  (VB2' : [_ ||-v<l> B2 | VΓB1])
+  (VΓA12 : [||-v Γ ,, A1 ,, A2]) 
+  (VΓB12 : [||-v Γ ,, B1,, B2])
+  (VP : [_ ||-v<l> P | VΓA12]) :
+  [_ ||-v<l> P | VΓB12].
+Proof.
+  eapply irrelevanceValidity; eapply convCtx2; irrValid.
+  Unshelve. all: tea; irrValid.
+Qed.
+
 
 End Conversion.

--- a/theories/Substitution/Introductions/Empty.v
+++ b/theories/Substitution/Introductions/Empty.v
@@ -123,7 +123,7 @@ Section EmptyElimRed.
       + now eapply ty_emptyElim.
       + now eapply ty_emptyElim.
       + eapply convneu_emptyElim; tea.
-        { eapply escapeEq, LRTyEqRefl_. }
+        { eapply escapeEq, reflLRTyEq. }
     Unshelve. all: tea.
   Qed.
 
@@ -153,7 +153,7 @@ Section EmptyElimRedEq.
       [Γ ||-<l> P[n..] ≅ P[n'..] | RPpt _ Rn].
   Proof.
     intros. eapply transEq; [| eapply LRTyEqSym ]; eapply RPQext; cycle 1; tea.
-    now eapply LREqTermRefl_.
+    now eapply reflLRTmEq.
     Unshelve. 2,3: eauto.
   Qed.
 
@@ -167,7 +167,7 @@ Section EmptyElimRedEq.
   Proof.
     eapply emptyElimRedAux; tea.
     + intros. eapply transEq; [eapply LRTyEqSym |]; eapply RPQext; cycle 1; tea.
-      now eapply LREqTermRefl_.
+      now eapply reflLRTmEq.
     Unshelve. all:tea.
   Qed.
 

--- a/theories/Substitution/Introductions/Empty.v
+++ b/theories/Substitution/Introductions/Empty.v
@@ -189,9 +189,9 @@ Section EmptyElimRedEq.
       * eapply LRTmEqRedConv.
         + eapply RPext; tea. 
           eapply LRTmEqSym; eapply redwfSubstTerm; cycle 1; tea.
-        + unshelve erewrite (redtmwf_det _ _ _ _ _ _ _ _ (EmptyRedTm.red RL) redL); tea.
+        + unshelve erewrite (redtmwf_det _ _ (EmptyRedTm.red RL) redL); tea.
           1: dependent inversion RL; subst; cbn; now eapply EmptyProp_whnf.
-          unshelve erewrite (redtmwf_det _ _ _ _ _ _ _ _ (EmptyRedTm.red RR) redR); tea.
+          unshelve erewrite (redtmwf_det _ _ (EmptyRedTm.red RR) redR); tea.
           1: dependent inversion RR; subst; cbn; now eapply EmptyProp_whnf.
           now eapply ih.
         Unshelve. tea. 2, 4: tea. 

--- a/theories/Substitution/Introductions/Id.v
+++ b/theories/Substitution/Introductions/Id.v
@@ -1,0 +1,754 @@
+From LogRel.AutoSubst Require Import core unscoped Ast Extra.
+From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
+From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity Reduction Application Universe Id.
+From LogRel.Substitution Require Import Irrelevance Properties Conversion SingleSubst Reflexivity Reduction.
+From LogRel.Substitution.Introductions Require Import Universe Var.
+
+Set Universe Polymorphism.
+
+Section Id.
+Context `{GenericTypingProperties}.
+
+  Lemma IdValid {Γ l A x y} 
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vy : [_ ||-v<l> y : _ | _ | VA]) :
+    [_ ||-v<l> tId A x y | VΓ].
+  Proof.
+    unshelve econstructor; intros.
+    - instValid vσ; cbn; now eapply IdRed.
+    - instAllValid vσ vσ' vσσ'; eapply IdCongRed; refold; tea.
+      eapply wft_Id; now escape.
+  Qed.
+
+  Lemma IdCongValid {Γ l A A' x x' y y'}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (VA' : [_ ||-v<l> A' | VΓ]) 
+    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
+    (Vy' : [_ ||-v<l> y' : _ | _ | VA]) 
+    (Vyy' : [_ ||-v<l> y ≅ y' : _ | _ | VA]) 
+    (VId : [_ ||-v<l> tId A x y | VΓ]) :
+    [_ ||-v<l> tId A x y ≅ tId A' x' y' | VΓ | VId].
+  Proof.
+    constructor; intros.
+    instValid Vσ; eapply IdCongRed; refold; tea.
+    eapply wft_Id. 
+    2,3: eapply ty_conv.
+    all: now escape.
+  Qed.
+
+
+  Lemma IdTmValid {Γ l A x y} 
+    (VΓ : [||-v Γ]) 
+    (VU := UValid VΓ)
+    (VAU : [_ ||-v<one> A : U | VΓ | VU]) 
+    (VA := univValid VΓ VU VAU)
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vy : [_ ||-v<l> y : _ | _ | VA]) :
+    [_ ||-v<one> tId A x y : _ | VΓ | VU].
+  Proof. 
+    unshelve econstructor; intros.
+    - instValid Vσ. 
+      unshelve eapply IdRedU; refold; tea.
+      1: now eapply univValid.
+      all: irrelevance.
+    - instAllValid Vσ Vσ' Vσσ'.
+      unshelve eapply IdCongRedU; refold; tea.
+      1,2: now eapply univValid.
+      all: irrelevance.
+  Qed.
+    
+  Lemma IdTmCongValid {Γ l A A' x x' y y'}
+    (VΓ : [||-v Γ]) 
+    (VU := UValid VΓ)
+    (VAU : [_ ||-v<one> A : _ | VΓ | VU]) 
+    (VA := univValid VΓ VU VAU)
+    (VAU' : [_ ||-v<one> A' : _ | VΓ | VU]) 
+    (VAAU' : [_ ||-v<one> A ≅ A' : _ | VΓ | VU]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
+    (Vy' : [_ ||-v<l> y' : _ | _ | VA]) 
+    (Vyy' : [_ ||-v<l> y ≅ y' : _ | _ | VA]) :
+    [_ ||-v<one> tId A x y ≅ tId A' x' y' : _ | VΓ | VU].
+  Proof.
+    constructor; intros; instValid Vσ.
+    unshelve eapply IdCongRedU; refold; tea.
+    1,2: now eapply univValid.
+    2,5: eapply LRTmRedConv; [eapply univEqValid; irrValid|].
+    all: irrelevance.
+    Unshelve. 3,9: now eapply univValid.
+    all: tea.
+  Qed.
+
+
+  Lemma reflValid {Γ l A x} 
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VId : [_ ||-v<l> tId A x x | VΓ]) :
+    [_ ||-v<l> tRefl A x : _ | _ | VId].
+  Proof.
+    unshelve econstructor; intros.
+    - instValid Vσ; now unshelve eapply reflRed.
+    - instAllValid Vσ Vσ' Vσσ'; escape; now unshelve eapply reflCongRed.
+  Qed.
+
+  Lemma reflCongValid {Γ l A A' x x'}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (VA' : [_ ||-v<l> A' | VΓ]) 
+    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (VId : [_ ||-v<l> tId A x x | VΓ]) :
+    [_ ||-v<l> tRefl A x ≅ tRefl A' x' : _ | _ | VId].
+  Proof.
+    constructor; intros; instValid Vσ.
+    escape; unshelve eapply reflCongRed; refold; tea.
+    now eapply ty_conv.
+  Qed.
+
+  Lemma subst_scons2 (P e y : term) (σ : nat -> term) : P[e .: y..][σ] = P [e[σ] .: (y[σ] .: σ)].
+  Proof. now asimpl. Qed.
+  
+  Lemma subst_upup_scons2 (P e y : term) (σ : nat -> term) : P[up_term_term (up_term_term σ)][e .: y..] = P [e .: (y .: σ)].
+  Proof. now asimpl. Qed.
+
+  Lemma consSubstS' {Γ σ t l A Δ} 
+    (VΓ : [||-v Γ])
+    (VΓA : [||-v Γ ,, A])
+    (wfΔ : [|- Δ])
+    (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
+    (VA : [Γ ||-v<l> A | VΓ])
+    (Vt : [ Δ ||-<l> t : A[σ] | validTy VA wfΔ Vσ]) :
+    [Δ ||-v (t .: σ) : Γ ,, A | VΓA | wfΔ].
+  Proof. 
+    pose proof (invValiditySnoc VΓA) as [? [? [? ->]]].
+    unshelve eapply consSubstS; [ irrValid| irrelevance].
+  Qed.
+
+  Lemma consSubstSEq'' {Γ σ σ' t u l A Δ} 
+    (VΓ : [||-v Γ])
+    (VΓA : [||-v Γ ,, A])
+    (wfΔ : [|- Δ])
+    (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
+    (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ])
+    (VA : [Γ ||-v<l> A | VΓ])
+    (Vt : [Δ ||-<l> t : A[σ] | validTy VA wfΔ Vσ])
+    (Vtu : [Δ ||-<l> t ≅ u : A[σ] | validTy VA wfΔ Vσ])
+    (Vσt : [_ ||-v (t .: σ) : _ | VΓA | wfΔ]) :
+    [Δ ||-v (t .: σ) ≅  (u .: σ') : Γ ,, A | VΓA | wfΔ | Vσt].
+  Proof.
+    pose proof (invValiditySnoc VΓA) as [? [? [? ->]]].
+    pose proof (consSubstSEq' VΓ wfΔ Vσ Vσσ' VA Vt Vtu).
+    irrValid.
+  Qed.  
+
+
+  Lemma idElimMotiveCtxIdValid {Γ l A x}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA]) :
+    [Γ,, A ||-v< l > tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) | validSnoc VΓ VA].
+  Proof.
+    unshelve eapply IdValid.
+    - now eapply wk1ValidTy.
+    - now eapply wk1ValidTm.
+    - exact (var0Valid VΓ VA).
+  Qed.
+  
+  Lemma idElimMotiveCtxIdCongValid {Γ l A A' x x'}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (VA' : [_ ||-v<l> A' | VΓ]) 
+    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA])
+    (Vx : [_ ||-v<l> x : _ | _ | VA]) 
+    (Vx' : [_ ||-v<l> x' : _ | _ | VA]) 
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA]) 
+    (VId : [Γ,, A ||-v< l > tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) | validSnoc VΓ VA]) :
+    [_ ||-v<l> _ ≅ tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0) | validSnoc VΓ VA | VId].
+  Proof.
+    assert (h : forall t, t⟨@wk1 Γ A'⟩ = t⟨@wk1 Γ A⟩) by reflexivity.
+    unshelve eapply IdCongValid.
+    - now eapply wk1ValidTy.
+    - rewrite h; now eapply wk1ValidTy.
+    - rewrite h; now eapply wk1ValidTyEq.
+    - now eapply wk1ValidTm.
+    - rewrite h; now eapply wk1ValidTm.
+    - rewrite h; now eapply wk1ValidTmEq.
+    - eapply var0Valid.
+    - eapply var0Valid.
+    - eapply reflValidTm; eapply var0Valid.
+  Qed.
+  
+  
+  Lemma idElimMotiveScons2Valid {Γ l A x y e}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vy : [Γ ||-v<l> y : _ | _ | VA])
+    (VId : [Γ ||-v<l> tId A x y | VΓ])
+    (Ve : [_ ||-v<l> e : _ | _ | VId]) 
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    Δ σ (wfΔ: [ |-[ ta ] Δ]) (vσ: [VΓ | Δ ||-v σ : _ | wfΔ]) :
+      [VΓext | Δ ||-v (e[σ] .: (y[σ] .: σ)) : _ | wfΔ].
+  Proof.
+    intros; unshelve eapply consSubstS'; tea.
+    2: now eapply consSubstSvalid.
+    1: now eapply idElimMotiveCtxIdValid.
+    instValid vσ; irrelevance.
+  Qed.
+  
+  Lemma substIdElimMotive {Γ l A x P y e}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (Vy : [Γ ||-v<l> y : _ | _ | VA])
+    (VId : [Γ ||-v<l> tId A x y | VΓ])
+    (Ve : [_ ||-v<l> e : _ | _ | VId]) : 
+    [_ ||-v<l> P[e .: y ..] | VΓ].
+  Proof.
+    opector; intros.
+    - rewrite subst_scons2; eapply validTy; tea; now eapply idElimMotiveScons2Valid.
+    - irrelevance0 ; rewrite subst_scons2;[reflexivity|].
+      unshelve eapply validTyExt.
+      5,6: eapply idElimMotiveScons2Valid; cycle 1; tea.
+      1: tea.
+      eapply consSubstSEq''.
+      + now unshelve eapply consSubstSEqvalid.
+      + instValid vσ; irrelevance.
+      + instAllValid vσ vσ' vσσ'; irrelevance.
+      Unshelve. 2: now eapply idElimMotiveCtxIdValid.
+  Qed.
+  
+
+  Lemma subst_idElimMotive_substupup {Γ Δ l A x P y e σ}
+    (VΓ : [||-v Γ]) 
+    (wfΔ : [|- Δ])
+    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (RVA := validTy VA wfΔ Vσ)
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (Ry : [ RVA |  _ ||- y : _])
+    (RId : [Δ ||-<l> tId A[σ] x[σ] y])
+    (Re : [RId | _ ||- e : _]) :
+    [Δ ||-<l> P[up_term_term (up_term_term σ)][e .: y ..]].
+  Proof.
+    pose (VΓA := validSnoc VΓ VA). 
+    rewrite subst_upup_scons2.
+    unshelve eapply validTy; cycle 2; tea.
+    unshelve eapply consSubstS'; tea.
+    + now eapply consSubstS.
+    + now eapply idElimMotiveCtxIdValid.
+    + irrelevance.
+  Qed.
+  
+  Lemma irrelevanceSubst' {Γ} (VΓ VΓ' : [||-v Γ]) {σ Δ Δ'} (wfΔ : [|- Δ]) (wfΔ' : [|- Δ']) : Δ = Δ' ->
+    [Δ ||-v σ : Γ | VΓ | wfΔ] -> [Δ' ||-v σ : Γ | VΓ' | wfΔ'].
+  Proof.
+    intros ->; eapply irrelevanceSubst.
+  Qed.
+
+  Lemma idElimMotive_Idsubst_eq {Γ Δ A x σ} : 
+    tId A[σ]⟨@wk1 Δ A[σ]⟩ x[σ]⟨@wk1 Δ A[σ]⟩ (tRel 0) = (tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0))[up_term_term σ].
+  Proof. now bsimpl. Qed.
+  
+  Lemma red_idElimMotive_substupup {Γ Δ l A x P σ}
+    (VΓ : [||-v Γ]) 
+    (wfΔ : [|- Δ])
+    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext]) :
+    [(Δ ,, A[σ]),, tId A[σ]⟨@wk1 Δ A[σ]⟩ x[σ]⟨@wk1 Δ A[σ]⟩ (tRel 0) ||-<l> P[up_term_term (up_term_term σ)]].
+  Proof.
+    pose (VΓA := validSnoc VΓ VA). 
+    instValid Vσ.
+    unshelve eapply validTy; cycle 2; tea.
+    * escape. 
+      assert [|- Δ,, A[σ]] by now eapply wfc_cons.
+      eapply wfc_cons; tea.
+      eapply wft_Id.
+      1: now eapply wft_wk.
+      1: now eapply ty_wk.
+      rewrite wk1_ren_on; now eapply ty_var0.
+    * epose (v1:= liftSubstS' VA Vσ).
+      epose (v2:= liftSubstS' _ v1).
+      eapply irrelevanceSubst'.
+      1: now erewrite idElimMotive_Idsubst_eq.
+      eapply v2.
+      Unshelve. 2: now eapply idElimMotiveCtxIdValid.
+  Qed.
+
+  Lemma irrelevanceSubstEq' {Γ} (VΓ VΓ' : [||-v Γ]) {σ σ' Δ Δ'} (wfΔ : [|- Δ]) (wfΔ' : [|- Δ'])
+    (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) (Vσ' : [Δ' ||-v σ : Γ | VΓ' | wfΔ']) :
+    Δ = Δ' ->
+    [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] -> [Δ' ||-v σ ≅ σ' : Γ | VΓ' | wfΔ' | Vσ'].
+  Proof.
+    intros ->; eapply irrelevanceSubstEq.
+  Qed.
+  
+  Lemma red_idElimMotive_substupup_cong {Γ Δ l A x P σ σ'}
+    (VΓ : [||-v Γ]) 
+    (wfΔ : [|- Δ])
+    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
+    (Vσ' : [_ ||-v σ' : _ | VΓ | wfΔ])
+    (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓ | wfΔ | Vσ])
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext]) 
+    (RPσ : [(Δ ,, A[σ]),, tId A[σ]⟨@wk1 Δ A[σ]⟩ x[σ]⟨@wk1 Δ A[σ]⟩ (tRel 0) ||-<l> P[up_term_term (up_term_term σ)]]) :
+    [RPσ | _ ||- _ ≅ P[up_term_term (up_term_term σ')]].
+  Proof.
+    pose (VΓA := validSnoc VΓ VA). 
+    instAllValid Vσ Vσ' Vσσ'.
+    irrelevanceRefl; unshelve eapply validTyExt; cycle 2; tea.
+    * escape. 
+      assert [|- Δ,, A[σ]] by now eapply wfc_cons.
+      eapply wfc_cons; tea.
+      eapply wft_Id.
+      1: now eapply wft_wk.
+      1: now eapply ty_wk.
+      rewrite wk1_ren_on; now eapply ty_var0.
+    * epose (v1:= liftSubstS' VA Vσ).
+      epose (v2:= liftSubstS' _ v1).
+      eapply irrelevanceSubst'.
+      1: now erewrite idElimMotive_Idsubst_eq.
+      eapply v2.
+      Unshelve. 2: now eapply idElimMotiveCtxIdValid.
+    * eapply irrelevanceSubst'.
+      1: now erewrite idElimMotive_Idsubst_eq.
+      eapply liftSubstSrealign'.
+      + now eapply liftSubstSEq'.
+      + now eapply liftSubstSrealign'.
+      Unshelve. 
+      2: now eapply idElimMotiveCtxIdValid.
+    * eapply irrelevanceSubstEq'.
+      1: now erewrite idElimMotive_Idsubst_eq.
+      eapply liftSubstSEq'.
+      now eapply liftSubstSEq'.
+      Unshelve.
+      2: now eapply idElimMotiveCtxIdValid.
+  Qed.
+
+  Lemma redEq_idElimMotive_substupup {Γ Δ l A A' x x' P P' σ}
+    (VΓ : [||-v Γ]) 
+    (wfΔ : [|- Δ])
+    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (VA' : [_ ||-v<l> A' | VΓ]) 
+    (VAA' : [_ ||-v<l> A ≅ A' | _ | VA])
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (VP' : [_ ||-v<l> P' | VΓext])
+    (VPP' : [_ ||-v<l> P ≅ P' | _ | VP]) 
+    (VPsubstupup : [(Δ ,, A[σ]),, tId A[σ]⟨@wk1 Δ A[σ]⟩ x[σ]⟨@wk1 Δ A[σ]⟩ (tRel 0) ||-<l> P[up_term_term (up_term_term σ)]]) :
+    [_ ||-<l> _ ≅ P'[up_term_term (up_term_term σ)] | VPsubstupup].
+  Proof.
+    pose (VΓA := validSnoc VΓ VA). 
+    instValid Vσ.
+    irrelevanceRefl; unshelve eapply validTyEq; cycle 2; tea.
+    * escape. 
+      assert [|- Δ,, A[σ]] by now eapply wfc_cons.
+      eapply wfc_cons; tea.
+      eapply wft_Id.
+      1: now eapply wft_wk.
+      1: now eapply ty_wk.
+      rewrite wk1_ren_on; now eapply ty_var0.
+    * epose (v1:= liftSubstS' VA Vσ).
+      epose (v2:= liftSubstS' _ v1).
+      eapply irrelevanceSubst'.
+      1: now erewrite idElimMotive_Idsubst_eq.
+      eapply v2.
+      Unshelve. 2: now eapply idElimMotiveCtxIdValid.
+  Qed.
+
+
+  Lemma substEq_idElimMotive_substupupEq {Γ Δ l A x P y y' e e' σ σ'}
+    (VΓ : [||-v Γ]) 
+    (wfΔ : [|- Δ])
+    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
+    (Vσ' : [_ ||-v σ' : _ | VΓ | wfΔ])
+    (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓ | wfΔ | Vσ])
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (RVA := validTy VA wfΔ Vσ)
+    (RVA' := validTy VA wfΔ Vσ')
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (Ry : [ RVA |  _ ||- y : _])
+    (Ry' : [ RVA' |  _ ||- y' : _])
+    (Ryy' : [ RVA |  _ ||- y ≅ y' : _])
+    (RId : [Δ ||-<l> tId A[σ] x[σ] y])
+    (RId' : [Δ ||-<l> tId A[σ'] x[σ'] y'])
+    (Re : [RId | _ ||- e : _])
+    (Re' : [RId' | _ ||- e' : _])
+    (Ree' : [RId | _ ||- e ≅ e' : _])
+    (RPsubst : [Δ ||-<l> P[up_term_term (up_term_term σ)][e .: y ..]]) :
+    [RPsubst | Δ ||- P[up_term_term (up_term_term σ)][e .: y ..] ≅ P[up_term_term (up_term_term σ')][e' .: y' ..]].
+  Proof.
+    pose (VΓA := validSnoc VΓ VA). 
+    irrelevance0; rewrite subst_upup_scons2; [reflexivity|].
+    unshelve eapply validTyExt; cycle 2; tea.
+    - unshelve eapply consSubstS'; tea.
+      + now eapply consSubstS.
+      + now eapply idElimMotiveCtxIdValid.
+      + irrelevance.
+    - unshelve eapply consSubstS'; tea.
+      + now eapply consSubstS.
+      + now eapply idElimMotiveCtxIdValid.
+      + irrelevance.
+    - unshelve eapply consSubstSEq''; tea.
+      4,5: irrelevance.
+      2: now eapply idElimMotiveCtxIdValid.
+      2: unshelve eapply consSubstSEq'; tea.
+  Qed.
+
+  Lemma substEq_idElimMotive_substupup {Γ Δ l A x P y y' e e' σ}
+    (VΓ : [||-v Γ]) 
+    (wfΔ : [|- Δ])
+    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (RVA := validTy VA wfΔ Vσ)
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (Ry : [ RVA |  _ ||- y : _])
+    (Ry' : [ RVA |  _ ||- y' : _])
+    (Ryy' : [ RVA |  _ ||- y ≅ y' : _])
+    (RId : [Δ ||-<l> tId A[σ] x[σ] y])
+    (RId' : [Δ ||-<l> tId A[σ] x[σ] y'])
+    (Re : [RId | _ ||- e : _])
+    (Re' : [RId' | _ ||- e' : _])
+    (Ree' : [RId | _ ||- e ≅ e' : _])
+    (RPsubst : [Δ ||-<l> P[up_term_term (up_term_term σ)][e .: y ..]]) :
+    [RPsubst | Δ ||- P[up_term_term (up_term_term σ)][e .: y ..] ≅ P[up_term_term (up_term_term σ)][e' .: y' ..]].
+  Proof.
+    eapply substEq_idElimMotive_substupupEq; tea; eapply reflSubst.
+  Qed.
+
+  Set Printing Primitive Projection Parameters.
+
+  Lemma substExt_idElimMotive_substupup {Γ Δ l A A' x x' P P' y y' e e' σ}
+    (VΓ : [||-v Γ]) 
+    (wfΔ : [|- Δ])
+    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (VA' : [_ ||-v<l> A' | VΓ]) 
+    (VAA' : [_ ||-v<l> A ≅ A' | _ | VA])
+    (RVA := validTy VA wfΔ Vσ)
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (VP' : [_ ||-v<l> P' | VΓext])
+    (VPP' : [_ ||-v<l> P ≅ P' | _ | VP]) 
+    (Ry : [ RVA |  _ ||- y : _])
+    (Ry' : [ RVA |  _ ||- y' : _])
+    (Ryy' : [ RVA |  _ ||- y ≅ y' : _])
+    (RId : [Δ ||-<l> tId A[σ] x[σ] y])
+    (RId' : [Δ ||-<l> tId A[σ] x[σ] y'])
+    (Re : [RId | _ ||- e : _])
+    (Re' : [RId' | _ ||- e' : _])
+    (Ree' : [RId | _ ||- e ≅ e' : _])
+    (RPsubst : [Δ ||-<l> P[up_term_term (up_term_term σ)][e .: y ..]]) :
+    [RPsubst | Δ ||- P[up_term_term (up_term_term σ)][e .: y ..] ≅ P'[up_term_term (up_term_term σ)][e' .: y' ..]].
+  Proof.
+    pose (VΓA := validSnoc VΓ VA). 
+    eapply LRTransEq.
+    eapply substEq_idElimMotive_substupup.
+    2,4,8: tea. all:tea.
+    irrelevance0; rewrite subst_upup_scons2; [reflexivity|].
+    unshelve eapply validTyEq; cycle 2; tea.
+    eapply irrelevanceSubst.
+    unshelve eapply consSubstS.
+    3: now eapply idElimMotiveCtxIdValid.
+    1: now eapply consSubstS.
+    irrelevance.
+    Unshelve. 2: eapply subst_idElimMotive_substupup; cycle 1; tea.
+  Qed.
+
+
+  Lemma substExtIdElimMotive {Γ l A x P y y' e e'}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (Vy : [Γ ||-v<l> y : _ | _ | VA])
+    (Vy' : [Γ ||-v<l> y' : _ | _ | VA])
+    (Vyy' : [Γ ||-v<l> y ≅ y' : _ | _ | VA])
+    (VId : [Γ ||-v<l> tId A x y | VΓ])
+    (VId' : [Γ ||-v<l> tId A x y' | VΓ])
+    (Ve : [_ ||-v<l> e : _ | _ | VId]) 
+    (Ve' : [_ ||-v<l> e' : _ | _ | VId']) 
+    (Vee' : [_ ||-v<l> e ≅ e' : _ | _ | VId]) 
+    (VPey : [_ ||-v<l> P[e .: y ..] | VΓ]) : 
+    [_ ||-v<l> P[e .: y ..] ≅ P[e' .: y' ..] | VΓ | VPey].
+  Proof.
+    constructor; intros.
+    irrelevance0; rewrite subst_scons2; [reflexivity|]. 
+    unshelve eapply validTyExt.
+    5,6: eapply idElimMotiveScons2Valid; cycle 1; tea.
+    1: tea.
+    instValid Vσ; unshelve eapply consSubstSEq''.
+    4: now eapply idElimMotiveCtxIdValid.
+    2: eapply consSubstSEq'; [now eapply reflSubst|]; irrelevance.
+    all: irrelevance.
+    Unshelve. 1:tea. irrelevance.
+  Qed.
+
+  Lemma substEqIdElimMotive {Γ l A A' x x' P P' y y' e e'}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (VA' : [_ ||-v<l> A' | VΓ]) 
+    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (VP' : [_ ||-v<l> P | VΓext])
+    (VPP' : [_ ||-v<l> P ≅ P' | _ | VP])
+    (Vy : [Γ ||-v<l> y : _ | _ | VA])
+    (Vy' : [Γ ||-v<l> y' : _ | _ | VA])
+    (Vyy' : [Γ ||-v<l> y ≅ y' : _ | _ | VA])
+    (VId : [Γ ||-v<l> tId A x y | VΓ])
+    (Ve : [_ ||-v<l> e : _ | _ | VId]) 
+    (Ve' : [_ ||-v<l> e' : _ | _ | VId]) 
+    (Vee' : [_ ||-v<l> e ≅ e' : _ | _ | VId]) 
+    (VPey : [_ ||-v<l> P[e .: y ..] | VΓ]) : 
+    [_ ||-v<l> P[e .: y ..] ≅ P'[e' .: y' ..] | VΓ | VPey].
+  Proof.
+    assert (VId' : [Γ ||-v<l> tId A x y' | VΓ]) by now eapply IdValid.
+    assert [Γ ||-v< l > e' : tId A x y' | VΓ | VId'].
+    1:{
+      eapply conv; tea.
+      eapply IdCongValid; tea.
+      1: eapply reflValidTy.
+      now eapply reflValidTm.
+    }
+    eapply transValidEq.
+    - eapply substExtIdElimMotive.
+      2: tea. all: tea.
+      Unshelve. eapply substIdElimMotive; cycle 1; tea.
+    - constructor; intros; irrelevance0; rewrite subst_scons2; [reflexivity|].
+      unshelve eapply validTyEq.
+      6: tea. 1: tea.
+      eapply idElimMotiveScons2Valid; tea.
+  Qed.
+    
+  (* Lemma liftSubstS' {Γ σ Δ lF F} 
+    {VΓ : [||-v Γ]} 
+    {wfΔ : [|- Δ]}
+    (VF : [Γ ||-v<lF> F | VΓ])
+    (VΓF : [||-v Γ,, F])
+    {wfΔF : [|- Δ ,, F[σ]]}
+    (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
+    [Δ ,, F[σ] ||-v up_term_term σ : Γ ,, F | VΓF | wfΔF ].
+  Proof.
+    eapply irrelevanceSubst.
+    now unshelve eapply liftSubstS'.
+  Qed. *)
+
+
+  Lemma IdElimValid {Γ l A x P hr y e}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (VPhr := substIdElimMotive VΓ VA Vx VΓext VP Vx (IdValid VΓ VA Vx Vx) (reflValid VΓ VA Vx _))
+    (Vhr : [_ ||-v<l> hr : _ | _ | VPhr ])
+    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
+    (VId : [Γ ||-v<l> tId A x y | VΓ])
+    (Ve : [_ ||-v<l> e : _ | _ | VId])
+    (VPye := substIdElimMotive VΓ VA Vx VΓext VP Vy VId Ve) :
+    [_ ||-v<l> tIdElim A x P hr y e : _ | _ | VPye].
+  Proof.
+    unshelve epose (h := _ : [||-v Γ,, A]). 1: now eapply validSnoc.
+    constructor; intros.
+    - instValid Vσ.
+      irrelevance0.
+      2: unshelve eapply idElimRed; refold; tea.
+      1: refold; now rewrite subst_upup_scons2, subst_scons2.
+      2,5: irrelevance.
+      + intros; eapply subst_idElimMotive_substupup; cycle 1; tea.
+      + now eapply red_idElimMotive_substupup.
+      + intros; eapply substEq_idElimMotive_substupup; cycle 1; tea.
+        eapply LRTmRedConv; tea; now eapply LRTyEqSym.
+    - instAllValid Vσ Vσ' Vσσ'.
+      irrelevance0.
+      2: unshelve eapply idElimCongRed; refold.
+      1: refold; now rewrite subst_upup_scons2, subst_scons2.
+      all: try now eapply LRCumulative.
+      all: tea; try irrelevanceCum.
+      2,4: now eapply red_idElimMotive_substupup.
+      + intros; eapply subst_idElimMotive_substupup; cycle 1; tea; irrelevanceCum.
+        Unshelve. all: tea. irrelevanceCum.
+      + intros; eapply subst_idElimMotive_substupup; cycle 1; tea; irrelevanceCum.
+        Unshelve. all: tea.
+      + now eapply red_idElimMotive_substupup_cong.
+      + intros; eapply substEq_idElimMotive_substupupEq; cycle 2; tea; irrelevanceCum.
+        Unshelve. all: tea. now eapply LRCumulative.
+      + intros; eapply substEq_idElimMotive_substupup; cycle 1; tea.
+        1,3-6: irrelevanceCum.
+        eapply LRTmRedConv;[|irrelevanceCum]; eapply LRTyEqSym; irrelevanceCum.
+        Unshelve. all: tea; now eapply LRCumulative.
+      + Set Printing Primitive Projection Parameters.
+        intros; eapply substEq_idElimMotive_substupup; cycle 1; tea.
+        1,3: irrelevanceCum.
+        eapply LRTmRedConv; [|irrelevanceCum]; eapply LRTyEqSym; irrelevanceCum.
+        Unshelve. all: tea.
+  Qed.
+
+  Lemma IdElimCongValid {Γ l A A' x x' P P' hr hr' y y' e e'}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (VA' : [_ ||-v<l> A' | VΓ]) 
+    (VAA' : [_ ||-v<l> A ≅ A' | _ | VA])
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (VP' : [_ ||-v<l> P' | VΓext])
+    (VPP' : [_ ||-v<l> P ≅ P' | _ | VP])
+    (VPhr := substIdElimMotive VΓ VA Vx VΓext VP Vx (IdValid VΓ VA Vx Vx) (reflValid VΓ VA Vx _))
+    (Vhr : [_ ||-v<l> hr : _ | _ | VPhr ])
+    (Vhr' : [_ ||-v<l> hr' : _ | _ | VPhr ])
+    (Vhrhr' : [_ ||-v<l> hr ≅ hr' : _ | _ | VPhr])
+    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
+    (Vy' : [_ ||-v<l> y' : _ | _ | VA]) 
+    (Vyy' : [_ ||-v<l> y ≅ y' : _ | _ | VA]) 
+    (VId : [Γ ||-v<l> tId A x y | VΓ])
+    (Ve : [_ ||-v<l> e : _ | _ | VId])
+    (Ve' : [_ ||-v<l> e' : _ | _ | VId])
+    (Vee' : [_ ||-v<l> e ≅ e' : _ | _ | VId])
+    (VPye := substIdElimMotive VΓ VA Vx VΓext VP Vy VId Ve) :
+    [_ ||-v<l> tIdElim A x P hr y e ≅ tIdElim A' x' P' hr' y' e' : _ | _ | VPye].
+  Proof.
+    assert [_ ||-v<l> x' : _ | _ | VA'] by now eapply conv.
+    assert [_ ||-v<l> y' : _ | _ | VA'] by now eapply conv.
+    assert (VΓext' : [||-v (Γ ,, A'),, tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0)]).
+    1: eapply validSnoc; now eapply idElimMotiveCtxIdValid.
+    assert (h : forall t, t⟨@wk1 Γ A'⟩ = t⟨@wk1 Γ A⟩) by reflexivity.
+    assert (VPalt' : [_ ||-v<l> P' | VΓext']).
+    1:{
+      eapply convCtx2'; tea.
+      1: eapply convCtx1; tea; [now eapply symValidEq| ].
+      1,3: now eapply idElimMotiveCtxIdValid.
+      eapply idElimMotiveCtxIdCongValid; tea.
+      Unshelve. 1: now eapply idElimMotiveCtxIdValid. tea.
+    }
+    constructor; intros.
+    instValid Vσ.
+    irrelevance0.
+    2: unshelve eapply idElimCongRed; refold.
+    1: refold; now rewrite subst_upup_scons2, subst_scons2.
+    all: first [now eapply LRCumulative | solve [irrelevance | irrelevanceCum] | now eapply LRTmRedConv | tea].
+    + intros ; eapply subst_idElimMotive_substupup; cycle 1; tea; irrelevanceCum.
+      Unshelve. all: tea. irrelevanceCum.
+    + intros; eapply red_idElimMotive_substupup; tea.
+    + intros; eapply subst_idElimMotive_substupup; cycle 1; tea.
+      irrelevance.
+      Unshelve. all: tea.
+    + unshelve eapply IdRed; tea; eapply LRTmRedConv; tea.
+    + eapply red_idElimMotive_substupup; tea.
+    + eapply redEq_idElimMotive_substupup.
+      6-8: tea. 3-5: tea. all: tea.
+    + intros.
+      assert [_ ||-<l> y'0 : _ | RVA] by (eapply LRTmRedConv; tea; now eapply LRTyEqSym).
+      eapply substExt_idElimMotive_substupup.
+      7: tea. 2,3,5,6: tea. all: tea; try solve [irrelevanceCum].
+      1: eapply LRTmRedConv; tea; eapply LRTyEqSym; tea.
+      eapply IdCongRed; tea; [now escape|  now eapply reflLRTmEq].
+      Unshelve. 1: now eapply LRCumulative. 1,2: now eapply IdRed.
+    + intros; eapply substEq_idElimMotive_substupup; cycle 1; tea; try solve [irrelevanceCum].
+      eapply LRTmRedConv. 2:irrelevanceCum. eapply LRTyEqSym; irrelevanceCum.
+      Unshelve. all: tea; now eapply LRCumulative.
+    + intros; eapply substEq_idElimMotive_substupup; cycle 1; tea; try solve [irrelevanceCum].
+      eapply LRTmRedConv. 2:irrelevanceCum. eapply LRTyEqSym; irrelevanceCum.
+      Unshelve. all: tea; now eapply LRCumulative.
+    + eapply LRTmRedConv; tea.
+      rewrite subst_upup_scons2; change (tRefl A'[σ] x'[σ]) with (tRefl A' x')[σ].
+      rewrite <- subst_scons2.
+      eapply validTyEq. eapply substEqIdElimMotive.
+      6,7: tea.  5-8: tea. 2-4: tea. 1: tea.
+      2: eapply conv.
+      1,3: now eapply reflValid.
+      1: eapply symValidEq; now eapply IdCongValid.
+      now eapply reflCongValid.
+      Unshelve. all: now eapply IdValid.
+    + eapply LRTmRedConv; tea.
+      now eapply IdCongValid.
+  Qed.
+
+
+  Lemma IdElimReflValid {Γ l A x P hr y B z}
+    (VΓ : [||-v Γ]) 
+    (VA : [_ ||-v<l> A | VΓ]) 
+    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    (VP : [_ ||-v<l> P | VΓext])
+    (VPhr := substIdElimMotive VΓ VA Vx VΓext VP Vx (IdValid VΓ VA Vx Vx) (reflValid VΓ VA Vx _))
+    (Vhr : [_ ||-v<l> hr : _ | _ | VPhr ])
+    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
+    (Vxy : [_ ||-v<l> x ≅ y : _ | _ | VA]) 
+    (VB : [_ ||-v<l> B | VΓ])
+    (VAB : [_ ||-v<l> _ ≅ B | VΓ | VA])
+    (Vz : [_ ||-v<l> z : _ | _ | VB]) 
+    (Vxz : [_ ||-v<l> x ≅ z : _ | _ | VA]) 
+    (VId : [Γ ||-v<l> tId A x y | VΓ]) 
+    (VRefl : [_ ||-v<l> tRefl B z : _ | _ | VId])
+    (VPye := substIdElimMotive VΓ VA Vx VΓext VP Vy VId VRefl) :
+    [_ ||-v<l> tIdElim A x P hr y (tRefl B z) ≅ hr : _ | _ | VPye].
+  Proof.
+    constructor; intros.
+    assert [Γ ||-v< l > P[tRefl A x .: x..] ≅ P[tRefl B z .: y..] | VΓ | VPhr].
+    1:{
+      eapply substExtIdElimMotive; cycle 1; tea.
+      1: now eapply reflValid.
+      eapply reflCongValid; tea.
+      eapply conv; tea.
+      now eapply symValidEq.
+      Unshelve. now eapply IdValid.
+    }
+    eapply redwfSubstValid; cycle 1.
+    + eapply conv; tea.
+    + constructor; intros.
+      instValid Vσ0; escape.
+      constructor.
+      - eapply ty_conv; tea.
+      - rewrite subst_scons2, <- subst_upup_scons2.
+        eapply redtm_idElimRefl; refold; tea.
+        * eapply escape. now eapply red_idElimMotive_substupup.
+        * rewrite subst_upup_scons2; change (tRefl ?A[?σ] ?x[_]) with (tRefl A x)[σ].
+          now rewrite <- subst_scons2.
+        * now eapply ty_conv.
+  Qed.
+
+End Id.
+
+
+  
+

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -94,7 +94,7 @@ Proof.
     }
     eapply convtm_exp; tea.
     1: now eapply redty_refl.
-    rewrite <- (eqσ t); eapply escapeEqTerm; now eapply LREqTermRefl_.
+    rewrite <- (eqσ t); eapply escapeEqTerm; now eapply reflLRTmEq.
   + eapply lamBetaRed; tea. 
   + pose proof (Vσa := consWkSubstS VF ρ h Vσ ha).
     pose proof (Vσb := consWkSubstS VF ρ h Vσ hb).
@@ -177,7 +177,7 @@ Proof.
     assert (Vσσa : [_ ||-v _ ≅ (a .: σ'⟨ρ⟩) : _ | _ | _ | Vσa]).
     {
       unshelve eapply consSubstSEq'.
-      2: eapply LREqTermRefl_; irrelevance0; [|exact ha]; now bsimpl.
+      2: eapply reflLRTmEq; irrelevance0; [|exact ha]; now bsimpl.
       eapply irrelevanceSubstEq; now eapply wkSubstSEq.
       Unshelve. all: tea.
     }
@@ -210,7 +210,7 @@ Proof.
   by (intros; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
   eapply convtm_exp. 
   1: now eapply redty_refl.
-  3: rewrite eqσ; eapply escapeEqTerm; eapply LREqTermRefl_; irrelevance.
+  3: rewrite eqσ; eapply escapeEqTerm; eapply reflLRTmEq; irrelevance.
   * eapply redtm_meta_conv. 3: reflexivity.
     1: eapply redtm_app.
     2: eapply (ty_var wfΔF (in_here _ _)).

--- a/theories/Substitution/Introductions/Nat.v
+++ b/theories/Substitution/Introductions/Nat.v
@@ -82,7 +82,7 @@ Lemma succRed {Γ l n} {NN : [Γ ||-Nat tNat]} :
 Proof.
   intros Rn; exists (tSucc n).
   + eapply redtmwf_refl; eapply ty_succ; now escape.
-  + eapply convtm_succ; eapply escapeEqTerm; now eapply LREqTermRefl_.
+  + eapply convtm_succ; eapply escapeEqTerm; now eapply reflLRTmEq.
   + now constructor.
 Defined.
 
@@ -207,9 +207,9 @@ Section NatElimRed.
       + now eapply ty_natElim.
       + now eapply ty_natElim.
       + eapply convneu_natElim; tea.
-        { eapply escapeEq, LRTyEqRefl_. }
-        { eapply escapeEqTerm; now eapply LREqTermRefl_. }
-        { eapply escapeEqTerm; now eapply LREqTermRefl_. }
+        { eapply escapeEq, reflLRTyEq. }
+        { eapply escapeEqTerm; now eapply reflLRTmEq. }
+        { eapply escapeEqTerm; now eapply reflLRTmEq. }
     Unshelve.
     * eapply ArrRedTy; now eapply RPpt.
     * rewrite subst_arr. eapply ArrRedTy.
@@ -256,7 +256,7 @@ Section NatElimRedEq.
       [Γ ||-<l> P[n..] ≅ P[n'..] | RPpt _ Rn].
   Proof.
     intros. eapply transEq; [| eapply LRTyEqSym ]; eapply RPQext; cycle 1; tea.
-    now eapply LREqTermRefl_.
+    now eapply reflLRTmEq.
     Unshelve. 2,3: eauto.
   Qed.
 
@@ -270,7 +270,7 @@ Section NatElimRedEq.
   Proof.
     eapply natElimRedAux; tea.
     + intros. eapply transEq; [eapply LRTyEqSym |]; eapply RPQext; cycle 1; tea.
-      now eapply LREqTermRefl_.
+      now eapply reflLRTmEq.
     Unshelve. all:tea.
   Qed.
 

--- a/theories/Substitution/Introductions/Nat.v
+++ b/theories/Substitution/Introductions/Nat.v
@@ -292,9 +292,9 @@ Section NatElimRedEq.
       * eapply LRTmEqRedConv.
         + eapply RPext; tea. 
           eapply LRTmEqSym; eapply redwfSubstTerm; cycle 1; tea.
-        + unshelve erewrite (redtmwf_det _ _ _ _ _ _ _ _ (NatRedTm.red RL) redL); tea.
+        + unshelve erewrite (redtmwf_det _ _ (NatRedTm.red RL) redL); tea.
           1: dependent inversion RL; subst; cbn; now eapply NatProp_whnf.
-          unshelve erewrite (redtmwf_det _ _ _ _ _ _ _ _ (NatRedTm.red RR) redR); tea.
+          unshelve erewrite (redtmwf_det _ _ (NatRedTm.red RR) redR); tea.
           1: dependent inversion RR; subst; cbn; now eapply NatProp_whnf.
           now eapply ih.
         Unshelve. tea.

--- a/theories/Substitution/Introductions/Pi.v
+++ b/theories/Substitution/Introductions/Pi.v
@@ -25,7 +25,7 @@ Section PolyRedPi.
   Proof.
     econstructor; tea; pose proof (polyRedId PAB) as []; escape.
     + eapply redtywf_refl; gen_typing.
-    + eapply convty_prod; tea; unshelve eapply escapeEq; tea; eapply LRTyEqRefl_.
+    + eapply convty_prod; tea; unshelve eapply escapeEq; tea; eapply reflLRTyEq.
   Defined.
 
   Definition LRPiPoly {Γ l A B} (PAB : PolyRed Γ l A B) : [Γ ||-<l> tProd A B] := LRPi' (LRPiPoly0 PAB).

--- a/theories/Substitution/Introductions/Poly.v
+++ b/theories/Substitution/Introductions/Poly.v
@@ -191,7 +191,7 @@ Section PolyValidity.
     - intros ?? ρ wfΔ' ha; irrelevance0; rewrite eq_subst_2.
       1: reflexivity.
       unshelve epose proof (Vabwkσ := consWkSubstSEq' VF Vσ (reflSubst _ _ Vσ) ρ wfΔ' ha _).
-      2: now eapply LREqTermRefl_.
+      2: now eapply reflLRTmEq.
       unshelve eapply validTyEq; cycle 2; tea. 
       now eapply consWkSubstS.
   Qed.
@@ -206,7 +206,7 @@ Section PolyValidity.
     - intros ?? ρ wfΔ' ha; irrelevance0; rewrite eq_subst_2.
       1: reflexivity.
       unshelve epose proof (Vabwkσ := consWkSubstSEq' VF Vσ Vσσ' ρ wfΔ' ha _).
-      2: now eapply LREqTermRefl_.
+      2: now eapply reflLRTmEq.
       eapply validTyExt; tea.
       eapply consWkSubstS; tea.
       eapply LRTmRedConv; tea.

--- a/theories/Substitution/Introductions/Poly.v
+++ b/theories/Substitution/Introductions/Poly.v
@@ -146,12 +146,12 @@ Section PolyValidity.
     : PolyRedEq PABt A B[u]⇑.
   Proof.
     constructor.
-    - intros; eapply LRTyEqRefl_.
+    - intros; eapply reflLRTyEq.
     - intros; irrelevance0; rewrite liftSubst_scons_eq; [reflexivity|].
       unshelve eapply PolyRed.posExt; cycle 1; tea.
       + eapply Rt; now irrelevanceRefl.
       + eapply Ru; now irrelevanceRefl.
-      + eapply Rtu; try eapply LREqTermRefl_; now irrelevanceRefl.
+      + eapply Rtu; try eapply reflLRTmEq; now irrelevanceRefl.
   Qed.
   
   Context {l Γ F G} (VΓ : [||-v Γ])

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -779,7 +779,7 @@ Section PairRed.
       instValid Vσ; instValidExt Vσ (reflSubst _ _ Vσ).
       pose (RVΣ0 := normRedΣ0 (invLRΣ RVΣ)).
       pose (RVB := snd (polyRedId RVΣ0)); fold subst_term in *.
-      pose (Vaσ := consSubstSvalid _ _ Vσ VA Va); instValid Vaσ.
+      pose (Vaσ := consSubstSvalid Vσ Va); instValid Vaσ.
       rewrite <- up_subst_single in RVB0.
       assert (RVb' : [RVB0 | Δ ||- b[σ] : B[up_term_term σ][(a[σ])..]])
         by (irrelevance0; tea; apply  singleSubstComm').

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -355,7 +355,7 @@ Section ProjRed.
       instAllValid Vσ Vσ' Vσσ'.
       pose (RΣinv := invLRΣ RVΣ); normRedΣin REVp; fold subst_term in *.
       destruct (fstRedEq RΣinv RVF REVp).
-      eapply LREqTermHelper; tea; eapply LRTyEqRefl_.
+      eapply LREqTermHelper; tea; eapply reflLRTyEq.
   Qed.  
   
   Lemma fstCongValid {p p'} 
@@ -521,7 +521,7 @@ Section PairRed.
         1: now eapply redtywf_refl.
         1: now eapply redtm_fst_beta.
         1: now eapply redtmwf_refl.
-        eapply escapeEqTerm; now eapply LREqTermRefl_.
+        eapply escapeEqTerm; now eapply reflLRTmEq.
       * enough [Γ |- tSnd (tPair A B a b) ≅ b : B[(tFst (tPair A B a b))..]].
         1: transitivity b; tea; now symmetry.
         eapply convtm_conv; tea.
@@ -529,7 +529,7 @@ Section PairRed.
         1: now eapply redty_refl.
         1: eapply redtm_conv; [| now symmetry]; now eapply redtm_snd_beta.
         1: now eapply redtm_refl.
-        eapply escapeEqTerm; now eapply LREqTermRefl_.
+        eapply escapeEqTerm; now eapply reflLRTmEq.
     + intros ? ρ wfΔ.
       irrelevance0.
       2: rewrite wk_snd; eapply wkTerm; now eapply pairSndRed.

--- a/theories/Substitution/Irrelevance.v
+++ b/theories/Substitution/Irrelevance.v
@@ -51,7 +51,7 @@ Proof.
   - constructor.
   - intros * ih. unshelve econstructor.
     1: apply ih.
-    apply LREqTermRefl_. exact (validHead Vσ).
+    apply reflLRTmEq. exact (validHead Vσ).
 Qed.
 
 Lemma symmetrySubstEq {Γ} (VΓ VΓ' : [||-v Γ]) : forall {σ σ' Δ} (wfΔ wfΔ' : [|- Δ])

--- a/theories/Substitution/Properties.v
+++ b/theories/Substitution/Properties.v
@@ -223,7 +223,7 @@ Lemma liftSubstSEq {Γ σ σ' Δ lF F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
 Proof.
   intros; unshelve econstructor.
   + now apply wk1SubstSEq.
-  + apply LREqTermRefl_; exact (validHead Vliftσ).
+  + apply reflLRTmEq; exact (validHead Vliftσ).
 Qed.
 
 Lemma liftSubstSEq' {Γ σ σ' Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}

--- a/theories/Substitution/Properties.v
+++ b/theories/Substitution/Properties.v
@@ -36,16 +36,6 @@ Lemma consSubstS {Γ σ t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   [Δ ||-v (t .: σ) : Γ ,, A | validSnoc VΓ VA | wfΔ].
 Proof.  unshelve econstructor; eassumption. Defined.
 
-Lemma consValid {Γ Δ σ a A l} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
-  {VA : [Γ ||-v<l> A| VΓ]}
-  (Va : [Γ ||-v<l> a : A | VΓ | VA])
-  (VΓA := validSnoc VΓ VA) :
-  [Δ ||-v (a[σ] .: σ) : Γ,, A | VΓA | wfΔ].
-Proof.
-  unshelve eapply consSubstS; tea; now eapply validTm.
-Qed.
-
 
 Lemma consSubstSEq {Γ σ σ' t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
@@ -71,21 +61,21 @@ Proof.
 Qed.  
 
 
-Lemma consSubstSvalid {Γ σ t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) (VA : [Γ ||-v<l> A | VΓ])
+Lemma consSubstSvalid {Γ σ t l A Δ} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) {VA : [Γ ||-v<l> A | VΓ]}
   (Vt : [ Γ ||-v<l> t : A | VΓ | VA]) :
   [Δ ||-v (t[σ] .: σ) : Γ ,, A | validSnoc VΓ VA | wfΔ].
 Proof. unshelve eapply consSubstS; tea; now eapply validTm. Defined.
 
 Set Printing Primitive Projection Parameters.
 
-Lemma consSubstSEqvalid {Γ σ σ' t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) 
+Lemma consSubstSEqvalid {Γ σ σ' t l A Δ} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
   (Vσ' : [Δ ||-v σ' : Γ | VΓ | wfΔ]) 
   (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ])
-  (VA : [Γ ||-v<l> A | VΓ])
+  {VA : [Γ ||-v<l> A | VΓ]}
   (Vt : [Γ ||-v<l> t : A | VΓ | VA]) :
-  [Δ ||-v (t[σ] .: σ) ≅  (t[σ'] .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ | consSubstSvalid VΓ wfΔ Vσ VA Vt].
+  [Δ ||-v (t[σ] .: σ) ≅  (t[σ'] .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ | consSubstSvalid Vσ Vt].
 Proof.
   unshelve econstructor; intros; tea.
   now apply validTmExt.

--- a/theories/Substitution/Reflexivity.v
+++ b/theories/Substitution/Reflexivity.v
@@ -11,7 +11,7 @@ Lemma reflValidTy {Γ A l} (VΓ : [||-v Γ])
   (VA : [Γ ||-v<l> A | VΓ]) :
   [Γ ||-v<l> A ≅ A | VΓ | VA].
 Proof.
-  constructor; intros; apply LRTyEqRefl_.
+  constructor; intros; apply reflLRTyEq.
 Qed.
 
 Lemma reflValidTm {Γ t A l} (VΓ : [||-v Γ])
@@ -19,7 +19,7 @@ Lemma reflValidTm {Γ t A l} (VΓ : [||-v Γ])
   (Vt : [Γ ||-v<l> t : A | VΓ | VA]) :
   [Γ ||-v<l> t ≅ t : A | VΓ | VA].
 Proof.
-  constructor; intros; apply LREqTermRefl_; now eapply validTm.
+  constructor; intros; apply reflLRTmEq; now eapply validTm.
 Qed.
 
 End Reflexivity.

--- a/theories/Substitution/SingleSubst.v
+++ b/theories/Substitution/SingleSubst.v
@@ -47,8 +47,8 @@ Lemma substSEq {Γ F F' G G' t t' l} {VΓ : [||-v Γ]}
 Proof.
   constructor; intros.
   assert (VtF' : [Γ ||-v<l> t : F' | VΓ | VF']) by now eapply conv.
-  pose proof (consSubstSvalid _ _ Vσ _ Vt').
-  pose proof (consSubstSvalid _ _ Vσ _ VtF').
+  pose proof (consSubstSvalid Vσ Vt').
+  pose proof (consSubstSvalid Vσ VtF').
   rewrite singleSubstComm; irrelevance0.
   1: symmetry; apply singleSubstComm.
   eapply transEq.
@@ -107,9 +107,9 @@ Proof.
   + unshelve now eapply validTmEq.
     2: now eapply consSubstSvalid.
   + assert (Vσt : [Δ ||-v (t[σ] .: σ) : _ | VΓF' | wfΔ])
-     by (eapply consValid; tea; now eapply conv).
+     by (eapply consSubstSvalid; tea; now eapply conv).
     assert (Vσt' : [Δ ||-v (t'[σ] .: σ) : _ | VΓF' | wfΔ])
-     by (eapply consValid; tea; now eapply conv).
+     by (eapply consSubstSvalid; tea; now eapply conv).
     assert (Vσtσt' : [Δ ||-v (t[σ] .: σ) ≅ (t'[σ] .: σ) : _ | VΓF' | wfΔ | Vσt]).
     1:{
       constructor.
@@ -119,7 +119,7 @@ Proof.
     eapply LRTmEqRedConv.
     2: eapply (validTmExt Vf' _ Vσt Vσt' Vσtσt').
     eapply LRTyEqSym. now eapply validTyEq.
-    Unshelve. 2: now eapply consValid.
+    Unshelve. 2: now eapply consSubstSvalid.
 Qed.
 
 (* Skipping a series of lemmas on single substitution of a weakened term *)

--- a/theories/TypeConstructorsInj.v
+++ b/theories/TypeConstructorsInj.v
@@ -350,6 +350,40 @@ Section Boundary.
   Lemma shift_subst_eq t a : t⟨↑⟩[a..] = t.
   Proof. now asimpl. Qed.
 
+  Lemma idElimMotiveCtx {Γ A x} : 
+    [Γ |- A] ->
+    [Γ |- x : A] ->
+    [|- (Γ,, A),, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)].
+  Proof.
+    intros; assert [|- Γ] by boundary.
+    assert [|- Γ,, A] by now econstructor.
+    econstructor; tea.
+    econstructor.
+    1: now eapply wft_wk. 
+    1:  eapply ty_wk; tea; econstructor; tea.
+    rewrite wk1_ren_on; now eapply ty_var0.
+  Qed.
+
+  Lemma idElimMotiveCtxConv {Γ Γ' A A' x x'} :
+    [|- Γ ≅ Γ'] ->
+    [Γ |- A ≅ A'] ->
+    [Γ |- x ≅ x' : A] ->
+    [ |- (Γ,, A),, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)] ->
+    [ |- (Γ',, A'),, tId A'⟨@wk1 Γ' A'⟩ x'⟨@wk1 Γ' A'⟩ (tRel 0)] ->
+    [ |- (Γ',, A'),, tId A'⟨@wk1 Γ' A'⟩ x'⟨@wk1 Γ' A'⟩ (tRel 0) ≅ (Γ,, A),, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)].
+  Proof.
+    intros.
+    assert [|- Γ] by boundary.
+    assert [Γ |- A] by boundary.
+    eapply convCtxSym0; tea.
+    econstructor.
+    1: econstructor; tea; now eapply ctx_refl.
+    erewrite (wk1_irr (t:=A')), (wk1_irr (t:=x')); econstructor.
+    1,2: eapply typing_wk; tea; gen_typing.
+    rewrite wk1_ren_on; eapply TermRefl; now eapply ty_var0.
+  Qed.
+
+
   Let PCon (Γ : context) := True.
   Let PTy (Γ : context) (A : term) := True.
   Let PTm (Γ : context) (A t : term) := [Γ |- A].
@@ -499,23 +533,9 @@ Section Boundary.
       1: now econstructor.
       econstructor.
       1: econstructor; tea; try eapply wfTermConv; refold; tea.
-      + assert [ |- (Γ,, A'),, tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0)].
-        1:{
-          econstructor; tea.
-          econstructor.
-          1: now eapply wft_wk. 
-          1:  eapply ty_wk; tea; econstructor; tea.
-          rewrite wk1_ren_on; now eapply ty_var0.
-        }
-        eapply stability0; tea.
-        eapply convCtxSym0; tea.
-        1: now boundary.
-        econstructor.
-        1: econstructor; tea; now eapply ctx_refl.
-        assert (h : forall t, t⟨@wk1 Γ A'⟩ = t⟨@wk1 Γ A⟩) by reflexivity.
-        rewrite 2!h; econstructor.
-        1,2: eapply typing_wk; tea; gen_typing.
-        rewrite wk1_ren_on; eapply TermRefl; now eapply ty_var0.
+      + eapply stability0; tea.
+        2: eapply idElimMotiveCtxConv; tea; try now boundary + eapply ctx_refl.
+        1,2: eapply idElimMotiveCtx; tea; now eapply wfTermConv.
       + eapply typing_subst2; tea.
         cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq.
         now econstructor.

--- a/theories/TypeConstructorsInj.v
+++ b/theories/TypeConstructorsInj.v
@@ -946,6 +946,22 @@ Proof.
   all: now cbn in Hconv.
 Qed.
 
+Lemma id_isId Γ t {A x y} :
+  [Γ |-[de] t : tId A x y] ->
+  whnf t ->
+  whne t + ∑ A' x', t = tRefl A' x'.
+Proof.
+  intros Hty wh; destruct wh; try easy.
+  all: eapply termGen' in Hty; cbn in *; exfalso.
+  all: prod_hyp_splitter ; try easy; subst.
+  all:
+    match goal with
+      H : [_ |-[de] _ ≅ tId _ _ _] |- _ => unshelve eapply ty_conv_inj in H as Hconv
+    end; try econstructor.
+  all: now cbn in Hconv.
+Qed.
+
+
 Lemma neutral_isNeutral Γ A t :
   [Γ |-[de] t : A] ->
   whne A ->

--- a/theories/TypeConstructorsInj.v
+++ b/theories/TypeConstructorsInj.v
@@ -22,6 +22,7 @@ Section TypeConstructors.
       | EmptyType, EmptyType => True
       | NeType _, NeType _ => [Γ |- T ≅ T' : U]
       | @SigType A B, @SigType A' B' => [Γ |- A' ≅ A] × [Γ,, A' |- B ≅ B']
+      | @IdType A x y, @IdType A' x' y' => [× [Γ |- A' ≅ A], [Γ |- x ≅ x' : A] & [Γ |- y ≅ y' : A]]
       | _, _ => False
     end.
 
@@ -38,30 +39,8 @@ Section TypeConstructors.
     clear HT.
     destruct HTred as [[] lr] ; cbn in *.
     destruct lr.
-    - destruct Hconv as [[]].
-      eexists ; split; tea.
-      constructor.
-    - destruct Hconv as [? red].
-      eexists ; split.
-      1: apply red.
-      symmetry in eq; apply convneu_whne in eq.
-      now constructor.
-    - destruct Hconv as [?? red].
-      eexists ; split.
-      1: apply red.
-      now constructor.
-    - destruct Hconv as [red].
-      eexists ; split.
-      1: apply red.
-      now constructor.
-    - destruct Hconv as [red].
-      eexists ; split.
-      1: apply red.
-      now constructor.
-    - destruct Hconv as [?? red].
-      eexists; split.
-      1: apply red.
-      now constructor.
+    all: destruct Hconv; eexists; split; [lazymatch goal with H : [_ |- _ :⇒*: _] |- _ => apply H end|]; constructor.
+    eapply convneu_whne; now symmetry.
   Qed.
 
   Lemma ty_conv_inj : forall (Γ : context) (T T' : term) (nfT : isType T) (nfT' : isType T'),
@@ -75,13 +54,14 @@ Section TypeConstructors.
     clearbody HTred.
     clear HT.
     eapply reducibleTy in HT'.
-    destruct HTred as [[] lrT].
-    cbn in *.
-    inversion lrT ; subst ; clear lrT.
-    - subst.
-      destruct Hconv as [].
+    revert nfT T' nfT' HΓ HT' Hconv. 
+    revert HTred. 
+    generalize (eq_refl : one = one).
+    generalize one at 1 3; intros l eql HTred; revert eql.
+    pattern l, Γ, T, HTred; apply LR_rect_TyUr; clear l Γ T HTred.
+    all: intros ? Γ T.
+    - intros [] -> nfT T' nfT' HΓ HT' [].
       assert (T' = U) as HeqT' by (eapply redtywf_whnf ; gen_typing); subst.
-      destruct H.
       assert (T = U) as HeqU by (eapply redtywf_whnf ; gen_typing). 
       destruct nfT ; inversion HeqU ; subst.
       2: now exfalso ; gen_typing.
@@ -90,74 +70,62 @@ Section TypeConstructors.
       destruct nfT' ; inversion HeqU ; subst.
       2: now exfalso ; gen_typing.
       now reflexivity.
-    - destruct neA as [nT ? ne], Hconv as [nT' ? ne'] ; cbn in *.
+    - intros [nT ? ne] -> nfT T' nfT' HΓ HT' [nT' ? ne']; cbn in *.
       assert (T = nT) as <- by
         (apply red_whnf ; gen_typing).
       assert (T' = nT') as <- by
         (apply red_whnf ; gen_typing).
       destruct nfT.
-      + apply convneu_whne in ne, ne'; exfalso ; gen_typing.
-      + apply convneu_whne in ne, ne'; exfalso ; gen_typing.
-      + apply convneu_whne in ne, ne'; inversion ne.
-      + apply convneu_whne in ne, ne'; inversion ne.
-      + apply convneu_whne in ne, ne'; inversion ne.
-      + destruct nfT'.
-        * symmetry in ne'; apply convneu_whne in ne, ne'; exfalso ; gen_typing.
-        * symmetry in ne'; apply convneu_whne in ne, ne'; exfalso ; gen_typing.
-        * symmetry in ne'; apply convneu_whne in ne, ne'; inversion ne'.
-        * symmetry in ne'; apply convneu_whne in ne, ne'; inversion ne'.
-        * symmetry in ne'; apply convneu_whne in ne, ne'; inversion ne'; gen_typing.
-        * cbn. gen_typing.
-    - assert [|- Γ] by (apply escape in HT' ; boundary).
-      rewrite <- (ParamRedTy.beta_pack ΠAad) in *.
-      remember (ParamRedTy.from ΠAad) as ΠA' eqn:Heq in *.
-      clear ΠA ΠAad Heq.
-      destruct ΠA' as [dom cod red], Hconv as [dom' cod' red'] ; cbn in *.
+      1-6: apply convneu_whne in ne; inversion ne.
+      destruct nfT'.
+      1-6: symmetry in ne'; apply convneu_whne in ne'; inversion ne'.
+      cbn. gen_typing.
+    - intros [dom cod red] _ _ -> nfT T' nfT' HΓ HT'[dom' cod' red']; cbn in *.
       assert (T = tProd dom cod) as HeqT by (apply red_whnf ; gen_typing). 
       assert (T' = tProd dom' cod') as HeqT' by (apply red_whnf ; gen_typing).
-      destruct nfT.
-      1,3,4,5: congruence.
-      2: subst ; exfalso ; gen_typing.
-      destruct nfT'.
-      1,3,4,5: congruence.
-      2: subst ; exfalso ; gen_typing.
-      inversion HeqT ; inversion HeqT' ; subst ; clear HeqT HeqT'.
-      cbn.
+      destruct nfT; cycle -1.
+      1: subst ; exfalso ; gen_typing.
+      all: try congruence.
+      destruct nfT'; cycle -1.
+      1: subst ; exfalso ; gen_typing.
+      all: try congruence.
+      inversion HeqT ; inversion HeqT' ; subst ; clear HeqT HeqT'; cbn.
       destruct (polyRedEqId (normRedΠ0 (invLRΠ HT')) (PolyRedEqSym _ polyRed0)).
       split; now escape.
-    - destruct Hconv.
+    - intros [] -> nfT T' nfT' HΓ HT' [].
       assert (T' = tNat) as HeqT' by (eapply redtywf_whnf ; gen_typing).
-      assert (T = tNat) as HeqT by (destruct NA; eapply redtywf_whnf ; gen_typing).
+      assert (T = tNat) as HeqT by (eapply redtywf_whnf ; gen_typing).
       destruct nfT; inversion HeqT.
       + destruct nfT'; inversion HeqT'.
         * constructor.
         * exfalso; subst; inversion w.
       + exfalso; subst; inversion w.
-    - destruct Hconv.
+    - intros [] -> nfT T' nfT' HΓ HT' [].
       assert (T' = tEmpty) as HeqT' by (eapply redtywf_whnf ; gen_typing).
-      assert (T = tEmpty) as HeqT by (destruct NA; eapply redtywf_whnf ; gen_typing).
+      assert (T = tEmpty) as HeqT by (eapply redtywf_whnf ; gen_typing).
       destruct nfT; inversion HeqT.
       + destruct nfT'; inversion HeqT'.
         * econstructor.
         * exfalso; subst; inversion w.
       + exfalso; subst; inversion w.
-    - assert [|- Γ] by (apply escape in HT' ; boundary).
-      rewrite <- (ParamRedTy.beta_pack ΣAad) in *.
-      remember (ParamRedTy.from ΣAad) as ΣA' eqn:Heq in *.
-      clear ΣA ΣAad Heq.
-      destruct ΣA' as [dom cod red], Hconv as [dom' cod' red'] ; cbn in *.
+    - intros [dom cod red] _ _ -> nfT T' nfT' HΓ HT' [dom' cod' red'].
       assert (T = tSig dom cod) as HeqT by (apply red_whnf ; gen_typing). 
       assert (T' = tSig dom' cod') as HeqT' by (apply red_whnf ; gen_typing).
-      destruct nfT.
-      1-4: congruence.
-      2: subst; inv_whne.
-      destruct nfT'.
-      1-4: congruence.
-      2: subst ; inv_whne.
-      inversion HeqT ; inversion HeqT' ; subst ; clear HeqT HeqT'.
-      cbn.
+      destruct nfT; cycle -1.
+      1: subst; inv_whne.
+      all: try congruence.
+      destruct nfT'; cycle -1.
+      1: subst; inv_whne.
+      all: try congruence.
+      inversion HeqT ; inversion HeqT' ; subst ; clear HeqT HeqT'; cbn.
       destruct (polyRedEqId (normRedΣ0 (invLRΣ HT')) (PolyRedEqSym _ polyRed0)).
       split; now escape.
+    - intros [??? ty] _ _ -> nfT T' nfT' HΓ HT' [??? ty']; cbn in *.
+      assert (T = ty) as HeqT by (apply red_whnf; gen_typing).
+      assert (T' = ty') as HeqT' by (apply red_whnf; gen_typing).
+      destruct nfT; cycle -1; [subst; inv_whne|..]; unfold ty in *; try congruence.
+      destruct nfT'; cycle -1; [subst; inv_whne|..]; unfold ty' in *; try congruence.
+      cbn; inversion HeqT; inversion HeqT'; subst; escape; now split.
   Qed.
 
   Corollary red_ty_compl_univ_l Γ T :
@@ -301,6 +269,40 @@ Section TypeConstructors.
     now eassumption.
   Qed.
 
+  Corollary red_ty_compl_id_l Γ A x y T :
+    [Γ |- tId A x y ≅ T] ->
+    ∑ A' x' y', [× [Γ |- T ⇒* tId A' x' y'], [Γ |- A' ≅ A], [Γ |- x ≅ x' : A] & [Γ |- y ≅ y' : A]].
+  Proof.
+    intros HT.
+    pose proof HT as HT'.
+    unshelve eapply red_ty_complete in HT as (T''&[? nfT]).
+    2: econstructor.
+    assert [Γ |- tId A x y ≅ T''] as Hconv by 
+      (etransitivity ; [eassumption|now eapply RedConvTyC]).
+    unshelve eapply ty_conv_inj in Hconv.
+    1: constructor.
+    1: assumption.
+    destruct nfT, Hconv.
+    do 3 eexists ; split; eassumption.
+  Qed.
+  
+  Corollary red_ty_compl_id_r Γ A x y T :
+    [Γ |- T ≅ tId A x y] ->
+    ∑ A' x' y', [× [Γ |- T ⇒* tId A' x' y'], [Γ |- A' ≅ A], [Γ |- x ≅ x' : A] & [Γ |- y ≅ y' : A]].
+  Proof.
+    intros; eapply red_ty_compl_id_l; now symmetry.
+  Qed.
+
+  Corollary id_ty_inj {Γ A A' x x' y y'} :
+    [Γ |- tId A x y ≅ tId A' x' y'] ->
+    [× [Γ |- A' ≅ A], [Γ |- x ≅ x' : A] & [Γ |- y ≅ y' : A]].
+  Proof.
+    intros Hty.
+    unshelve eapply ty_conv_inj in Hty.
+    1-2: constructor.
+    now eassumption.
+  Qed.
+
 End TypeConstructors.
 
 Section Boundary.
@@ -320,11 +322,40 @@ Section Boundary.
       now eapply typing_wk.
   Qed.
 
+  Lemma scons2_well_subst {Γ A B} : 
+    (forall a b, [Γ |- a : A] -> [Γ |- b : B[a..]] -> [Γ |-s (b .: a ..) : (Γ ,, A),, B])
+    × (forall a a' b b', [Γ |- a ≅ a' : A] -> [Γ |- b ≅ b' : B[a..]] -> [Γ |-s (b .: a..) ≅ (b' .: a'..) : (Γ ,, A),, B]).
+  Proof.
+    assert (h : forall (a : term) σ, ↑ >> (a .: σ) =1 σ) by reflexivity.
+    assert (h' : forall a σ t, t[↑ >> (a .: σ)] = t[σ]) by (intros; now setoid_rewrite h).
+    split; intros; econstructor.
+    - asimpl; econstructor.
+      2: cbn; rewrite h'; now asimpl.
+      asimpl; eapply id_subst; gen_typing.
+    - cbn; now rewrite h'.
+    - asimpl; econstructor.
+      2: cbn; rewrite h'; now asimpl.
+      asimpl; eapply subst_refl; eapply id_subst; gen_typing.
+    - cbn; now rewrite h'.
+  Qed.
+
+  Lemma typing_subst2 {Γ A B} :
+    [|- Γ] ->
+    (forall P a b, [Γ |- a : A] -> [Γ |- b : B[a..]] -> [Γ,, A,, B |- P] -> [Γ |- P[b .: a ..]])
+    × (forall P P' a a' b b', [Γ |- a ≅ a' : A] -> [Γ |- b ≅ b' : B[a..]] -> [Γ,, A ,, B |- P ≅ P'] -> [Γ |- P[b .: a..] ≅ P'[b' .: a'..]]).
+  Proof.
+    intros;split; intros; eapply typing_subst; tea; now eapply scons2_well_subst.
+  Qed.
+
+  Lemma shift_subst_eq t a : t⟨↑⟩[a..] = t.
+  Proof. now asimpl. Qed.
+
   Let PCon (Γ : context) := True.
   Let PTy (Γ : context) (A : term) := True.
   Let PTm (Γ : context) (A t : term) := [Γ |- A].
   Let PTyEq (Γ : context) (A B : term) := [Γ |- A] × [Γ |- B].
   Let PTmEq (Γ : context) (A t u : term) := [× [Γ |- A], [Γ |- t : A] & [Γ |- u : A]].
+
 
   Lemma boundary : WfDeclInductionConcl PCon PTy PTm PTyEq PTmEq.
   Proof.
@@ -350,6 +381,10 @@ Section Boundary.
       eapply typing_subst1.
       + now econstructor.
       + now eapply sig_ty_inv.
+    - intros; now econstructor.
+    - intros; eapply typing_subst2; tea.
+      1: gen_typing.
+      cbn; now rewrite 2!wk1_ren_on, 2!shift_subst_eq.
     - intros * ? _ ? [] ? [].
       split.
       all: constructor ; tea.
@@ -362,6 +397,7 @@ Section Boundary.
       eapply stability1. 
       3: now symmetry.
       all: tea.
+    - intros; prod_hyp_splitter; split; econstructor; tea; now eapply wfTermConv.
     - intros * ? [].
       split.
       all: now econstructor.
@@ -448,6 +484,60 @@ Section Boundary.
       + now do 2 econstructor.
       + econstructor; tea.
         symmetry; eapply typing_subst1; tea.
+        now econstructor.
+    - intros; prod_hyp_splitter; split; tea; econstructor; tea.
+      all: eapply wfTermConv; tea; now econstructor.
+    - intros; prod_hyp_splitter; split.
+      all: econstructor; tea.
+      1: econstructor; tea; now eapply wfTermConv.
+      symmetry; now econstructor.
+    - intros; prod_hyp_splitter.
+      assert [|- Γ] by gen_typing.
+      assert [|- Γ,, A'] by now econstructor.
+      split.
+      1: eapply typing_subst2; tea; cbn; now rewrite 2!wk1_ren_on, 2!shift_subst_eq.
+      1: now econstructor.
+      econstructor.
+      1: econstructor; tea; try eapply wfTermConv; refold; tea.
+      + assert [ |- (Γ,, A'),, tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0)].
+        1:{
+          econstructor; tea.
+          econstructor.
+          1: now eapply wft_wk. 
+          1:  eapply ty_wk; tea; econstructor; tea.
+          rewrite wk1_ren_on; now eapply ty_var0.
+        }
+        eapply stability0; tea.
+        eapply convCtxSym0; tea.
+        1: now boundary.
+        econstructor.
+        1: econstructor; tea; now eapply ctx_refl.
+        assert (h : forall t, t⟨@wk1 Γ A'⟩ = t⟨@wk1 Γ A⟩) by reflexivity.
+        rewrite 2!h; econstructor.
+        1,2: eapply typing_wk; tea; gen_typing.
+        rewrite wk1_ren_on; eapply TermRefl; now eapply ty_var0.
+      + eapply typing_subst2; tea.
+        cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq.
+        now econstructor.
+      + now econstructor.
+      + symmetry; eapply typing_subst2; tea.
+        cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq; tea.
+    - intros; prod_hyp_splitter.
+      assert [|- Γ] by gen_typing.
+      assert [Γ |- tRefl A' z : tId A x y].
+      1:{
+        econstructor.
+        1: econstructor; tea; now econstructor.
+        symmetry; econstructor; tea; etransitivity; tea; now symmetry.
+      }
+      split; tea.
+      + eapply typing_subst2; tea.
+        cbn; now rewrite 2!wk1_ren_on, 2!shift_subst_eq.
+      + econstructor; tea.
+      + econstructor; tea.
+        eapply typing_subst2; tea.
+        2: now econstructor.
+        cbn; rewrite 2!wk1_ren_on, 2!shift_subst_eq.
         now econstructor.
     - intros * ? [] ? [].
       split ; gen_typing.
@@ -561,18 +651,7 @@ Section Stability.
     [ |- Γ ≅ Δ] ->
     [Γ |-s tRel : Δ].
   Proof.
-    induction 1 as [| * ? HA].
-    - now econstructor.
-    - assert [Γ |- A] by boundary.
-      assert [|- Γ,, A] by
-        (econstructor ; boundary).
-      econstructor ; tea.
-      + eapply well_subst_ext, well_subst_up ; tea.
-        reflexivity.
-      + eapply wfTermConv.
-        1: econstructor; [gen_typing| now econstructor].
-        rewrite <- rinstInst'_term; do 2 erewrite <- wk1_ren_on.
-        now eapply typing_wk.
+    intros; eapply conv_well_subst; tea; boundary.
   Qed.
 
   Let PCon (Γ : context) := True.
@@ -587,16 +666,7 @@ Section Stability.
 
   Theorem stability : WfDeclInductionConcl PCon PTy PTm PTyEq PTmEq.
   Proof.
-    red.
-    repeat match goal with |- _ × _ => split end.
-    1: now unfold PCon.
-    all: intros * Hty Δ HΔ.
-    all: pose proof (boundary_ctx_conv_l _ _ HΔ).
-    all: eapply conv_well_subst in HΔ.
-    all: pose proof (subst_refl _ _ _ HΔ).
-    all: eapply typing_subst in Hty ; tea.
-    all: asimpl ; repeat (rewrite idSubst_term in Hty ; [..|reflexivity]).
-    all: try eassumption.
+    red; prod_splitter; intros; red;intros; eapply stability0; tea; boundary.
   Qed.
 
 
@@ -699,6 +769,17 @@ Proof.
     }
     eapply TermConv; tea; refold.
     now econstructor.
+  - apply termGen' in Hty as [? [[-> ????? h]]].
+    apply termGen' in h as [? [[->] h']].
+    pose proof h' as []%id_ty_inj.
+    econstructor; tea.
+    econstructor; tea.
+    1: now econstructor.
+    + eapply TermConv; refold; [etransitivity; tea|]; now symmetry.
+    + eapply TermConv; refold; now symmetry.
+  - apply termGen' in Hty as [? [[-> ????? h]]].
+    econstructor; tea; econstructor; tea.
+    all: now first [eapply TypeRefl |eapply TermRefl| eauto].
   Qed.
 
 
@@ -781,10 +862,9 @@ Lemma type_isType Γ A :
   whnf A ->
   isType A.
 Proof.
-  intros [] ; refold.
-  1-5: econstructor.
-  intros.
-  now eapply Uterm_isType.
+  intros [] ; refold; cycle -1.
+  1: intros; now eapply Uterm_isType.
+  all: econstructor.
 Qed.
 
 Lemma fun_isFun Γ A B t:

--- a/theories/UntypedReduction.v
+++ b/theories/UntypedReduction.v
@@ -33,6 +33,11 @@ Inductive OneRedAlg : term -> term -> Type :=
     [ tSnd p ⇒ tSnd p']
 | sndPair {A B a b} :
     [ tSnd (tPair A B a b) ⇒ b ]
+| idElimRefl {A x P hr y A' z} :
+  [ tIdElim A x P hr y (tRefl A' z) ⇒ hr ]
+| idElimSubst {A x P hr y e e'} :
+  [e ⇒ e'] ->
+  [ tIdElim A x P hr y e ⇒ tIdElim A x P hr y e' ]
 
 where "[ t ⇒ t' ]" := (OneRedAlg t t') : typing_scope.
 
@@ -81,8 +86,8 @@ Lemma whnf_nored n u :
 Proof.
   intros nf red.
   induction red in nf |- *.
-  2,3,6,7,9: inversion nf; subst; inv_whne; subst; apply IHred; now constructor.
-  all: inversion nf; subst; inv_whne; subst; now inv_whne.
+  2,3,6,7,9,12: inversion nf; subst; inv_whne; subst; apply IHred; now constructor.
+  all: inversion nf; subst; inv_whne; subst; try now inv_whne.
 Qed.
 
 (** *** Determinism of reduction *)
@@ -125,6 +130,11 @@ Proof.
     exfalso; eapply whnf_nored; tea; constructor.
   - inversion red'; subst; try reflexivity.
     exfalso; eapply whnf_nored; tea; constructor.
+  - inversion red'; subst; try reflexivity.
+    exfalso; eapply whnf_nored;tea; constructor.
+  - inversion red'; subst.
+    2: f_equal; eauto.
+    exfalso; eapply whnf_nored;tea; constructor.
 Qed.
 
 Lemma red_whne t u : [t ⇒* u] -> whne t -> t = u.
@@ -176,7 +186,7 @@ Lemma oredalg_wk (ρ : nat -> nat) (t u : term) :
 Proof.
   intros Hred.
   induction Hred in ρ |- *.
-  2-5,6-10: cbn; asimpl; now econstructor.
+  2-5,6-12: cbn; asimpl; now econstructor.
   - cbn ; asimpl.
     evar (t' : term).
     replace (subst_term _ t) with t'.
@@ -225,6 +235,12 @@ Proof.
 Qed.
 
 Lemma redalg_snd {t t'} : [t ⇒* t'] -> [tSnd t ⇒* tSnd t'].
+Proof.
+  induction 1; [reflexivity|].
+  econstructor; tea; now constructor.
+Qed.
+
+Lemma redalg_idElim {A x P hr y t t'} : [t ⇒* t'] -> [tIdElim A x P hr y t ⇒* tIdElim A x P hr y t'].
 Proof.
   induction 1; [reflexivity|].
   econstructor; tea; now constructor.

--- a/theories/Weakening.v
+++ b/theories/Weakening.v
@@ -455,3 +455,5 @@ Lemma wk_comp_assoc {Γ Δ Ξ ζ} (ρ : Δ ≤ Γ) (ρ' : Ξ ≤ Δ) (ρ'' : ζ 
 Proof. now bsimpl. Qed.
 
 
+Lemma wk1_irr {Γ Γ' A A' t} : t⟨@wk1 Γ A⟩ = t⟨@wk1 Γ' A'⟩.
+Proof. intros; now rewrite 2!wk1_ren_on. Qed.

--- a/theories/Weakening.v
+++ b/theories/Weakening.v
@@ -157,7 +157,6 @@ Definition wk_well_wk_compose {Γ Γ' Γ'' : context} (ρ : Γ ≤ Γ') (ρ' : �
   {| wk := wk_compose ρ.(wk) ρ'.(wk) ; well_wk := well_wk_compose ρ.(well_wk) ρ'.(well_wk) |}.
 Notation "ρ ∘w ρ'" := (wk_well_wk_compose ρ ρ').
 
-
 (** ** The ubiquitous operation of adding one variable at the end of a context *)
 
 Definition wk1 {Γ} A : Γ,, A ≤ Γ := wk_step A (wk_id (Γ := Γ)).
@@ -444,3 +443,15 @@ Proof. now bsimpl. Qed.
 Lemma wk_idElim {A x P hr y e Δ Γ} (ρ : Δ ≤ Γ) :
   tIdElim A⟨ρ⟩ x⟨ρ⟩ P⟨wk_up (tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)) (wk_up A ρ)⟩ hr⟨ρ⟩ y⟨ρ⟩ e⟨ρ⟩ = (tIdElim A x P hr y e)⟨ρ⟩.
 Proof.  now cbn. Qed.
+
+Lemma wk_comp_lunit {Γ Δ} (ρ : Δ ≤ Γ) : wk_id ∘w ρ =1 ρ.
+Proof. now bsimpl. Qed.
+
+Lemma wk_comp_runit {Γ Δ} (ρ : Δ ≤ Γ) : ρ ∘w wk_id =1 ρ.
+Proof. now bsimpl. Qed.
+
+Lemma wk_comp_assoc {Γ Δ Ξ ζ} (ρ : Δ ≤ Γ) (ρ' : Ξ ≤ Δ) (ρ'' : ζ ≤ Ξ) :
+  (ρ'' ∘w ρ') ∘w ρ =1 ρ'' ∘w (ρ' ∘w ρ).
+Proof. now bsimpl. Qed.
+
+

--- a/theories/Weakening.v
+++ b/theories/Weakening.v
@@ -363,8 +363,16 @@ Ltac bsimpl := check_no_evars;
 Lemma subst_ren_wk_up {Γ Δ P A n} (ρ : Γ ≤ Δ): P[n..]⟨ρ⟩ = P⟨wk_up A ρ⟩[n⟨ρ⟩..].
 Proof. now bsimpl. Qed.
 
+Lemma subst_ren_wk_up2 {Γ Δ P A B a b} (ρ : Γ ≤ Δ): 
+  P[a .: b..]⟨ρ⟩ = P⟨wk_up A (wk_up B ρ)⟩[a⟨ρ⟩ .: b⟨ρ⟩..].
+Proof. now bsimpl. Qed.
+
 Lemma subst_ren_subst_mixed {Γ Δ P n} (ρ : Γ ≤ Δ): P[n..]⟨ρ⟩ = P[n⟨ρ⟩ .: ρ >> tRel].
 Proof. now bsimpl. Qed.
+
+Lemma subst_ren_subst_mixed2 {Γ Δ P a b} (ρ : Γ ≤ Δ): P[a .: b..]⟨ρ⟩ = P[a⟨ρ⟩ .: (b⟨ρ⟩ .: ρ >> tRel)].
+Proof. now bsimpl. Qed.
+
 
 Lemma wk_up_ren_subst {Γ Δ Ξ P A n}  (ρ : Γ ≤ Δ) (ρ' : Δ ≤ Ξ) : 
   P[n .: ρ ∘w ρ' >> tRel] = P⟨wk_up A ρ'⟩[n .: ρ >> tRel].
@@ -419,3 +427,20 @@ Proof. now cbn. Qed.
 Lemma wk_comp {Γ Δ A f g} (ρ : Δ ≤ Γ) : (comp A f g)⟨ρ⟩ = comp A⟨ρ⟩ f⟨ρ⟩ g⟨ρ⟩.
 Proof. now bsimpl. Qed.
 
+Lemma wk_Id {A x y Γ Δ} (ρ : Δ ≤ Γ) : tId A⟨ρ⟩ x⟨ρ⟩ y⟨ρ⟩ = (tId A x y)⟨ρ⟩.
+Proof. now cbn. Qed.
+
+Lemma wk_refl {A x Γ Δ} (ρ : Δ ≤ Γ) : tRefl A⟨ρ⟩ x⟨ρ⟩ = (tRefl A x)⟨ρ⟩.
+Proof. now cbn. Qed.
+
+
+Lemma wk_step_wk1 {A t Γ Δ} (ρ : Δ ≤ Γ) :  t⟨ρ⟩⟨@wk1 Δ A⟩ = t⟨wk_step A ρ⟩.
+Proof. now bsimpl. Qed.
+
+Lemma wk_up_wk1 {A t Γ Δ} (ρ : Δ ≤ Γ) :  t⟨ρ⟩⟨@wk1 Δ A⟨ρ⟩⟩ = t⟨@wk1 Γ A⟩⟨wk_up A ρ⟩.
+Proof. now bsimpl. Qed.
+
+
+Lemma wk_idElim {A x P hr y e Δ Γ} (ρ : Δ ≤ Γ) :
+  tIdElim A⟨ρ⟩ x⟨ρ⟩ P⟨wk_up (tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)) (wk_up A ρ)⟩ hr⟨ρ⟩ y⟨ρ⟩ e⟨ρ⟩ = (tIdElim A x P hr y e)⟨ρ⟩.
+Proof.  now cbn. Qed.


### PR DESCRIPTION
This PR adds Identity types à la Martin-Löf: types `Id A x y`, reflexivity proofs `refl A x : Id A x x`, the dependent eliminator `J` and the computation rule for `J` on `refl`.