### PR TITLE
Provide explicit statements of consistency and canonicity

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -62,6 +62,8 @@ theories/AlgorithmicTyping.v
 theories/DeclarativeSubst.v
 theories/TypeConstructorsInj.v
 theories/Normalisation.v
+theories/Consequences.v
+
 theories/BundledAlgorithmicTyping.v
 theories/AlgorithmicConvProperties.v
 theories/AlgorithmicTypingProperties.v

--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -375,7 +375,7 @@ Section TermTypeConv.
   Let PTyEq (Γ : context) (A B : term) := True.
   Let PNeEq (Γ : context) (A t u : term) := True.
   Let PTmEq (Γ : context) (A t u : term) :=
-      [A ⇒* U] ->
+      [A ⤳* U] ->
       [Γ |-[al] t ≅ u].
   Let PTmRedEq (Γ : context) (A t u : term) := 
     A = U ->

--- a/theories/AlgorithmicTyping.v
+++ b/theories/AlgorithmicTyping.v
@@ -14,8 +14,8 @@ Section Definitions.
   (** **** Conversion of types *)
   Inductive ConvTypeAlg : context -> term -> term  -> Type :=
     | typeConvRed {Γ A A' B B'} :
-      [A ⇒* A'] ->
-      [B ⇒* B'] ->
+      [A ⤳* A'] ->
+      [B ⤳* B'] ->
       [Γ |- A' ≅h B'] ->
       [Γ |- A ≅ B]
   (** **** Conversion of types reduced to weak-head normal forms *)
@@ -89,15 +89,15 @@ Section Definitions.
   with ConvNeuRedAlg : context -> term -> term -> term -> Type :=
     | neuConvRed {Γ m n A A'} :
       [Γ |- m ~ n ▹ A] ->
-      [A ⇒* A'] ->
+      [A ⤳* A'] ->
       whnf A' ->
       [Γ |- m ~h n ▹ A']
   (** **** Conversion of terms *)
   with ConvTermAlg : context -> term -> term -> term -> Type :=
     | termConvRed {Γ t t' u u' A A'} :
-      [A ⇒* A'] ->
-      [t ⇒* t'] ->
-      [u ⇒* u' ] ->
+      [A ⤳* A'] ->
+      [t ⤳* t'] ->
+      [u ⤳* u' ] ->
       [Γ |- t' ≅h u' : A'] ->
       [Γ |- t ≅ u : A]
   (** **** Conversion of terms reduced to a weak-head normal form at a reduced type *)
@@ -150,8 +150,8 @@ Section Definitions.
   and "[ Γ |- m ~h n ▹ T ]" := (ConvNeuRedAlg Γ T m n)
   and "[ Γ |- t ≅ u : T ]" := (ConvTermAlg Γ T t u)
   and "[ Γ |- t ≅h u : T ]" := (ConvTermRedAlg Γ T t u)
-  and "[ t ⇒ t' ]" := (OneRedAlg t t')
-  and "[ t ⇒* t' ]" := (RedClosureAlg t t').
+  and "[ t ⤳ t' ]" := (OneRedAlg t t')
+  and "[ t ⤳* t' ]" := (RedClosureAlg t t').
 
 (** ** Typing *)
 
@@ -252,7 +252,7 @@ Section Definitions.
   with InferRedAlg : context -> term -> term -> Type :=
     | infRed {Γ t A A'} :
       [Γ |- t ▹ A ] ->
-      [ A ⇒* A'] ->
+      [ A ⤳* A'] ->
       [Γ |- t ▹h A']
   (** **** Type-checking *)
   with CheckAlg : context -> term -> term -> Type :=

--- a/theories/BundledAlgorithmicTyping.v
+++ b/theories/BundledAlgorithmicTyping.v
@@ -144,7 +144,7 @@ Record RedTypeBun Γ A B :=
 {
   bun_red_ty_ctx : [|-[de] Γ] ;
   bun_red_ty_ty : [Γ |-[al] A] ;
-  bun_red_ty : [A ⇒* B] ;
+  bun_red_ty : [A ⤳* B] ;
 }.
 
 Record OneStepRedTermBun Γ A t u :=
@@ -153,35 +153,35 @@ Record OneStepRedTermBun Γ A t u :=
   (** We do not have the instance yet, so we have to specify it by hand,
   but this really is [Γ |-[bn] t : A]. *)
   bun_osred_tm_tm : typing (ta := bn) (Typing := InferConvBun) Γ A t ;
-  bun_osred_tm : [t ⇒ u]
+  bun_osred_tm : [t ⤳ u]
 }.
 
 Record RedTermBun Γ A t u :=
 {
   bun_red_tm_ctx : [|-[de] Γ] ;
   bun_red_tm_tm : typing (ta := bn) (Typing := InferConvBun) Γ A t ;
-  bun_red_tm : [t ⇒* u] ;
+  bun_red_tm : [t ⤳* u] ;
 }.
 
 Record RedTypeBunI Γ A B :=
 {
   buni_red_ty_ctx : [|-[de] Γ] ;
   buni_red_ty_ty : [Γ |-[de] A] ;
-  buni_red_ty : [A ⇒* B] ;
+  buni_red_ty : [A ⤳* B] ;
 }.
 
 Record OneStepRedTermBunI Γ A t u :=
 {
   buni_osred_tm_ctx : [|-[de] Γ] ;
   buni_osred_tm_tm : [Γ |-[de] t : A] ;
-  buni_osred_tm : [t ⇒ u]
+  buni_osred_tm : [t ⤳ u]
 }.
 
 Record RedTermBunI Γ A t u :=
 {
   buni_red_tm_ctx : [|-[de] Γ] ;
   buni_red_tm_tm : [Γ |-[de] t : A] ;
-  buni_red_tm : [t ⇒* u] ;
+  buni_red_tm : [t ⤳* u] ;
 }.
 
 (** ** Instances *)

--- a/theories/Consequences.v
+++ b/theories/Consequences.v
@@ -1,0 +1,48 @@
+(** * LogRel.TypeConstructorsInj: injectivity and no-confusion of type constructors, and many consequences, including subject reduction. *)
+From Coq Require Import CRelationClasses.
+From LogRel.AutoSubst Require Import core unscoped Ast Extra.
+From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening UntypedReduction
+  GenericTyping DeclarativeTyping DeclarativeInstance TypeConstructorsInj Normalisation.
+
+
+Import DeclarativeTypingData.
+
+
+Lemma no_neutral_empty_ctx {A t} : whne t -> [ε |-[de] t : A] -> False.
+Proof.
+  intros wh; induction wh in A |- *.
+  - intros [? [[? [?? h]]]]%termGen'; inversion h.
+  - intros [? [[? [? []]]]]%termGen'; eauto.
+  - intros [? [[? []]]]%termGen'; eauto.
+  - intros [? [[? []]]]%termGen'; eauto.
+  - intros [? [[? [? []]]]]%termGen'; eauto.
+  - intros [? [[? [? []]]]]%termGen'; eauto.
+  - intros [? [[?]]]%termGen'; eauto.
+Qed.
+
+Lemma wty_norm {Γ t A} : [Γ |- t : A] ->
+  ∑ wh, [× whnf wh, [Γ |- t ⤳* wh : A]& [Γ |- wh : A]].
+Proof.
+  intros wtyt.
+  pose proof (normalisation wtyt) as [wh red].
+  pose proof (h := subject_reduction _ _ _ _ wtyt red).
+  assert [Γ |- wh : A] by (destruct h; boundary).
+  now eexists.
+Qed.
+
+Lemma consistency {t} : [ε |- t : tEmpty] -> False.
+Proof.
+  intros [wh []]%wty_norm; refold.
+  eapply no_neutral_empty_ctx; tea.
+  eapply empty_isEmpty; tea.
+Qed.
+
+
+Lemma nat_canonicity {t} : [ε |- t : tNat] -> [ε |- t ≅ tZero : tNat] + ∑ n, [ε |- t ≅ tSucc n : tNat].
+Proof.
+  intros [wh [whwh [] wtywh]]%wty_norm; refold.
+  destruct (nat_isNat _ _ wtywh whwh).
+  - now left.
+  - right; now eexists.
+  - exfalso; now eapply no_neutral_empty_ctx.
+Qed.

--- a/theories/Consequences.v
+++ b/theories/Consequences.v
@@ -1,11 +1,12 @@
-(** * LogRel.TypeConstructorsInj: injectivity and no-confusion of type constructors, and many consequences, including subject reduction. *)
+(** * LogRel.Consequences: important meta-theoretic consequences of normalization: canonicity of natural numbers and consistency. *)
 From Coq Require Import CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening UntypedReduction
+  LogicalRelation Fundamental Validity LogicalRelation.Induction Substitution.Escape LogicalRelation.Irrelevance
   GenericTyping DeclarativeTyping DeclarativeInstance TypeConstructorsInj Normalisation.
 
 
-Import DeclarativeTypingData.
+Import DeclarativeTypingData DeclarativeTypingProperties.
 
 
 Lemma no_neutral_empty_ctx {A t} : whne t -> [ε |-[de] t : A] -> False.
@@ -30,6 +31,8 @@ Proof.
   now eexists.
 Qed.
 
+(** *** Consistency: there are no closed proofs of false, i.e. no closed inhabitants of the empty type. *)
+
 Lemma consistency {t} : [ε |- t : tEmpty] -> False.
 Proof.
   intros [wh []]%wty_norm; refold.
@@ -37,12 +40,54 @@ Proof.
   eapply empty_isEmpty; tea.
 Qed.
 
+(** *** Canonicity: every closed natural number is a numeral, i.e. an iteration of [tSucc] on [tZero]. *)
 
-Lemma nat_canonicity {t} : [ε |- t : tNat] -> [ε |- t ≅ tZero : tNat] + ∑ n, [ε |- t ≅ tSucc n : tNat].
+Section NatCanonicityInduction.
+
+  Let numeral : nat -> term := fun n => Nat.iter n tSucc tZero.
+
+  #[local] Coercion numeral : nat >-> term.
+
+  #[local] Lemma red_nat_empty : [ε ||-Nat tNat].
+  Proof.
+    repeat econstructor.
+  Qed.
+
+  Lemma nat_red_empty_ind :
+    (forall t, [ε ||-Nat t : tNat | red_nat_empty] ->
+    ∑ n : nat, [ε |- t ≅ n : tNat]) ×
+    (forall t, NatProp red_nat_empty t -> ∑ n : nat, [ε |- t ≅ n : tNat]).
+  Proof.
+    apply NatRedInduction.
+    - intros * [? []] ? _ [n] ; refold.
+      exists n.
+      now etransitivity.
+    - exists 0 ; cbn.
+      now repeat constructor.
+    - intros ? _ [n].
+      exists (S n) ; simpl.
+      now econstructor.
+    - intros ? [? [? _ _]].
+      exfalso.
+      now eapply no_neutral_empty_ctx.
+  Qed.
+
+  Lemma _nat_canonicity {t} : [ε |- t : tNat] ->
+  ∑ n : nat, [ε |- t ≅ n : tNat].
+  Proof.
+    intros Ht.
+    assert [LRNat_ one red_nat_empty | ε ||- t : tNat] as ?%nat_red_empty_ind.
+    {
+      apply Fundamental in Ht as [?? Vt%reducibleTm].
+      irrelevance.
+    }
+    now assumption.
+  Qed.
+
+End NatCanonicityInduction.
+
+Lemma nat_canonicity {t} : [ε |- t : tNat] ->
+  ∑ n : nat, [ε |- t ≅ Nat.iter n tSucc tZero : tNat].
 Proof.
-  intros [wh [whwh [] wtywh]]%wty_norm; refold.
-  destruct (nat_isNat _ _ wtywh whwh).
-  - now left.
-  - right; now eexists.
-  - exfalso; now eapply no_neutral_empty_ctx.
+  now apply _nat_canonicity.
 Qed.

--- a/theories/Decidability/Completeness.v
+++ b/theories/Decidability/Completeness.v
@@ -246,7 +246,7 @@ Section RedImplemComplete.
   Qed.
 
   Corollary wh_red_complete_whnf_class Γ K t t' :
-  [Γ |- t ⇒* t' ∈ K] ->
+  [Γ |- t ⤳* t' ∈ K] ->
   whnf t' ->
   graph wh_red t t'.
   Proof.
@@ -265,7 +265,7 @@ Section RedImplemComplete.
   
   Corollary wh_red_complete_whnf_ty Γ A A' :
   [Γ |-[de] A] ->
-  [A ⇒* A'] ->
+  [A ⤳* A'] ->
   whnf A' ->
   graph wh_red A A'.
   Proof.
@@ -276,7 +276,7 @@ Section RedImplemComplete.
   
   Corollary wh_red_complete_whnf_tm Γ A t t' :
   [Γ |-[de] t : A] ->
-  [t ⇒* t'] ->
+  [t ⤳* t'] ->
   whnf t' ->
   graph wh_red t t'.
   Proof.

--- a/theories/Decidability/Soundness.v
+++ b/theories/Decidability/Soundness.v
@@ -14,7 +14,7 @@ Set Universe Polymorphism.
 
 Section RedImplemSound.
 
-Lemma zip_ored t t' π : [t ⇒ t'] -> [zip t π ⇒ zip t' π].
+Lemma zip_ored t t' π : [t ⤳ t'] -> [zip t π ⤳ zip t' π].
 Proof.
   intros Hred.
   induction π as [|[]] in t, t', Hred |- * ; cbn in *.
@@ -22,7 +22,7 @@ Proof.
   all: apply IHπ ; now econstructor.
 Qed.
 
-Lemma zip_red t t' π : [t ⇒* t'] -> [zip t π ⇒* zip t' π].
+Lemma zip_red t t' π : [t ⤳* t'] -> [zip t π ⤳* zip t' π].
 Proof.
   induction 1.
   1: reflexivity.
@@ -31,7 +31,7 @@ Proof.
 Qed.
 
 Lemma red_stack_sound :
-  funrect wh_red_stack (fun _ => True) (fun '(t,π) t' => [zip t π ⇒* t']).
+  funrect wh_red_stack (fun _ => True) (fun '(t,π) t' => [zip t π ⤳* t']).
 Proof.
   intros ? _.
   funelim (wh_red_stack _).
@@ -83,7 +83,7 @@ Proof.
 Qed.
 
 Corollary _red_sound :
-  funrect wh_red (fun _ => True) (fun t t' => [t ⇒* t'] × whnf t').
+  funrect wh_red (fun _ => True) (fun t t' => [t ⤳* t'] × whnf t').
 Proof.
   intros ? _.
   funelim (wh_red _).
@@ -100,7 +100,7 @@ Qed.
 
 #[universes(polymorphic)]Corollary red_sound t t' :
   graph wh_red t t' ->
-  [t ⇒* t'] × whnf t'.
+  [t ⤳* t'] × whnf t'.
 Proof.
   intros H.
   eapply (funrect_graph wh_red _ _ _ _ _red_sound). (* weird universe inconsistency? *)

--- a/theories/DeclarativeInstance.v
+++ b/theories/DeclarativeInstance.v
@@ -374,7 +374,7 @@ End TypingWk.
 (** ** A first set of boundary conditions *)
 
 (** These lemmas assert that various boundary conditions, ie that if a certain typing-like relation
-holds, some of its components are themselves well-formed. For instance, if [Γ |- t ⇒* u : A] then
+holds, some of its components are themselves well-formed. For instance, if [Γ |- t ⤳* u : A] then
 [Γ |- t : A ]. The tactic boundary automates usage of these lemmas. *)
 
 (** We cannot prove yet that all boundaries are well-typed: this needs stability of typing
@@ -423,21 +423,21 @@ Section Boundaries.
 
 
   Definition boundary_red_l {Γ t u K} : 
-    [ Γ |- t ⇒* u ∈ K] ->
+    [ Γ |- t ⤳* u ∈ K] ->
     match K with istype => [ Γ |- t ] | isterm A => [ Γ |- t : A ] end.
   Proof.
     destruct 1; assumption.
   Qed.
 
   Definition boundary_red_tm_l {Γ t u A} : 
-    [ Γ |- t ⇒* u : A] ->
+    [ Γ |- t ⤳* u : A] ->
     [ Γ |- t : A ].
   Proof.
     apply @boundary_red_l with (K := isterm A).
   Qed.
 
   Definition boundary_red_ty_l {Γ A B} : 
-    [ Γ |- A ⇒* B ] ->
+    [ Γ |- A ⤳* B ] ->
     [ Γ |- A ].
   Proof.
     apply @boundary_red_l with (K := istype).
@@ -454,21 +454,21 @@ End Boundaries.
 (** ** Inclusion of the various reductions in conversion *)
 
 Definition RedConvC {Γ} {t u : term} {K} :
-    [Γ |- t ⇒* u ∈ K] -> 
+    [Γ |- t ⤳* u ∈ K] -> 
     match K with istype => [Γ |- t ≅ u] | isterm A => [Γ |- t ≅ u : A] end.
 Proof.
 apply reddecl_conv.
 Qed.
 
 Definition RedConvTeC {Γ} {t u A : term} :
-    [Γ |- t ⇒* u : A] -> 
+    [Γ |- t ⤳* u : A] -> 
     [Γ |- t ≅ u : A].
 Proof.
 apply @RedConvC with (K := isterm A).
 Qed.
 
 Definition RedConvTyC {Γ} {A B : term} :
-    [Γ |- A ⇒* B] -> 
+    [Γ |- A ⤳* B] -> 
     [Γ |- A ≅ B].
 Proof.
 apply @RedConvC with (K := istype).
@@ -477,7 +477,7 @@ Qed.
 (** ** Weakenings of reduction *)
 
 Lemma redtmdecl_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
-  [|- Δ ] -> [Γ |- t ⇒* u : A] -> [Δ |- t⟨ρ⟩ ⇒* u⟨ρ⟩ : A⟨ρ⟩].
+  [|- Δ ] -> [Γ |- t ⤳* u : A] -> [Δ |- t⟨ρ⟩ ⤳* u⟨ρ⟩ : A⟨ρ⟩].
 Proof.
   intros * ? []; split.
   - now apply typing_wk.
@@ -486,7 +486,7 @@ Proof.
 Qed.
 
 Lemma redtydecl_wk {Γ Δ A B} (ρ : Δ ≤ Γ) :
-  [|- Δ ] -> [Γ |- A ⇒* B] -> [Δ |- A⟨ρ⟩ ⇒* B⟨ρ⟩].
+  [|- Δ ] -> [Γ |- A ⤳* B] -> [Δ |- A⟨ρ⟩ ⤳* B⟨ρ⟩].
 Proof.
   intros * ? []; split.
   - now apply typing_wk.
@@ -497,9 +497,9 @@ Qed.
 (** ** Derived rules for multi-step reduction *)
 
 Lemma redtmdecl_app Γ A B f f' t :
-  [ Γ |- f ⇒* f' : tProd A B ] ->
+  [ Γ |- f ⤳* f' : tProd A B ] ->
   [ Γ |- t : A ] ->
-  [ Γ |- tApp f t ⇒* tApp f' t : B[t..] ].
+  [ Γ |- tApp f t ⤳* tApp f' t : B[t..] ].
 Proof.
   intros [] ?; split.
   + now econstructor.
@@ -508,9 +508,9 @@ Proof.
 Qed.
 
 Lemma redtmdecl_conv Γ t u A A' : 
-  [Γ |- t ⇒* u : A] ->
+  [Γ |- t ⤳* u : A] ->
   [Γ |- A ≅ A'] ->
-  [Γ |- t ⇒* u : A'].
+  [Γ |- t ⤳* u : A'].
 Proof.
   intros [] ?; split.
   + now econstructor.
@@ -519,7 +519,7 @@ Proof.
 Qed.
 
 Lemma redtydecl_term Γ A B :
-  [ Γ |- A ⇒* B : U] -> [Γ |- A ⇒* B ].
+  [ Γ |- A ⤳* B : U] -> [Γ |- A ⤳* B ].
 Proof.
   intros []; split.
   + now constructor.

--- a/theories/DeclarativeTyping.v
+++ b/theories/DeclarativeTyping.v
@@ -307,7 +307,7 @@ Section Definitions.
     reddecl_conv : match A with istype => [ Γ |- t ≅ u ] | isterm A => [Γ |- t ≅ u : A] end;
   }.
 
-  Notation "[ Γ |- t ⇒* t' ∈ A ]" := (RedClosureDecl Γ A t t').
+  Notation "[ Γ |- t ⤳* t' ∈ A ]" := (RedClosureDecl Γ A t t').
 
   Record ConvNeuConvDecl (Γ : context) (A : term) (t u : term) := {
     convnedecl_whne_l : whne t;
@@ -320,7 +320,7 @@ End Definitions.
 Definition TermRedClosure Γ A t u := RedClosureDecl Γ (isterm A) t u.
 Definition TypeRedClosure Γ A B := RedClosureDecl Γ istype A B.
 
-Notation "[ Γ |- t ⇒* u ∈ A ]" := (RedClosureDecl Γ A t u).
+Notation "[ Γ |- t ⤳* u ∈ A ]" := (RedClosureDecl Γ A t u).
 
 (** ** Instances *)
 (** Used for printing (see Notations) and as a support for the generic typing
@@ -419,15 +419,15 @@ Section TypeErasure.
   Import DeclarativeTypingData.
 
 Lemma redtmdecl_red Γ t u A : 
-  [Γ |- t ⇒* u : A] ->
-  [t ⇒* u].
+  [Γ |- t ⤳* u : A] ->
+  [t ⤳* u].
 Proof.
 apply reddecl_red.
 Qed.
 
 Lemma redtydecl_red Γ A B : 
-  [Γ |- A ⇒* B] ->
-  [A ⇒* B].
+  [Γ |- A ⤳* B] ->
+  [A ⤳* B].
 Proof.
 apply reddecl_red.
 Qed.

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -18,8 +18,8 @@ More precisely, an instance consists of giving notions of
 - convertibility of types [Γ |- A ≅ B]
 - convertibility of terms [Γ |- t ≅ u : A]
 - neutral convertibility of terms [Γ |- m ~ n : A]
-- (multi-step, weak-head) reduction of types [Γ |- A ⇒* B]
-- (multi-step, weak-head) reduction of terms [Γ |- t ⇒* u : A]
+- (multi-step, weak-head) reduction of types [Γ |- A ⤳* B]
+- (multi-step, weak-head) reduction of terms [Γ |- t ⤳* u : A]
 *)
 
 (** ** Generic definitions *)
@@ -37,13 +37,13 @@ Section RedDefinitions.
 
   Record TypeRedWhnf (Γ : context) (A B : term) : Type :=
     {
-      tyred_whnf_red :> [ Γ |- A ⇒* B ] ;
+      tyred_whnf_red :> [ Γ |- A ⤳* B ] ;
       tyred_whnf_whnf :> whnf B
     }.
 
   Record TermRedWhnf (Γ : context) (A t u : term) : Type :=
     {
-      tmred_whnf_red :> [ Γ |- t ⇒* u : A ] ;
+      tmred_whnf_red :> [ Γ |- t ⤳* u : A ] ;
       tmred_whnf_whnf :> whnf u
     }.
 
@@ -63,12 +63,12 @@ Section RedDefinitions.
 
   Record TypeRedWf (Γ : context) (A B : term) : Type := {
     tyr_wf_r : [Γ |- B];
-    tyr_wf_red :> [Γ |- A ⇒* B]
+    tyr_wf_red :> [Γ |- A ⤳* B]
   }.
 
   Record TermRedWf (Γ : context) (A t u : term) : Type := {
     tmr_wf_r : [Γ |- u : A];
-    tmr_wf_red :> [Γ |- t ⇒* u : A]
+    tmr_wf_red :> [Γ |- t ⤳* u : A]
   }.
 
   (** *** Lifting of typing and conversion to contexts and substitutions *)
@@ -134,10 +134,10 @@ Notation "[ Γ |- A :≅: B ]" := (TypeConvWf Γ A B) (only parsing) : typing_sc
 Notation "[ Γ |-[ ta  ] A :≅: B ]" := (TypeConvWf (ta := ta) Γ A B) : typing_scope.
 Notation "[ Γ |- t :≅: u : A ]" := (TermConvWf Γ A t u) (only parsing) : typing_scope.
 Notation "[ Γ |-[ ta  ] t :≅: u : A ]" := (TermConvWf (ta := ta) Γ A t u) : typing_scope.
-Notation "[ Γ |- A :⇒*: B ]" := (TypeRedWf Γ A B) (only parsing) : typing_scope.
-Notation "[ Γ |-[ ta  ] A :⇒*: B ]" := (TypeRedWf (ta := ta) Γ A B) : typing_scope.
-Notation "[ Γ |- t :⇒*: u : A ]" := (TermRedWf Γ A t u) (only parsing) : typing_scope.
-Notation "[ Γ |-[ ta  ] t :⇒*: u : A ]" := (TermRedWf (ta := ta) Γ A t u) : typing_scope.
+Notation "[ Γ |- A :⤳*: B ]" := (TypeRedWf Γ A B) (only parsing) : typing_scope.
+Notation "[ Γ |-[ ta  ] A :⤳*: B ]" := (TypeRedWf (ta := ta) Γ A B) : typing_scope.
+Notation "[ Γ |- t :⤳*: u : A ]" := (TermRedWf Γ A t u) (only parsing) : typing_scope.
+Notation "[ Γ |-[ ta  ] t :⤳*: u : A ]" := (TermRedWf (ta := ta) Γ A t u) : typing_scope.
 Notation "[ Γ '|-s' σ : A ]" := (WellSubst Γ A σ) (only parsing) : typing_scope.
 Notation "[ Γ |-[ ta ']s' σ : A ]" := (WellSubst (ta := ta) Γ A σ) : typing_scope.
 Notation "[ Γ '|-s' σ ≅ τ : A ]" := (ConvSubst Γ A σ τ) (only parsing) : typing_scope.
@@ -159,8 +159,8 @@ Notation "[ |-[ ta  ] Γ ≅ Δ ]" := (ConvCtx (ta := ta) Γ Δ) : typing_scope.
     |  H : [ _ |- _ ↘ _ : _ ] |- _ => destruct H
     |  H : [ _ |- _ :≅: _ ] |- _ => destruct H
     |  H : [ _ |- _ :≅: _ : _] |- _ => destruct H
-    |  H : [ _ |- _ :⇒*: _ ] |- _ => destruct H
-    |  H : [ _ |- _ :⇒*: _ : _ ] |- _ => destruct H
+    |  H : [ _ |- _ :⤳*: _ ] |- _ => destruct H
+    |  H : [ _ |- _ :⤳*: _ : _ ] |- _ => destruct H
   end
   : gen_typing. *)
 
@@ -180,8 +180,8 @@ Section GenericTyping.
     wfc_ty {Γ A t} : [Γ |- t : A] -> [|- Γ];
     wfc_convty {Γ A B} : [Γ |- A ≅ B] -> [|- Γ];
     wfc_convtm {Γ A t u} : [Γ |- t ≅ u : A] -> [|- Γ];
-    wfc_redty {Γ A B} : [Γ |- A ⇒* B] -> [|- Γ];
-    wfc_redtm {Γ A t u} : [Γ |- t ⇒* u : A] -> [|- Γ];
+    wfc_redty {Γ A B} : [Γ |- A ⤳* B] -> [|- Γ];
+    wfc_redtm {Γ A t u} : [Γ |- t ⤳* u : A] -> [|- Γ];
   }.
 
   Class WfTypeProperties :=
@@ -284,7 +284,7 @@ Section GenericTyping.
       [Γ |- y : A] ->
       [Γ |- e : tId A x y] ->
       [Γ |- tIdElim A x P hr y e : P[e .: y..]];
-    ty_exp {Γ t A A'} : [Γ |- t : A'] -> [Γ |- A ⇒* A'] -> [Γ |- t : A] ;
+    ty_exp {Γ t A A'} : [Γ |- t : A'] -> [Γ |- A ⤳* A'] -> [Γ |- t : A] ;
     ty_conv {Γ t A A'} : [Γ |- t : A'] -> [Γ |- A' ≅ A] -> [Γ |- t : A] ;
   }.
 
@@ -295,7 +295,7 @@ Section GenericTyping.
     convty_wk {Γ Δ A B} (ρ : Δ ≤ Γ) :
       [|- Δ ] -> [Γ |- A ≅ B] -> [Δ |- A⟨ρ⟩ ≅ B⟨ρ⟩] ;
     convty_exp {Γ A A' B B'} :
-      [Γ |- A ⇒* A'] -> [Γ |- B ⇒* B'] ->
+      [Γ |- A ⤳* A'] -> [Γ |- B ⤳* B'] ->
       [Γ |- A' ≅ B'] -> [Γ |- A ≅ B] ;
     convty_uni {Γ} :
       [|- Γ] -> [Γ |- U ≅ U] ;
@@ -322,7 +322,7 @@ Section GenericTyping.
     convtm_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
       [|- Δ ] -> [Γ |- t ≅ u : A] -> [Δ |- t⟨ρ⟩ ≅ u⟨ρ⟩ : A⟨ρ⟩] ;
     convtm_exp {Γ A A' t t' u u'} :
-      [Γ |- A ⇒* A'] -> [Γ |- t ⇒* t' : A'] -> [Γ |- u ⇒* u' : A'] ->
+      [Γ |- A ⤳* A'] -> [Γ |- t ⤳* t' : A'] -> [Γ |- u ⤳* u' : A'] ->
       [Γ |- t' ≅ u' : A'] -> [Γ |- t ≅ u : A] ;
     convtm_convneu {Γ n n' A} :
       [Γ |- n ~ n' : A] -> [Γ |- n ≅ n' : A] ;
@@ -419,14 +419,14 @@ Section GenericTyping.
   Class RedTypeProperties :=
   {
     redty_wk {Γ Δ A B} (ρ : Δ ≤ Γ) :
-      [|- Δ ] -> [Γ |- A ⇒* B] -> [Δ |- A⟨ρ⟩ ⇒* B⟨ρ⟩] ;
-    redty_sound {Γ A B} : [Γ |- A ⇒* B] -> [A ⇒* B] ;
-    redty_ty_src {Γ A B} : [Γ |- A ⇒* B] -> [Γ |- A] ;
+      [|- Δ ] -> [Γ |- A ⤳* B] -> [Δ |- A⟨ρ⟩ ⤳* B⟨ρ⟩] ;
+    redty_sound {Γ A B} : [Γ |- A ⤳* B] -> [A ⤳* B] ;
+    redty_ty_src {Γ A B} : [Γ |- A ⤳* B] -> [Γ |- A] ;
     redty_term {Γ A B} :
-      [ Γ |- A ⇒* B : U] -> [Γ |- A ⇒* B ] ;
+      [ Γ |- A ⤳* B : U] -> [Γ |- A ⤳* B ] ;
     redty_refl {Γ A} :
       [ Γ |- A] ->
-      [Γ |- A ⇒* A] ;
+      [Γ |- A ⤳* A] ;
     redty_trans {Γ} :>
       Transitive (red_ty Γ) ;
   }.
@@ -434,57 +434,57 @@ Section GenericTyping.
   Class RedTermProperties :=
   {
     redtm_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
-      [|- Δ ] -> [Γ |- t ⇒* u : A] -> [Δ |- t⟨ρ⟩ ⇒* u⟨ρ⟩ : A⟨ρ⟩] ;
-    redtm_sound {Γ A t u} : [Γ |- t ⇒* u : A] -> [t ⇒* u] ;
-    redtm_ty_src {Γ A t u} : [Γ |- t ⇒* u : A] -> [Γ |- t : A] ;
+      [|- Δ ] -> [Γ |- t ⤳* u : A] -> [Δ |- t⟨ρ⟩ ⤳* u⟨ρ⟩ : A⟨ρ⟩] ;
+    redtm_sound {Γ A t u} : [Γ |- t ⤳* u : A] -> [t ⤳* u] ;
+    redtm_ty_src {Γ A t u} : [Γ |- t ⤳* u : A] -> [Γ |- t : A] ;
     redtm_beta {Γ A B t u} :
       [ Γ |- A ] ->
       [ Γ ,, A |- t : B ] ->
       [ Γ |- u : A ] ->
-      [ Γ |- tApp (tLambda A t) u ⇒* t[u..] : B[u..] ] ;
+      [ Γ |- tApp (tLambda A t) u ⤳* t[u..] : B[u..] ] ;
     redtm_natElimZero {Γ P hz hs} :
         [Γ ,, tNat |- P ] ->
         [Γ |- hz : P[tZero..]] ->
         [Γ |- hs : elimSuccHypTy P] ->
-        [Γ |- tNatElim P hz hs tZero ⇒* hz : P[tZero..]] ;
+        [Γ |- tNatElim P hz hs tZero ⤳* hz : P[tZero..]] ;
     redtm_natElimSucc {Γ P hz hs n} :
         [Γ ,, tNat |- P ] ->
         [Γ |- hz : P[tZero..]] ->
         [Γ |- hs : elimSuccHypTy P] ->
         [Γ |- n : tNat] ->
-        [Γ |- tNatElim P hz hs (tSucc n) ⇒* tApp (tApp hs n) (tNatElim P hz hs n) : P[(tSucc n)..]] ;
+        [Γ |- tNatElim P hz hs (tSucc n) ⤳* tApp (tApp hs n) (tNatElim P hz hs n) : P[(tSucc n)..]] ;
     redtm_app {Γ A B f f' t} :
-      [ Γ |- f ⇒* f' : tProd A B ] ->
+      [ Γ |- f ⤳* f' : tProd A B ] ->
       [ Γ |- t : A ] ->
-      [ Γ |- tApp f t ⇒* tApp f' t : B[t..] ];
+      [ Γ |- tApp f t ⤳* tApp f' t : B[t..] ];
     redtm_natelim {Γ P hz hs n n'} :
       [ Γ,, tNat |- P ] ->
       [ Γ |- hz : P[tZero..] ] ->
       [ Γ |- hs : elimSuccHypTy P ] ->
-      [ Γ |- n ⇒* n' : tNat ] ->
-      [ Γ |- tNatElim P hz hs n ⇒* tNatElim P hz hs n' : P[n..] ];
+      [ Γ |- n ⤳* n' : tNat ] ->
+      [ Γ |- tNatElim P hz hs n ⤳* tNatElim P hz hs n' : P[n..] ];
     redtm_emptyelim {Γ P n n'} :
       [ Γ,, tEmpty |- P ] ->
-      [ Γ |- n ⇒* n' : tEmpty ] ->
-      [ Γ |- tEmptyElim P n ⇒* tEmptyElim P n' : P[n..] ];
+      [ Γ |- n ⤳* n' : tEmpty ] ->
+      [ Γ |- tEmptyElim P n ⤳* tEmptyElim P n' : P[n..] ];
     redtm_fst_beta {Γ A B a b} :
       [Γ |- A] ->
       [Γ ,, A |- B] ->
       [Γ |- a : A] ->
       [Γ |- b : B[a..]] ->
-      [Γ |- tFst (tPair A B a b) ⇒* a : A] ;
+      [Γ |- tFst (tPair A B a b) ⤳* a : A] ;
     redtm_fst {Γ A B p p'} :
-      [Γ |- p ⇒* p' : tSig A B] ->
-      [Γ |- tFst p ⇒* tFst p' : A] ;
+      [Γ |- p ⤳* p' : tSig A B] ->
+      [Γ |- tFst p ⤳* tFst p' : A] ;
     redtm_snd_beta {Γ A B a b} :
       [Γ |- A] ->
       [Γ ,, A |- B] ->
       [Γ |- a : A] ->
       [Γ |- b : B[a..]] ->
-      [Γ |- tSnd (tPair A B a b) ⇒* b : B[(tFst (tPair A B a b))..]] ;
+      [Γ |- tSnd (tPair A B a b) ⤳* b : B[(tFst (tPair A B a b))..]] ;
     redtm_snd {Γ A B p p'} :
-      [Γ |- p ⇒* p' : tSig A B] ->
-      [Γ |- tSnd p ⇒* tSnd p' : B[(tFst p)..]] ;
+      [Γ |- p ⤳* p' : tSig A B] ->
+      [Γ |- tSnd p ⤳* tSnd p' : B[(tFst p)..]] ;
     redtm_idElimRefl {Γ A x P hr y A' z} :
       [Γ |- A] ->
       [Γ |- x : A] ->
@@ -496,22 +496,22 @@ Section GenericTyping.
       [Γ |- A ≅ A'] ->
       [Γ |- x ≅ y : A] ->
       [Γ |- x ≅ z : A] ->
-      [Γ |- tIdElim A x P hr y (tRefl A' z) ⇒* hr : P[tRefl A' z .: y..]];
+      [Γ |- tIdElim A x P hr y (tRefl A' z) ⤳* hr : P[tRefl A' z .: y..]];
     redtm_idElim {Γ A x P hr y e e'} :
       [Γ |- A] ->
       [Γ |- x : A] ->
       [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P] ->
       [Γ |- hr : P[tRefl A x .: x..]] ->
       [Γ |- y : A] ->
-      [Γ |- e ⇒* e' : tId A x y] ->
-      [Γ |- tIdElim A x P hr y e ⇒* tIdElim A x P hr y e' : P[e .: y..]];
+      [Γ |- e ⤳* e' : tId A x y] ->
+      [Γ |- tIdElim A x P hr y e ⤳* tIdElim A x P hr y e' : P[e .: y..]];
     redtm_conv {Γ t u A A'} : 
-      [Γ |- t ⇒* u : A] ->
+      [Γ |- t ⤳* u : A] ->
       [Γ |- A ≅ A'] ->
-      [Γ |- t ⇒* u : A'] ;
+      [Γ |- t ⤳* u : A'] ;
     redtm_refl {Γ A t } :
       [ Γ |- t : A] ->
-      [Γ |- t ⇒* t : A] ;
+      [Γ |- t ⤳* t : A] ;
     redtm_trans {Γ A} :>
       Transitive (red_tm Γ A) ;
   }.
@@ -687,30 +687,30 @@ Section GenericConsequences.
   Qed.
 
   Lemma redtm_meta_conv (Γ : context) (t u u' A A' : term) :
-    [Γ |- t ⇒* u : A] ->
+    [Γ |- t ⤳* u : A] ->
     A' = A ->
     u' = u ->
-    [Γ |- t ⇒* u' : A'].
+    [Γ |- t ⤳* u' : A'].
   Proof.
     now intros ? -> ->.
   Qed.
 
   Lemma redtmwf_meta_conv_ty (Γ : context) (t u A A' : term) :
-    [Γ |- t :⇒*: u : A] ->
+    [Γ |- t :⤳*: u : A] ->
     A' = A ->
-    [Γ |- t :⇒*: u : A'].
+    [Γ |- t :⤳*: u : A'].
   Proof.
     now intros ? ->. 
   Qed.
 
   (** *** Properties of well-typed reduction *)
 
-  Lemma tyr_wf_l {Γ A B} : [Γ |- A :⇒*: B] -> [Γ |- A].
+  Lemma tyr_wf_l {Γ A B} : [Γ |- A :⤳*: B] -> [Γ |- A].
   Proof.
     intros []; now eapply redty_ty_src.
   Qed.
   
-  Lemma tmr_wf_l {Γ t u A} : [Γ |- t :⇒*: u : A] -> [Γ |- t : A].
+  Lemma tmr_wf_l {Γ t u A} : [Γ |- t :⤳*: u : A] -> [Γ |- t : A].
   Proof.
     intros []; now eapply redtm_ty_src.
   Qed.
@@ -721,15 +721,15 @@ Section GenericConsequences.
   #[local] Hint Resolve  redtm_conv | 6 : gen_typing.
 
   Lemma redty_red {Γ A B} :
-      [Γ |- A ⇒* B] -> [ A ⇒* B ].
+      [Γ |- A ⤳* B] -> [ A ⤳* B ].
   Proof.
     intros ?%redty_sound. 
     assumption.
   Qed.
 
   Lemma redtm_red {Γ t u A} : 
-      [Γ |- t ⇒* u : A] ->
-      [t ⇒* u].
+      [Γ |- t ⤳* u : A] ->
+      [t ⤳* u].
   Proof.
     intros ?%redtm_sound.
     assumption.
@@ -738,78 +738,78 @@ Section GenericConsequences.
   #[local] Hint Resolve redty_red  redtm_red | 2 : gen_typing.
 
   Lemma redtywf_wk {Γ Δ A B} (ρ : Δ ≤ Γ) :
-      [|- Δ ] -> [Γ |- A :⇒*: B] -> [Δ |- A⟨ρ⟩ :⇒*: B⟨ρ⟩].
+      [|- Δ ] -> [Γ |- A :⤳*: B] -> [Δ |- A⟨ρ⟩ :⤳*: B⟨ρ⟩].
   Proof.
     intros ? []; constructor; gen_typing.
   Qed.
 
-  Lemma redtywf_red {Γ A B} : [Γ |- A :⇒*: B] -> [A ⇒* B].
+  Lemma redtywf_red {Γ A B} : [Γ |- A :⤳*: B] -> [A ⤳* B].
   Proof.
     intros []; now eapply redty_red.
   Qed.
   
   Lemma redtywf_term {Γ A B} :
-      [ Γ |- A :⇒*: B : U] -> [Γ |- A :⇒*: B ].
+      [ Γ |- A :⤳*: B : U] -> [Γ |- A :⤳*: B ].
   Proof.
     intros []; constructor; gen_typing.
   Qed.
 
-  Lemma redtywf_refl {Γ A} : [Γ |- A] -> [Γ |- A :⇒*: A].
+  Lemma redtywf_refl {Γ A} : [Γ |- A] -> [Γ |- A :⤳*: A].
   Proof.  constructor; gen_typing.  Qed.
 
   #[global]
-  Instance redtywf_trans {Γ} : Transitive (TypeRedWf Γ). (* fun A B => [Γ |- A :⇒*: B] *)
+  Instance redtywf_trans {Γ} : Transitive (TypeRedWf Γ). (* fun A B => [Γ |- A :⤳*: B] *)
   Proof.
     intros ??? [] []; unshelve econstructor; try etransitivity; tea.
   Qed.
 
   (** Almost all of the RedTermProperties can be derived 
-    for the well-formed reduction [Γ |- t :⇒*: u : A]
+    for the well-formed reduction [Γ |- t :⤳*: u : A]
     but for application (which requires stability of typing under substitution). *)
     
   Definition redtmwf_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
-      [|- Δ ] -> [Γ |- t :⇒*: u : A] -> [Δ |- t⟨ρ⟩ :⇒*: u⟨ρ⟩ : A⟨ρ⟩].
+      [|- Δ ] -> [Γ |- t :⤳*: u : A] -> [Δ |- t⟨ρ⟩ :⤳*: u⟨ρ⟩ : A⟨ρ⟩].
   Proof.  intros ? []; constructor; gen_typing. Qed.
 
   Definition redtmwf_red {Γ t u A} :
-    [Γ |- t :⇒*: u : A] -> [t ⇒* u].
+    [Γ |- t :⤳*: u : A] -> [t ⤳* u].
   Proof. intros []; now eapply redtm_red. Qed.
 
   Definition redtmwf_conv {Γ} {t u A B} :
-      [Γ |- t :⇒*: u : A] ->
+      [Γ |- t :⤳*: u : A] ->
       [Γ |- A ≅ B ] ->
-      [Γ |- t :⇒*: u : B].
+      [Γ |- t :⤳*: u : B].
   Proof.
     intros [wfl red] ?.
     constructor.
     all: gen_typing.
   Qed.
 
-  Lemma redtmwf_refl {Γ a A} : [Γ |- a : A] -> [Γ |- a :⇒*: a : A].
+  Lemma redtmwf_refl {Γ a A} : [Γ |- a : A] -> [Γ |- a :⤳*: a : A].
   Proof.
     constructor; tea.
     now apply redtm_refl.
   Qed.
 
   #[global]
-  Instance redtmwf_trans {Γ A} : Transitive (TermRedWf Γ A). (*fun t u => [Γ |- t :⇒*: u : A]*)
+  Instance redtmwf_trans {Γ A} : Transitive (TermRedWf Γ A). (*fun t u => [Γ |- t :⤳*: u : A]*)
   Proof.
     intros ??? [] []; unshelve econstructor; try etransitivity; tea.
   Qed.
 
   Lemma redtmwf_app {Γ A B f f' t} :
-    [ Γ |- f :⇒*: f' : tProd A B ] ->
+    [ Γ |- f :⤳*: f' : tProd A B ] ->
     [ Γ |- t : A ] ->
-    [ Γ |- tApp f t :⇒*: tApp f' t : B[t..] ].
+    [ Γ |- tApp f t :⤳*: tApp f' t : B[t..] ].
   Proof.
     intros [] ?; constructor; gen_typing.
   Qed.
   
   Lemma redtmwf_appwk {Γ Δ A B B' t u a} (ρ : Δ ≤ Γ) :
-    [Γ |- t :⇒*: u : tProd A B] ->
+    [Γ |- t :⤳*: u : tProd A B] ->
     [Δ |- a : A⟨ρ⟩] ->
     B' = B⟨upRen_term_term ρ⟩[a..] ->
-    [Δ |- tApp t⟨ρ⟩ a :⇒*: tApp u⟨ρ⟩ a : B'].
+    [Δ |- tApp t⟨ρ⟩ a :⤳*: tApp u⟨ρ⟩ a : B'].
   Proof.
     intros redtu **.
     eapply redtmwf_meta_conv_ty; tea.
@@ -822,7 +822,7 @@ Section GenericConsequences.
     [Γ ,, tNat |- P ] ->
     [Γ |- hz : P[tZero..]] ->
     [Γ |- hs : elimSuccHypTy P] ->
-    [Γ |- tNatElim P hz hs tZero :⇒*: hz : P[tZero..]].
+    [Γ |- tNatElim P hz hs tZero :⤳*: hz : P[tZero..]].
   Proof.
     intros ???; constructor; tea; gen_typing.
   Qed.
@@ -929,7 +929,7 @@ Section GenericConsequences.
     [Γ |- A] ->
     [Γ |- A ≅ A] ->
     [Γ |- a : A] ->
-    [Γ |- tApp (idterm A) a ⇒* a : A].
+    [Γ |- tApp (idterm A) a ⤳* a : A].
   Proof.
     intros.
     eapply redtm_meta_conv.
@@ -1013,7 +1013,7 @@ Section GenericConsequences.
     [Γ |- f : arr A B] ->
     [Γ |- g : arr B C] ->
     [Γ |- a : A] ->
-    [Γ |- tApp (comp A g f) a ⇒* tApp g (tApp f a) : C].
+    [Γ |- tApp (comp A g f) a ⤳* tApp g (tApp f a) : C].
   Proof.
     intros hA hB hC hf hg ha.
     eapply redtm_meta_conv.
@@ -1158,43 +1158,43 @@ Section GenericConsequences.
   
   (** *** Lifting determinism properties from untyped reduction to typed reduction. *)
 
-  Lemma redtm_whnf {Γ t u A} : [Γ |- t ⇒* u : A] -> whnf t -> t = u.
+  Lemma redtm_whnf {Γ t u A} : [Γ |- t ⤳* u : A] -> whnf t -> t = u.
   Proof.
     intros.
     apply red_whnf; [|assumption].
     now eapply redtm_sound.
   Qed.
 
-  Lemma redtmwf_whnf {Γ t u A} : [Γ |- t :⇒*: u : A] -> whnf t -> t = u.
+  Lemma redtmwf_whnf {Γ t u A} : [Γ |- t :⤳*: u : A] -> whnf t -> t = u.
   Proof.
     intros []; now eapply redtm_whnf.
   Qed.
 
-  Lemma redtmwf_whne {Γ t u A} : [Γ |- t :⇒*: u : A] -> whne t -> t = u.
+  Lemma redtmwf_whne {Γ t u A} : [Γ |- t :⤳*: u : A] -> whne t -> t = u.
   Proof.
     intros ? ?%whnf_whne; now eapply redtmwf_whnf.
   Qed.
 
-  Lemma redty_whnf {Γ A B} : [Γ |- A ⇒* B] -> whnf A -> A = B.
+  Lemma redty_whnf {Γ A B} : [Γ |- A ⤳* B] -> whnf A -> A = B.
   Proof.
     intros.
     apply red_whnf; [|eassumption].
     now eapply redty_sound.
   Qed.
 
-  Lemma redtywf_whnf {Γ A B} : [Γ |- A :⇒*: B] -> whnf A -> A = B.
+  Lemma redtywf_whnf {Γ A B} : [Γ |- A :⤳*: B] -> whnf A -> A = B.
   Proof.
     intros []; now eapply redty_whnf.
   Qed.
 
-  Lemma redtywf_whne {Γ A B} : [Γ |- A :⇒*: B] -> whne A -> A = B.
+  Lemma redtywf_whne {Γ A B} : [Γ |- A :⤳*: B] -> whne A -> A = B.
   Proof.
     intros ? ?%whnf_whne; now eapply redtywf_whnf.
   Qed.
 
   Lemma redtmwf_det {Γ t u u' A A'} :
     whnf u -> whnf u' ->
-    [Γ |- t :⇒*: u : A] -> [Γ |- t :⇒*: u' : A'] ->
+    [Γ |- t :⤳*: u : A] -> [Γ |- t :⤳*: u' : A'] ->
     u = u'.
   Proof.
     intros ?? [] [].
@@ -1204,7 +1204,7 @@ Section GenericConsequences.
 
   Lemma redtywf_det {Γ A B B'} :
     whnf B -> whnf B' ->
-    [Γ |- A :⇒*: B] -> [Γ |- A :⇒*: B'] ->
+    [Γ |- A :⤳*: B] -> [Γ |- A :⤳*: B'] ->
     B = B'.
   Proof.
     intros ?? [] [].

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -118,7 +118,7 @@ Module neRedTy.
     {Γ : context} {A : term}
   : Set := {
     ty : term;
-    red : [ Γ |- A :⇒*: ty];
+    red : [ Γ |- A :⤳*: ty];
     eq : [ Γ |- ty ~ ty : U] ;
   }.
 
@@ -136,7 +136,7 @@ Module neRedTyEq.
     {Γ : context} {A B : term} {neA : [ Γ ||-ne A ]}
   : Set := {
     ty   : term;
-    red  : [ Γ |- B :⇒*: ty];
+    red  : [ Γ |- B :⤳*: ty];
     eq  : [ Γ |- neA.(neRedTy.ty) ~ ty : U];
   }.
 
@@ -155,7 +155,7 @@ Module neRedTm.
     {Γ : context} {t A : term} {R : [ Γ ||-ne A ]}
   : Set := {
     te  : term;
-    red  : [ Γ |- t :⇒*: te : R.(neRedTy.ty)];
+    red  : [ Γ |- t :⤳*: te : R.(neRedTy.ty)];
     eq : [Γ |- te ~ te : R.(neRedTy.ty)] ;
   }.
 
@@ -176,8 +176,8 @@ Module neRedTmEq.
   : Set := {
     termL     : term;
     termR     : term;
-    redL      : [ Γ |- t :⇒*: termL : R.(neRedTy.ty) ];
-    redR      : [ Γ |- u :⇒*: termR : R.(neRedTy.ty) ];
+    redL      : [ Γ |- t :⤳*: termL : R.(neRedTy.ty) ];
+    redR      : [ Γ |- u :⤳*: termR : R.(neRedTy.ty) ];
     eq : [ Γ |- termL ~ termR : R.(neRedTy.ty)] ;
   }.
 
@@ -198,7 +198,7 @@ Module URedTy.
     level  : TypeLevel;
     lt  : level << l;
     wfCtx : [|- Γ] ;
-    red : [ Γ |- A  :⇒*: U ]
+    red : [ Γ |- A  :⤳*: U ]
   }.
 
   Arguments URedTy {_ _ _ _}.
@@ -214,7 +214,7 @@ Module URedTyEq.
 
   Record URedTyEq `{ta : tag} `{!WfType ta} `{!RedType ta} 
     {Γ : context} {B : term} : Set := {
-    red : [Γ |- B :⇒*: U]
+    red : [Γ |- B :⤳*: U]
   }.
 
   Arguments URedTyEq : clear implicits.
@@ -234,7 +234,7 @@ Module URedTm.
     {Γ : context} {t A : term} {R : [Γ ||-U<l> A]}
   : Type@{j} := {
     te : term;
-    red : [ Γ |- t :⇒*: te : U ];
+    red : [ Γ |- t :⤳*: te : U ];
     type : isType te;
     eqr : [Γ |- te ≅ te : U];
     rel : [rec R.(URedTy.lt) | Γ ||- t ] ;
@@ -342,7 +342,7 @@ Module ParamRedTyPack.
     dom : term ;
     cod : term ;
     outTy := T dom cod ;
-    red : [Γ |- A :⇒*: T dom cod];
+    red : [Γ |- A :⤳*: T dom cod];
     eq : [Γ |- T dom cod ≅ T dom cod];
     polyRed : PolyRedPack@{i} Γ dom cod
   }.
@@ -364,7 +364,7 @@ Module ParamRedTyEq.
   : Type := {
     dom : term;
     cod : term;
-    red : [Γ |- B :⇒*: T dom cod ];
+    red : [Γ |- B :⤳*: T dom cod ];
     eq  : [Γ |- T ΠA.(ParamRedTyPack.dom) ΠA.(ParamRedTyPack.cod) ≅ T dom cod ];
     polyRed : PolyRedEq ΠA dom cod
   }.
@@ -406,7 +406,7 @@ Module PiRedTm.
     {Γ : context} {t A : term} {ΠA : PiRedTy Γ A}
   : Type := {
     nf : term;
-    red : [ Γ |- t :⇒*: nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
+    red : [ Γ |- t :⤳*: nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
     isfun : isFun nf;
     refl : [ Γ |- nf ≅ nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
     app {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
@@ -472,7 +472,7 @@ Module SigRedTm.
     {Γ : context} {A : term} {ΣA : SigRedTy Γ A} {t : term}
   : Type := {
     nf : term;
-    red : [ Γ |- t :⇒*: nf : ΣA.(outTy) ];
+    red : [ Γ |- t :⤳*: nf : ΣA.(outTy) ];
     isfun : isPair nf;
     refl : [ Γ |- nf ≅ nf : ΣA.(outTy) ];
     fstRed {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
@@ -542,7 +542,7 @@ Module NatRedTy.
     {Γ : context} {A : term}
   : Set := 
   {
-    red : [Γ |- A :⇒*: tNat]
+    red : [Γ |- A :⤳*: tNat]
   }.
 
   Arguments NatRedTy {_ _ _}.
@@ -556,7 +556,7 @@ Module NatRedTyEq.
   Record NatRedTyEq `{ta : tag} `{WfType ta} `{RedType ta}
     {Γ : context} {A : term} {NA : NatRedTy Γ A} {B : term}
   : Set := {
-    red : [Γ |- B :⇒*: tNat];
+    red : [Γ |- B :⤳*: tNat];
   }.
 
   Arguments NatRedTyEq {_ _ _ _ _}.
@@ -576,7 +576,7 @@ Section NatRedTm.
   Inductive NatRedTm {Γ : context} {A: term} {NA : NatRedTy Γ A} : term -> Set :=
   | Build_NatRedTm {t}
     (nf : term)
-    (red : [Γ |- t :⇒*: nf : tNat ])
+    (red : [Γ |- t :⤳*: nf : tNat ])
     (eq : [Γ |- nf ≅ nf : tNat])
     (prop : NatProp nf) : NatRedTm t
 
@@ -618,7 +618,7 @@ Proof.
   intros [? nf]. exact nf.
 Defined.
 
-Definition red {Γ A n} {NA : [Γ ||-Nat A]} (Rn : @NatRedTm _ _ NA n) : [Γ |- n :⇒*: nf Rn : tNat].
+Definition red {Γ A n} {NA : [Γ ||-Nat A]} (Rn : @NatRedTm _ _ NA n) : [Γ |- n :⤳*: nf Rn : tNat].
 Proof.
   dependent inversion Rn; subst; cbn; tea.
 Defined.
@@ -643,8 +643,8 @@ Section NatRedTmEq.
   Inductive NatRedTmEq {Γ : context} {A: term} {NA : NatRedTy Γ A} : term -> term -> Set :=
   | Build_NatRedTmEq {t u}
     (nfL nfR : term)
-    (redL : [Γ |- t :⇒*: nfL : tNat])
-    (redR : [Γ |- u :⇒*: nfR : tNat ])
+    (redL : [Γ |- t :⤳*: nfL : tNat])
+    (redR : [Γ |- u :⤳*: nfR : tNat ])
     (eq : [Γ |- nfL ≅ nfR : tNat])
     (prop : NatPropEq nfL nfR) : NatRedTmEq t u
 
@@ -701,7 +701,7 @@ Module EmptyRedTy.
     {Γ : context} {A : term}
   : Set := 
   {
-    red : [Γ |- A :⇒*: tEmpty]
+    red : [Γ |- A :⤳*: tEmpty]
   }.
 
   Arguments EmptyRedTy {_ _ _}.
@@ -715,7 +715,7 @@ Module EmptyRedTyEq.
   Record EmptyRedTyEq `{ta : tag} `{WfType ta} `{RedType ta}
     {Γ : context} {A : term} {NA : EmptyRedTy Γ A} {B : term}
   : Set := {
-    red : [Γ |- B :⇒*: tEmpty];
+    red : [Γ |- B :⤳*: tEmpty];
   }.
 
   Arguments EmptyRedTyEq {_ _ _ _ _}.
@@ -738,7 +738,7 @@ Section EmptyRedTm.
   Inductive EmptyRedTm {Γ : context} {A: term} {NA : EmptyRedTy Γ A} : term -> Set :=
   | Build_EmptyRedTm {t}
     (nf : term)
-    (red : [Γ |- t :⇒*: nf : tEmpty ])
+    (red : [Γ |- t :⤳*: nf : tEmpty ])
     (eq : [Γ |- nf ≅ nf : tEmpty])
     (prop : @EmptyProp Γ nf) : EmptyRedTm t.
 
@@ -747,7 +747,7 @@ Proof.
   intros [? nf]. exact nf.
 Defined.
 
-Definition red {Γ A n} {NA : [Γ ||-Empty A]} (Rn : @EmptyRedTm _ _ NA n) : [Γ |- n :⇒*: nf Rn : tEmpty].
+Definition red {Γ A n} {NA : [Γ ||-Empty A]} (Rn : @EmptyRedTm _ _ NA n) : [Γ |- n :⤳*: nf Rn : tEmpty].
 Proof.
   dependent inversion Rn; subst; cbn; tea.
 Defined.
@@ -775,8 +775,8 @@ Section EmptyRedTmEq.
   Inductive EmptyRedTmEq {Γ : context} {A: term} {NA : EmptyRedTy Γ A} : term -> term -> Set :=
   | Build_EmptyRedTmEq {t u}
     (nfL nfR : term)
-    (redL : [Γ |- t :⇒*: nfL : tEmpty])
-    (redR : [Γ |- u :⇒*: nfR : tEmpty ])
+    (redL : [Γ |- t :⤳*: nfL : tEmpty])
+    (redR : [Γ |- u :⤳*: nfR : tEmpty ])
     (eq : [Γ |- nfL ≅ nfR : tEmpty])
     (prop : @EmptyPropEq Γ nfL nfR) : EmptyRedTmEq t u.
 
@@ -802,7 +802,7 @@ Module IdRedTyPack.
     lhs : term ;
     rhs : term ;
     outTy := tId ty lhs rhs ;
-    red : [Γ |- A :⇒*: outTy] ;
+    red : [Γ |- A :⤳*: outTy] ;
     eq : [Γ |- outTy ≅ outTy] ;
     tyRed : LRPack@{i} Γ ty ;
     lhsRed : [ tyRed | Γ ||- lhs : _ ] ;
@@ -844,7 +844,7 @@ Module IdRedTyEq.
     lhs : term ;
     rhs : term ;
     outTy := tId ty lhs rhs ;
-    red : [Γ |- B :⇒*: outTy];
+    red : [Γ |- B :⤳*: outTy];
     eq : [Γ |- IA.(IdRedTyPack.outTy) ≅ outTy] ;
     tyRed0 := IA.(IdRedTyPack.tyRed) ;
     tyRed : [ tyRed0 | _ ||- _ ≅ ty ] ;
@@ -881,7 +881,7 @@ Section IdRedTm.
   Record IdRedTm  {t : term} : Type :=
     Build_IdRedTm {
       nf : term ;
-      red : [Γ |- t :⇒*: nf : IA.(IdRedTyPack.outTy) ] ;
+      red : [Γ |- t :⤳*: nf : IA.(IdRedTyPack.outTy) ] ;
       eq : [Γ |- nf ≅ nf : IA.(IdRedTyPack.outTy)] ;
       prop : IdProp nf ;
   }. 
@@ -922,8 +922,8 @@ Section IdRedTmEq.
     Build_IdRedTmEq {
       nfL : term ;
       nfR : term ;
-      redL : [Γ |- t :⇒*: nfL : IA.(IdRedTyPack.outTy) ] ;
-      redR : [Γ |- u :⇒*: nfR : IA.(IdRedTyPack.outTy) ] ;
+      redL : [Γ |- t :⤳*: nfL : IA.(IdRedTyPack.outTy) ] ;
+      redR : [Γ |- u :⤳*: nfR : IA.(IdRedTyPack.outTy) ] ;
       eq : [Γ |- nfL ≅ nfR : IA.(IdRedTyPack.outTy)] ;
       prop : IdPropEq nfL nfR ;
   }. 
@@ -1171,7 +1171,7 @@ Section ParamRedTy.
     {
       dom : term ;
       cod : term ;
-      red : [Γ |- A :⇒*: T dom cod] ;
+      red : [Γ |- A :⤳*: T dom cod] ;
       outTy := T dom cod ;
       eq : [Γ |- T dom cod ≅ T dom cod] ;
       polyRed :> PolyRed@{i j k l} Γ l dom cod
@@ -1332,7 +1332,7 @@ Lemma EmptyRedInduction :
     (Γ : context) (A : term) (NA : [Γ ||-Empty A])
     (P : forall t : term, [Γ ||-Empty t : A | NA] -> Type)
     (P0 : forall t : term, EmptyProp Γ t -> Type),
-    (forall (t nf : term) (red : [Γ |-[ ta ] t :⇒*: nf : tEmpty])
+    (forall (t nf : term) (red : [Γ |-[ ta ] t :⤳*: nf : tEmpty])
        (eq : [Γ |-[ ta ] nf ≅ nf : tEmpty]) (prop : EmptyProp Γ nf),
         P0 nf prop -> P t (Build_EmptyRedTm nf red eq prop)) ->
     (forall (ne : term) (r : [Γ ||-NeNf ne : tEmpty]), P0 ne (EmptyRedTm.neR r)) ->
@@ -1352,8 +1352,8 @@ Lemma EmptyRedEqInduction :
     (Γ : context) (A : term) (NA : [Γ ||-Empty A])
     (P : forall t t0 : term, [Γ ||-Empty t ≅ t0 : A | NA] -> Type)
     (P0 : forall t t0 : term, EmptyPropEq Γ t t0 -> Type),
-    (forall (t u nfL nfR : term) (redL : [Γ |-[ ta ] t :⇒*: nfL : tEmpty])
-       (redR : [Γ |-[ ta ] u :⇒*: nfR : tEmpty]) (eq : [Γ |-[ ta ] nfL ≅ nfR : tEmpty])
+    (forall (t u nfL nfR : term) (redL : [Γ |-[ ta ] t :⤳*: nfL : tEmpty])
+       (redR : [Γ |-[ ta ] u :⤳*: nfR : tEmpty]) (eq : [Γ |-[ ta ] nfL ≅ nfR : tEmpty])
        (prop : EmptyPropEq Γ nfL nfR),
         P0 nfL nfR prop -> P t u (Build_EmptyRedTmEq nfL nfR redL redR eq prop)) ->
     (forall (ne ne' : term) (r : [Γ ||-NeNf ne ≅ ne' : tEmpty]),
@@ -1382,7 +1382,7 @@ Section IdRedTy.
     lhs : term ;
     rhs : term ;
     outTy := tId ty lhs rhs ;
-    red : [Γ |- A :⇒*: outTy] ;
+    red : [Γ |- A :⤳*: outTy] ;
     eq : [Γ |- outTy ≅ outTy] ;
     tyRed : [ LogRel@{i j k l} l | Γ ||- ty ] ;
     lhsRed : [ tyRed | Γ ||- lhs : _ ] ;

--- a/theories/LogicalRelation/Id.v
+++ b/theories/LogicalRelation/Id.v
@@ -11,7 +11,7 @@ Section IdRed.
   Lemma mkIdRedTy {Γ l A} :
     forall (ty lhs rhs  : term)
       (tyRed : [Γ ||-<l> ty]),
-      [Γ |- A :⇒*: tId ty lhs rhs] ->
+      [Γ |- A :⤳*: tId ty lhs rhs] ->
       [tyRed | Γ ||- lhs : _] ->
       [tyRed | Γ ||- rhs : _] ->
       [Γ ||-Id<l> A].

--- a/theories/LogicalRelation/Induction.v
+++ b/theories/LogicalRelation/Induction.v
@@ -275,7 +275,7 @@ Section Inversions.
     `{!RedType ta} `{!RedTerm ta} `{!RedTypeProperties}
     `{!ConvNeuProperties}.
   
-  Definition invLRTy {Γ l A A'} (lr : [Γ ||-<l> A]) (r : [A ⇒* A']) (w : isType A') :=
+  Definition invLRTy {Γ l A A'} (lr : [Γ ||-<l> A]) (r : [A ⤳* A']) (w : isType A') :=
     match w return Type with
     | UnivType => [Γ ||-U<l> A]
     | ProdType => [Γ ||-Π<l> A]
@@ -286,7 +286,7 @@ Section Inversions.
     | NeType _ => [Γ ||-ne A]
     end.
 
-  Lemma invLR {Γ l A A'} (lr : [Γ ||-<l> A]) (r : [A ⇒* A']) (w : isType A') : invLRTy lr r w.
+  Lemma invLR {Γ l A A'} (lr : [Γ ||-<l> A]) (r : [A ⤳* A']) (w : isType A') : invLRTy lr r w.
   Proof.
     unfold invLRTy.
     revert A' r w.

--- a/theories/LogicalRelation/NormalRed.v
+++ b/theories/LogicalRelation/NormalRed.v
@@ -8,7 +8,7 @@ Set Universe Polymorphism.
 
 Ltac redSubst :=
   match goal with
-  | [H : [_ |- ?X :⇒*: ?Y] |- _] => 
+  | [H : [_ |- ?X :⤳*: ?Y] |- _] => 
     assert (X = Y)by (eapply redtywf_whnf ; gen_typing); subst; clear H
   end.
 

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -12,7 +12,7 @@ Set Printing Primitive Projection Parameters.
 
 Lemma redSubst {Γ A B l} :
   [Γ ||-<l> B] ->
-  [Γ |- A ⇒* B] ->
+  [Γ |- A ⤳* B] ->
   ∑ (RA : [Γ ||-<l> A]), [Γ ||-<l> A ≅ B | RA].
 Proof.
   intros RB; revert A; pattern l, Γ, B, RB; apply LR_rect_TyUr; clear l Γ B RB; intros l Γ.
@@ -51,7 +51,7 @@ Qed.
 
 Lemma redwfSubst {Γ A B l} :
   [Γ ||-<l> B] ->
-  [Γ |- A :⇒*: B] ->
+  [Γ |- A :⤳*: B] ->
   ∑ (RA : [Γ ||-<l> A]), [Γ ||-<l> A ≅ B | RA].
 Proof.
   intros ? []; now eapply redSubst.
@@ -59,14 +59,14 @@ Qed.
 
 Lemma redSubstTerm {Γ A t u l} (RA : [Γ ||-<l> A]) :
   [Γ ||-<l> u : A | RA] ->
-  [Γ |- t ⇒* u : A ] ->
+  [Γ |- t ⤳* u : A ] ->
   [Γ ||-<l> t : A | RA] × [Γ ||-<l> t ≅ u : A | RA].
 Proof.
   revert t u; pattern l, Γ, A, RA; apply LR_rect_TyUr; clear l Γ A RA; intros l Γ.
   - intros ? h ?? ru' redtu; pose (ru := ru'); destruct ru' as [T].
     assert [Γ |- A ≅ U] by (destruct h; gen_typing).
     assert [Γ |- t : U] by (eapply ty_conv; [gen_typing| now escape]).
-    assert (redtu' : [Γ |-[ ta ] t ⇒* u]) by gen_typing.
+    assert (redtu' : [Γ |-[ ta ] t ⤳* u]) by gen_typing.
     destruct (redSubst (A:=t) (RedTyRecFwd h rel) redtu') as [rTyt0].
     pose proof (rTyt := RedTyRecBwd h rTyt0).
     unshelve refine (let rt : [LRU_ h | Γ ||- t : A]:= _ in _).
@@ -82,7 +82,7 @@ Proof.
        2: apply convty_term; now apply convtm_convneu.
        gen_typing.
     }
-    assert [Γ |-[ ta ] t ⇒* u : neRedTy.ty neA] by (eapply redtm_conv; tea). 
+    assert [Γ |-[ ta ] t ⤳* u : neRedTy.ty neA] by (eapply redtm_conv; tea). 
     assert [Γ |-[ ta ] t : neRedTy.ty neA] by (eapply ty_conv; tea; gen_typing). 
     unshelve refine (let rt : [LRne_ l neA | Γ ||- t : A] := _ in _).
     + exists n; tea; destruct red; constructor; tea; now etransitivity.
@@ -93,7 +93,7 @@ Proof.
       eapply convty_exp; tea.
       now apply redtywf_refl.
     }
-    assert [Γ |-[ ta ] t ⇒* u : ΠA.(outTy)] by now eapply redtm_conv. 
+    assert [Γ |-[ ta ] t ⤳* u : ΠA.(outTy)] by now eapply redtm_conv. 
     assert [Γ |-[ ta ] t : ΠA.(outTy)] by (eapply ty_conv; gen_typing).
     unshelve refine (let rt : [LRPi' ΠA | Γ ||- t : A] := _ in _).
     1: exists f; tea; constructor; destruct red; tea; etransitivity; tea.
@@ -102,7 +102,7 @@ Proof.
     now apply reflLRTmEq.
   - intros ? NA t ? Ru red; inversion Ru; subst.
     assert [Γ |- A ≅ tNat] by (destruct NA; gen_typing).
-    assert [Γ |- t :⇒*: nf : tNat]. 1:{
+    assert [Γ |- t :⤳*: nf : tNat]. 1:{
       constructor. 1: gen_typing.
       etransitivity. 2: gen_typing.
       now eapply redtm_conv.
@@ -111,7 +111,7 @@ Proof.
     now eapply reflNatRedTmEq.
   - intros ? NA t ? Ru red; inversion Ru; subst.
     assert [Γ |- A ≅ tEmpty] by (destruct NA; gen_typing).
-    assert [Γ |- t :⇒*: nf : tEmpty]. 1:{
+    assert [Γ |- t :⤳*: nf : tEmpty]. 1:{
       constructor. 
       1: eapply ty_conv; gen_typing.
       etransitivity. 2: gen_typing.
@@ -126,16 +126,16 @@ Proof.
       eapply convty_exp; tea.
       now apply redtywf_refl.
     }
-    assert [Γ |-[ ta ] t ⇒* u : PA.(outTy)] by now eapply redtm_conv. 
+    assert [Γ |-[ ta ] t ⤳* u : PA.(outTy)] by now eapply redtm_conv. 
     assert [Γ |-[ ta ] t : PA.(outTy)] by (eapply ty_conv; gen_typing).
     unshelve refine (let rt : [LRSig' PA | Γ ||- t : A] := _ in _).
     1: unshelve eexists p _; tea; constructor; destruct red; tea; etransitivity; tea.
     split; tea; exists rt ru; tea; intros; cbn; now apply reflLRTmEq.
   - intros ? IA ih _ t u [nf ?? prop] redt.
     assert [Γ |- A ≅ IA.(IdRedTy.outTy)] by (destruct IA; unfold IdRedTy.outTy; cbn; gen_typing).
-    assert [Γ |-[ ta ] t ⇒* u : IA.(IdRedTy.outTy)] by now eapply redtm_conv. 
+    assert [Γ |-[ ta ] t ⤳* u : IA.(IdRedTy.outTy)] by now eapply redtm_conv. 
     assert [Γ |-[ ta ] t : IA.(IdRedTy.outTy)] by (eapply ty_conv; gen_typing).
-    assert [Γ |-[ ta ] t :⇒*: nf : IA.(IdRedTy.outTy)].
+    assert [Γ |-[ ta ] t :⤳*: nf : IA.(IdRedTy.outTy)].
     1: constructor; [apply red|etransitivity; tea; apply red].
     split; eexists; tea.
     now eapply reflIdPropEq.
@@ -143,7 +143,7 @@ Qed.
 
 Lemma redSubstTerm' {Γ A t u l} (RA : [Γ ||-<l> A]) :
   [Γ ||-<l> u : A | RA] ->
-  [Γ |- t ⇒* u : A ] ->
+  [Γ |- t ⤳* u : A ] ->
   [Γ ||-<l> t : A | RA] ×  
   [Γ ||-<l> u : A | RA] ×
   [Γ ||-<l> t ≅ u : A | RA].
@@ -155,14 +155,14 @@ Qed.
 
 Lemma redwfSubstTerm {Γ A t u l} (RA : [Γ ||-<l> A]) :
   [Γ ||-<l> u : A | RA] ->
-  [Γ |- t :⇒*: u : A ] ->
+  [Γ |- t :⤳*: u : A ] ->
   [Γ ||-<l> t : A | RA] × [Γ ||-<l> t ≅ u : A | RA].
 Proof.
   intros ? []; now eapply redSubstTerm.
 Qed.
 
 
-Lemma redFwd {Γ l A B} : [Γ ||-<l> A] -> [Γ |- A :⇒*: B] -> whnf B -> [Γ ||-<l> B].
+Lemma redFwd {Γ l A B} : [Γ ||-<l> A] -> [Γ |- A :⤳*: B] -> whnf B -> [Γ ||-<l> B].
 Proof.
   intros RA; revert B; pattern l, Γ, A, RA; apply LR_rect_TyUr; clear l Γ A RA.
   - intros ??? [??? red] ? red' ?. 
@@ -203,7 +203,7 @@ Proof.
     econstructor; tea. eapply redtywf_refl; gen_typing.
 Qed.
 
-Lemma redFwdConv {Γ l A B} (RA : [Γ ||-<l> A]) : [Γ |- A :⇒*: B] -> whnf B -> [Γ ||-<l> B] × [Γ ||-<l> A ≅ B | RA].
+Lemma redFwdConv {Γ l A B} (RA : [Γ ||-<l> A]) : [Γ |- A :⤳*: B] -> whnf B -> [Γ ||-<l> B] × [Γ ||-<l> A ≅ B | RA].
 Proof.
   intros red wh. pose (RB := redFwd RA red wh).
   destruct (redwfSubst RB red).
@@ -214,7 +214,7 @@ Lemma IdProp_whnf {Γ l A} (IA : [Γ ||-Id<l> A]) t : IdProp IA t -> whnf t.
 Proof. intros []; constructor; destruct r; now eapply convneu_whne. Qed.
 
 Lemma redTmFwd {Γ l A t u} {RA : [Γ ||-<l> A]} : 
-  [Γ ||-<l> t : A | RA] -> [Γ |- t :⇒*: u : A] -> whnf u -> [Γ ||-<l> u : A | RA].
+  [Γ ||-<l> t : A | RA] -> [Γ |- t :⤳*: u : A] -> whnf u -> [Γ ||-<l> u : A | RA].
 Proof.
   revert t u; pattern l,Γ,A,RA; apply LR_rect_TyUr; clear l Γ A RA.
   - intros ?????? [? red] red' ?.
@@ -259,7 +259,7 @@ Proof.
 Qed.
 
 Lemma redTmFwdConv {Γ l A t u} {RA : [Γ ||-<l> A]} : 
-  [Γ ||-<l> t : A | RA] -> [Γ |- t :⇒*: u : A] -> whnf u -> [Γ ||-<l> u : A | RA] × [Γ ||-<l> t ≅ u : A | RA].
+  [Γ ||-<l> t : A | RA] -> [Γ |- t :⤳*: u : A] -> whnf u -> [Γ ||-<l> u : A | RA] × [Γ ||-<l> t ≅ u : A | RA].
 Proof.
   intros Rt red wh. pose (Ru := redTmFwd Rt red wh).
   destruct (redwfSubstTerm RA Ru red); now split.

--- a/theories/LogicalRelation/ShapeView.v
+++ b/theories/LogicalRelation/ShapeView.v
@@ -43,7 +43,7 @@ when showing symmetry or transitivity of the logical relation. *)
 
   Lemma red_whnf@{i j k l} {Γ A lA eqTyA redTmA eqTmA}
     (lrA : LogRel@{i j k l} lA Γ A eqTyA redTmA eqTmA) : 
-    ∑ nf, [Γ |- A :⇒*: nf] × whnf nf.
+    ∑ nf, [Γ |- A :⤳*: nf] × whnf nf.
   Proof.
     pattern lA, Γ, A, eqTyA, redTmA, eqTmA, lrA; eapply LR_rect; intros ??[].
     all: eexists; split; tea; constructor; tea.
@@ -52,7 +52,7 @@ when showing symmetry or transitivity of the logical relation. *)
 
   Lemma eqTy_red_whnf@{i j k l} {Γ A lA eqTyA redTmA eqTmA B}
     (lrA : LogRel@{i j k l} lA Γ A eqTyA redTmA eqTmA) : 
-    eqTyA B -> ∑ nf, [Γ |- B :⇒*: nf] × whnf nf.
+    eqTyA B -> ∑ nf, [Γ |- B :⤳*: nf] × whnf nf.
   Proof.
     pattern lA, Γ, A, eqTyA, redTmA, eqTmA, lrA.
     eapply LR_rect_LogRelRec@{i j k l k}; intros ??? [].

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -168,6 +168,14 @@ Section Normalisation.
       apply escapeTmEq in H as []; now split.
   Qed.
 
+  Import DeclarativeTypingData.
+
+  Corollary normalisation {Γ A t} : [Γ |-[de] t : A] -> WN t.
+  Proof. now intros ?%TermRefl%typing_nf. Qed.
+
+  Corollary type_normalisation {Γ A} : [Γ |-[de] A] -> WN A.
+  Proof. now intros ?%TypeRefl%typing_nf. Qed.
+
 End Normalisation.
 
 Import DeclarativeTypingProperties.

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -9,7 +9,7 @@ From LogRel.Substitution Require Import Escape Poly.
 
 Record WN (t : term) := {
   wn_val : term;
-  wn_red : [ t ⇒* wn_val ];
+  wn_red : [ t ⤳* wn_val ];
   wn_whnf : whnf wn_val;
 }.
 
@@ -21,7 +21,7 @@ exists r⟨ρ⟩.
 + now apply whnf_ren.
 Qed.
 
-Lemma WN_exp : forall t u, [t ⇒* u] -> WN u -> WN t.
+Lemma WN_exp : forall t u, [t ⤳* u] -> WN u -> WN t.
 Proof.
 intros t u ? [r].
 exists r; tea.
@@ -57,8 +57,8 @@ Qed.
 #[export] Instance ConvTypeNf : ConvType nf := fun Γ A B => WN A × WN B.
 #[export] Instance ConvTermNf : ConvTerm nf := fun Γ A t u => WN t × WN u.
 #[export] Instance ConvNeuConvNf : ConvNeuConv nf := fun Γ A m n => whne m × whne n.
-#[export] Instance RedTypeNf : RedType nf := fun Γ A B => [A ⇒* B].
-#[export] Instance RedTermNf : RedTerm nf := fun Γ A t u => [t ⇒* u].
+#[export] Instance RedTypeNf : RedType nf := fun Γ A B => [A ⤳* B].
+#[export] Instance RedTermNf : RedTerm nf := fun Γ A t u => [t ⤳* u].
 
 #[export, refine] Instance WfCtxDeclProperties : WfContextProperties (ta := nf) := {}.
 Proof.
@@ -172,7 +172,7 @@ End Normalisation.
 
 Import DeclarativeTypingProperties.
 
-Record cored t t' : Prop := { _ : [t' ⇒ t] }.
+Record cored t t' : Prop := { _ : [t' ⤳ t] }.
 
 Theorem typing_SN Γ t :
   well_formed Γ t ->

--- a/theories/Notations.v
+++ b/theories/Notations.v
@@ -104,27 +104,27 @@ Class OneStepRedTerm (ta : tag) := osred_tm : context -> term -> term -> term ->
 Class RedTerm (ta : tag) := red_tm : context -> term -> term -> term -> Set.
 
 (** Term t untyped one-step weak-head reduces to term t' *)
-Reserved Notation "[ t ⇒ t' ]" (at level 0, t, t' at level 50).
+Reserved Notation "[ t ⤳ t' ]" (at level 0, t, t' at level 50).
 (** Term t untyped multi-step weak-head reduces to term t' *)
-Reserved Notation "[ t ⇒* t' ]" (at level 0, t, t' at level 50).
+Reserved Notation "[ t ⤳* t' ]" (at level 0, t, t' at level 50).
 
 (** Type A one-step weak-head reduces to type B in Γ *)
-Reserved Notation "[ Γ |- A ⇒ B ]" (at level 0, Γ, A, B at level 50).
+Reserved Notation "[ Γ |- A ⤳ B ]" (at level 0, Γ, A, B at level 50).
 (** Term or type t one-step weak-head reduces to term or type type u as class A in Γ *)
-Reserved Notation "[ Γ |- t ⇒ u ∈ A ]" (at level 0, Γ, t, u, A at level 50).
+Reserved Notation "[ Γ |- t ⤳ u ∈ A ]" (at level 0, Γ, t, u, A at level 50).
 (** Term or type t multi-step weak-head reduces to term or type type u as class A in Γ *)
-Reserved Notation "[ Γ |- t ⇒* u ∈ A ]" (at level 0, Γ, t, u, A at level 50).
+Reserved Notation "[ Γ |- t ⤳* u ∈ A ]" (at level 0, Γ, t, u, A at level 50).
 (** Term t one-step weak-head reduces to term u at type A in Γ *)
-Notation "[ Γ |- t ⇒ u : A ]" := (osred_tm Γ A t u) (at level 0, Γ, t, u, A at level 50, only parsing) : typing_scope.
-Notation "[ Γ |-[ ta  ] t ⇒ u : A ]" := (osred_tm (ta:=ta) Γ A t u) (at level 0, ta,Γ, t, u, A at level 50) : typing_scope.
+Notation "[ Γ |- t ⤳ u : A ]" := (osred_tm Γ A t u) (at level 0, Γ, t, u, A at level 50, only parsing) : typing_scope.
+Notation "[ Γ |-[ ta  ] t ⤳ u : A ]" := (osred_tm (ta:=ta) Γ A t u) (at level 0, ta,Γ, t, u, A at level 50) : typing_scope.
 (** Type A multi-step weak-head reduces to type B in Γ *)
-Notation "[ Γ |- A ⇒* B ]" := (red_ty Γ A B) (at level 0, Γ, A, B at level 50, only parsing) : typing_scope.
-Notation "[ Γ |-[ ta  ] A ⇒* B ]" := (red_ty (ta := ta) Γ A B)
+Notation "[ Γ |- A ⤳* B ]" := (red_ty Γ A B) (at level 0, Γ, A, B at level 50, only parsing) : typing_scope.
+Notation "[ Γ |-[ ta  ] A ⤳* B ]" := (red_ty (ta := ta) Γ A B)
 (at level 0, ta, Γ, A, B at level 50) : typing_scope.
 (** Term t multi-step weak-head reduces to term t' at type A in Γ *)
-Notation "[ Γ |- t ⇒* t' : A ]" := (red_tm Γ A t t')
+Notation "[ Γ |- t ⤳* t' : A ]" := (red_tm Γ A t t')
 (at level 0, Γ, t, t', A at level 50, only parsing) : typing_scope.
-Notation "[ Γ |-[ ta  ] t ⇒* t' : A ]" := (red_tm (ta := ta) Γ A t t')
+Notation "[ Γ |-[ ta  ] t ⤳* t' : A ]" := (red_tm (ta := ta) Γ A t t')
 (at level 0, ta, Γ, t, t', A at level 50) : typing_scope.
 (** Set A weak-head normalizes to B in Γ, ie it multi-step reduces to the weak-head normal form B*)
 Reserved Notation "[ Γ |- A ↘ B ]" (at level 0, Γ, A, B at level 50).
@@ -150,11 +150,11 @@ Reserved Notation "[ Γ |-[ ta  ] A :≅: B ]" (at level 0, ta, Γ, A, B at leve
 Reserved Notation "[ Γ |- t :≅: u : A ]" (at level 0, Γ, t, u, A at level 50).
 Reserved Notation "[ Γ |-[ ta  ] t :≅: u : A ]" (at level 0, ta, Γ, t, u, A at level 50).
 (** Set A and B are well-formed and A weak-head reduces to B in Γ *)
-Reserved Notation "[ Γ |- A :⇒*: B ]" (at level 0, Γ, A, B at level 50).
-Reserved Notation "[ Γ |-[ ta  ] A :⇒*: B ]" (at level 0, ta, Γ, A, B at level 50).
+Reserved Notation "[ Γ |- A :⤳*: B ]" (at level 0, Γ, A, B at level 50).
+Reserved Notation "[ Γ |-[ ta  ] A :⤳*: B ]" (at level 0, ta, Γ, A, B at level 50).
 (** Terms t and u have type A in Γ and t weak-head reduces to u *)
-Reserved Notation "[ Γ |- t :⇒*: u : A ]" (at level 0, Γ, t, u, A at level 50).
-Reserved Notation "[ Γ |-[ ta  ] t :⇒*: u : A ]" (at level 0, ta, Γ, t, u, A at level 50).
+Reserved Notation "[ Γ |- t :⤳*: u : A ]" (at level 0, Γ, t, u, A at level 50).
+Reserved Notation "[ Γ |-[ ta  ] t :⤳*: u : A ]" (at level 0, ta, Γ, t, u, A at level 50).
 
 (** ** Weakenings *)
 (** Well-formed weakening *)

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -84,7 +84,7 @@ Proof.
     1,2: now constructor.
     assert (eqσ : forall Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])
     by (intro; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
-    assert [Δ,, F[σ] |-[ ta ] tApp (tLambda F[σ] t[up_term_term σ])⟨S⟩ (tRel 0) ⇒*  t[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0)..] : G[up_term_term σ]].
+    assert [Δ,, F[σ] |-[ ta ] tApp (tLambda F[σ] t[up_term_term σ])⟨S⟩ (tRel 0) ⤳*  t[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0)..] : G[up_term_term σ]].
     {
       rewrite (eqσ G). eapply redtm_beta.
       * renToWk; eapply wft_wk; tea; gen_typing.

--- a/theories/Substitution/Reduction.v
+++ b/theories/Substitution/Reduction.v
@@ -11,7 +11,7 @@ Set Printing Primitive Projection Parameters.
 
 Lemma redwfSubstValid {Γ A t u l}
   (VΓ : [||-v Γ])
-  (red : [Γ ||-v t :⇒*: u : A | VΓ])
+  (red : [Γ ||-v t :⤳*: u : A | VΓ])
   (VA : [Γ ||-v<l> A | VΓ])
   (Vu : [Γ ||-v<l> u : A | VΓ | VA]) :
   [Γ ||-v<l> t : A | VΓ | VA] × [Γ ||-v<l> t ≅ u : A | VΓ | VA].

--- a/theories/TypeConstructorsInj.v
+++ b/theories/TypeConstructorsInj.v
@@ -29,7 +29,7 @@ Section TypeConstructors.
   Lemma red_ty_complete : forall (Γ : context) (T T' : term),
     isType T ->
     [Γ |- T ≅ T'] ->
-    ∑ T'', [Γ |- T' ⇒* T''] × isType T''.
+    ∑ T'', [Γ |- T' ⤳* T''] × isType T''.
   Proof.
     intros * tyT Hconv.
     eapply Fundamental in Hconv as [HΓ HT HT' Hconv].
@@ -39,7 +39,7 @@ Section TypeConstructors.
     clear HT.
     destruct HTred as [[] lr] ; cbn in *.
     destruct lr.
-    all: destruct Hconv; eexists; split; [lazymatch goal with H : [_ |- _ :⇒*: _] |- _ => apply H end|]; constructor.
+    all: destruct Hconv; eexists; split; [lazymatch goal with H : [_ |- _ :⤳*: _] |- _ => apply H end|]; constructor.
     eapply convneu_whne; now symmetry.
   Qed.
 
@@ -130,7 +130,7 @@ Section TypeConstructors.
 
   Corollary red_ty_compl_univ_l Γ T :
     [Γ |- U ≅ T] ->
-    [Γ |- T ⇒* U].
+    [Γ |- T ⤳* U].
   Proof.
     intros HT.
     pose proof HT as HT'.
@@ -147,7 +147,7 @@ Section TypeConstructors.
 
   Corollary red_ty_compl_univ_r Γ T :
     [Γ |- T ≅ U] ->
-    [Γ |- T ⇒* U].
+    [Γ |- T ⤳* U].
   Proof.
     intros.
     eapply red_ty_compl_univ_l.
@@ -156,7 +156,7 @@ Section TypeConstructors.
 
   Corollary red_ty_compl_nat_l Γ T :
     [Γ |- tNat ≅ T] ->
-    [Γ |- T ⇒* tNat].
+    [Γ |- T ⤳* tNat].
   Proof.
     intros HT.
     pose proof HT as HT'.
@@ -173,7 +173,7 @@ Section TypeConstructors.
 
   Corollary red_ty_compl_nat_r Γ T :
     [Γ |- T ≅ tNat] ->
-    [Γ |- T ⇒* tNat].
+    [Γ |- T ⤳* tNat].
   Proof.
     intros.
     eapply red_ty_compl_nat_l.
@@ -182,7 +182,7 @@ Section TypeConstructors.
 
   Corollary red_ty_compl_empty_l Γ T :
     [Γ |- tEmpty ≅ T] ->
-    [Γ |- T ⇒* tEmpty].
+    [Γ |- T ⤳* tEmpty].
   Proof.
     intros HT.
     pose proof HT as HT'.
@@ -199,7 +199,7 @@ Section TypeConstructors.
 
   Corollary red_ty_compl_empty_r Γ T :
     [Γ |- T ≅ tEmpty] ->
-    [Γ |- T ⇒* tEmpty].
+    [Γ |- T ⤳* tEmpty].
   Proof.
     intros.
     eapply red_ty_compl_empty_l.
@@ -208,7 +208,7 @@ Section TypeConstructors.
 
   Corollary red_ty_compl_prod_l Γ A B T :
     [Γ |- tProd A B ≅ T] ->
-    ∑ A' B', [× [Γ |- T ⇒* tProd A' B'], [Γ |- A' ≅ A] & [Γ,, A' |- B ≅ B']].
+    ∑ A' B', [× [Γ |- T ⤳* tProd A' B'], [Γ |- A' ≅ A] & [Γ,, A' |- B ≅ B']].
   Proof.
     intros HT.
     pose proof HT as HT'.
@@ -236,7 +236,7 @@ Section TypeConstructors.
 
   Corollary red_ty_compl_sig_l Γ A B T :
     [Γ |- tSig A B ≅ T] ->
-    ∑ A' B', [× [Γ |- T ⇒* tSig A' B'], [Γ |- A' ≅ A] & [Γ,, A' |- B ≅ B']].
+    ∑ A' B', [× [Γ |- T ⤳* tSig A' B'], [Γ |- A' ≅ A] & [Γ,, A' |- B ≅ B']].
   Proof.
     intros HT.
     pose proof HT as HT'.
@@ -254,7 +254,7 @@ Section TypeConstructors.
   
   Corollary red_ty_compl_sig_r Γ A B T :
     [Γ |- T ≅ tSig A B] ->
-    ∑ A' B', [× [Γ |- T ⇒* tSig A' B'], [Γ |- A' ≅ A] & [Γ,, A' |- B ≅ B']].
+    ∑ A' B', [× [Γ |- T ⤳* tSig A' B'], [Γ |- A' ≅ A] & [Γ,, A' |- B ≅ B']].
   Proof.
     intros; eapply red_ty_compl_sig_l; now symmetry.
   Qed.
@@ -271,7 +271,7 @@ Section TypeConstructors.
 
   Corollary red_ty_compl_id_l Γ A x y T :
     [Γ |- tId A x y ≅ T] ->
-    ∑ A' x' y', [× [Γ |- T ⇒* tId A' x' y'], [Γ |- A' ≅ A], [Γ |- x ≅ x' : A] & [Γ |- y ≅ y' : A]].
+    ∑ A' x' y', [× [Γ |- T ⤳* tId A' x' y'], [Γ |- A' ≅ A], [Γ |- x ≅ x' : A] & [Γ |- y ≅ y' : A]].
   Proof.
     intros HT.
     pose proof HT as HT'.
@@ -288,7 +288,7 @@ Section TypeConstructors.
   
   Corollary red_ty_compl_id_r Γ A x y T :
     [Γ |- T ≅ tId A x y] ->
-    ∑ A' x' y', [× [Γ |- T ⇒* tId A' x' y'], [Γ |- A' ≅ A], [Γ |- x ≅ x' : A] & [Γ |- y ≅ y' : A]].
+    ∑ A' x' y', [× [Γ |- T ⤳* tId A' x' y'], [Γ |- A' ≅ A], [Γ |- x ≅ x' : A] & [Γ |- y ≅ y' : A]].
   Proof.
     intros; eapply red_ty_compl_id_l; now symmetry.
   Qed.
@@ -584,7 +584,7 @@ Proof.
   now intros ?%boundary.
 Qed.
 
-Corollary boundary_red_ty_r Γ A B : [Γ |- A ⇒* B] -> [Γ |- B].
+Corollary boundary_red_ty_r Γ A B : [Γ |- A ⤳* B] -> [Γ |- B].
 Proof.
   now intros ?%RedConvTyC%boundary.
 Qed.
@@ -604,12 +604,12 @@ Proof.
   now intros []%boundary.
 Qed.
 
-Corollary boundary_red_tm_r Γ A t u : [Γ |- t ⇒* u : A] -> [Γ |- u : A].
+Corollary boundary_red_tm_r Γ A t u : [Γ |- t ⤳* u : A] -> [Γ |- u : A].
 Proof.
   now intros []%RedConvTeC%boundary.
 Qed.
 
-Corollary boundary_red_tm_ty Γ A t u : [Γ |- t ⇒* u : A] -> [Γ |- A].
+Corollary boundary_red_tm_ty Γ A t u : [Γ |- t ⤳* u : A] -> [Γ |- A].
 Proof.
   now intros []%RedConvTeC%boundary.
 Qed.
@@ -652,7 +652,7 @@ Qed.
 
 Corollary red_ty_compl_prod_r Γ A B T :
   [Γ |- T ≅ tProd A B] ->
-  ∑ A' B', [× [Γ |- T ⇒* tProd A' B'], [Γ |- A ≅ A'] & [Γ,, A |- B' ≅ B]].
+  ∑ A' B', [× [Γ |- T ⤳* tProd A' B'], [Γ |- A ≅ A'] & [Γ,, A |- B' ≅ B]].
 Proof.
   intros HT.
   symmetry in HT.
@@ -735,7 +735,7 @@ Qed.
 
 Theorem subject_reduction_one Γ A t t' :
     [Γ |- t : A] ->
-    [t ⇒ t'] ->
+    [t ⤳ t'] ->
     [Γ |- t ≅ t' : A].
 Proof.
   intros Hty Hred.
@@ -805,7 +805,7 @@ Proof.
 
   Theorem subject_reduction_one_type Γ A A' :
   [Γ |- A] ->
-  [A ⇒ A'] ->
+  [A ⤳ A'] ->
   [Γ |- A ≅ A'].
 Proof.
   intros Hty Hred.
@@ -818,8 +818,8 @@ Qed.
 
 Theorem subject_reduction Γ t t' A :
   [Γ |- t : A] ->
-  [t ⇒* t'] ->
-  [Γ |- t ⇒* t' : A].
+  [t ⤳* t'] ->
+  [Γ |- t ⤳* t' : A].
 Proof.
   intros Hty Hr; split ; refold.
   - assumption.
@@ -834,8 +834,8 @@ Qed.
 
 Theorem subject_reduction_type Γ A A' :
 [Γ |- A] ->
-[A ⇒* A'] ->
-[Γ |- A ⇒* A'].
+[A ⤳* A'] ->
+[Γ |- A ⤳* A'].
 Proof.
   intros Hty Hr; split; refold.
   - assumption.
@@ -848,7 +848,7 @@ Proof.
       now boundary.
 Qed.
 
-Corollary conv_red_l Γ A A' A'' : [Γ |-[de] A' ≅ A''] -> [A' ⇒* A] -> [Γ |-[de] A ≅ A''].
+Corollary conv_red_l Γ A A' A'' : [Γ |-[de] A' ≅ A''] -> [A' ⤳* A] -> [Γ |-[de] A ≅ A''].
 Proof.
   intros Hconv **.
   etransitivity ; tea.

--- a/theories/TypeUniqueness.v
+++ b/theories/TypeUniqueness.v
@@ -11,7 +11,7 @@ Section AlgorithmicUnique.
   Lemma algo_typing_unique : AlgoTypingInductionConcl
     (fun Γ A => True)
     (fun Γ A t => forall A', [Γ |-[al] t ▹ A'] -> A' = A)
-    (fun Γ A t => forall A', [Γ |-[al] t ▹h A'] -> ∑ A'', [A'' ⇒* A] × [A'' ⇒* A'])
+    (fun Γ A t => forall A', [Γ |-[al] t ▹h A'] -> ∑ A'', [A'' ⤳* A] × [A'' ⤳* A'])
     (fun Γ A t => True).
   Proof.
     apply AlgoTypingInduction.

--- a/theories/UntypedReduction.v
+++ b/theories/UntypedReduction.v
@@ -9,37 +9,37 @@ From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakenin
 
 Inductive OneRedAlg : term -> term -> Type :=
 | BRed {A a t} :
-    [ tApp (tLambda A t) a ⇒ t[a..] ]
+    [ tApp (tLambda A t) a ⤳ t[a..] ]
 | appSubst {t u a} :
-    [ t ⇒ u ] ->
-    [ tApp t a ⇒ tApp u a ]
+    [ t ⤳ u ] ->
+    [ tApp t a ⤳ tApp u a ]
 | natElimSubst {P hz hs n n'} :
-    [ n ⇒ n' ] ->
-    [ tNatElim P hz hs n ⇒ tNatElim P hz hs n' ]
+    [ n ⤳ n' ] ->
+    [ tNatElim P hz hs n ⤳ tNatElim P hz hs n' ]
 | natElimZero {P hz hs} :
-    [ tNatElim P hz hs tZero ⇒ hz ]
+    [ tNatElim P hz hs tZero ⤳ hz ]
 | natElimSucc {P hz hs n} :
-    [ tNatElim P hz hs (tSucc n) ⇒ tApp (tApp hs n) (tNatElim P hz hs n) ]
+    [ tNatElim P hz hs (tSucc n) ⤳ tApp (tApp hs n) (tNatElim P hz hs n) ]
 | emptyElimSubst {P e e'} :
-    [e ⇒ e'] ->
-    [tEmptyElim P e ⇒ tEmptyElim P e']        
+    [e ⤳ e'] ->
+    [tEmptyElim P e ⤳ tEmptyElim P e']        
 | fstSubst {p p'} :
-    [ p ⇒ p'] ->
-    [ tFst p ⇒ tFst p']
+    [ p ⤳ p'] ->
+    [ tFst p ⤳ tFst p']
 | fstPair {A B a b} :
-    [ tFst (tPair A B a b) ⇒ a ]
+    [ tFst (tPair A B a b) ⤳ a ]
 | sndSubst {p p'} :
-    [ p ⇒ p'] ->
-    [ tSnd p ⇒ tSnd p']
+    [ p ⤳ p'] ->
+    [ tSnd p ⤳ tSnd p']
 | sndPair {A B a b} :
-    [ tSnd (tPair A B a b) ⇒ b ]
+    [ tSnd (tPair A B a b) ⤳ b ]
 | idElimRefl {A x P hr y A' z} :
-  [ tIdElim A x P hr y (tRefl A' z) ⇒ hr ]
+  [ tIdElim A x P hr y (tRefl A' z) ⤳ hr ]
 | idElimSubst {A x P hr y e e'} :
-  [e ⇒ e'] ->
-  [ tIdElim A x P hr y e ⇒ tIdElim A x P hr y e' ]
+  [e ⤳ e'] ->
+  [ tIdElim A x P hr y e ⤳ tIdElim A x P hr y e' ]
 
-where "[ t ⇒ t' ]" := (OneRedAlg t t') : typing_scope.
+where "[ t ⤳ t' ]" := (OneRedAlg t t') : typing_scope.
 
 (* Keep in sync with OneRedTermDecl! *)
 
@@ -47,12 +47,12 @@ where "[ t ⇒ t' ]" := (OneRedAlg t t') : typing_scope.
 
 Inductive RedClosureAlg : term -> term -> Type :=
   | redIdAlg {t} :
-    [ t ⇒* t ]
+    [ t ⤳* t ]
   | redSuccAlg {t t' u} :
-    [ t ⇒ t'] ->
-    [ t' ⇒* u ] ->
-    [ t ⇒* u ]
-  where "[ t ⇒* t' ]" := (RedClosureAlg t t') : typing_scope.
+    [ t ⤳ t'] ->
+    [ t' ⤳* u ] ->
+    [ t ⤳* u ]
+  where "[ t ⤳* t' ]" := (RedClosureAlg t t') : typing_scope.
 
 #[export] Instance RedAlgTrans : PreOrder RedClosureAlg.
   Proof.
@@ -72,7 +72,7 @@ Ltac inv_whne :=
   match goal with [ H : whne _ |- _ ] => inversion H end.
 
 Lemma whne_nored n u :
-  whne n -> [n ⇒ u] -> False.
+  whne n -> [n ⤳ u] -> False.
 Proof.
   intros ne red.
   induction red in ne |- *.
@@ -82,7 +82,7 @@ Proof.
 Qed.
 
 Lemma whnf_nored n u :
-  whnf n -> [n ⇒ u] -> False.
+  whnf n -> [n ⤳ u] -> False.
 Proof.
   intros nf red.
   induction red in nf |- *.
@@ -93,7 +93,7 @@ Qed.
 (** *** Determinism of reduction *)
 
 Lemma ored_det {t u v} :
-  [t ⇒ u] -> [t ⇒ v] ->
+  [t ⤳ u] -> [t ⤳ v] ->
   u = v.
 Proof.
   intros red red'.
@@ -137,7 +137,7 @@ Proof.
     exfalso; eapply whnf_nored;tea; constructor.
 Qed.
 
-Lemma red_whne t u : [t ⇒* u] -> whne t -> t = u.
+Lemma red_whne t u : [t ⤳* u] -> whne t -> t = u.
 Proof.
   intros [] ?.
   1: reflexivity.
@@ -145,7 +145,7 @@ Proof.
   eauto using whne_nored.
 Qed.
 
-Lemma red_whnf t u : [t ⇒* u] -> whnf t -> t = u.
+Lemma red_whnf t u : [t ⤳* u] -> whnf t -> t = u.
 Proof.
   intros [] ?.
   1: reflexivity.
@@ -155,8 +155,8 @@ Qed.
 
 Lemma whred_red_det t u u' :
   whnf u ->
-  [t ⇒* u] -> [t ⇒* u'] ->
-  [u' ⇒* u].
+  [t ⤳* u] -> [t ⤳* u'] ->
+  [u' ⤳* u].
 Proof.
   intros whnf red red'.
   induction red in whnf, u', red' |- *.
@@ -170,7 +170,7 @@ Qed.
 
 Corollary whred_det t u u' :
   whnf u -> whnf u' ->
-  [t ⇒* u] -> [t ⇒* u'] ->
+  [t ⤳* u] -> [t ⤳* u'] ->
   u = u'.
 Proof.
   intros.
@@ -181,8 +181,8 @@ Qed.
 (** *** Stability by weakening *)
 
 Lemma oredalg_wk (ρ : nat -> nat) (t u : term) :
-[t ⇒ u] ->
-[t⟨ρ⟩ ⇒ u⟨ρ⟩].
+[t ⤳ u] ->
+[t⟨ρ⟩ ⤳ u⟨ρ⟩].
 Proof.
   intros Hred.
   induction Hred in ρ |- *.
@@ -196,15 +196,15 @@ Proof.
 Qed.
 
 Lemma credalg_wk (ρ : nat -> nat) (t u : term) :
-[t ⇒* u] ->
-[t⟨ρ⟩ ⇒* u⟨ρ⟩].
+[t ⤳* u] ->
+[t⟨ρ⟩ ⤳* u⟨ρ⟩].
 Proof.
   induction 1 ; econstructor ; eauto using oredalg_wk.
 Qed.
 
 (** Derived rules *)
 
-Lemma redalg_app {t t' u} : [t ⇒* t'] -> [tApp t u ⇒* tApp t' u].
+Lemma redalg_app {t t' u} : [t ⤳* t'] -> [tApp t u ⤳* tApp t' u].
 Proof.
 induction 1.
 + reflexivity.
@@ -212,7 +212,7 @@ induction 1.
   now econstructor.
 Qed.
 
-Lemma redalg_natElim {P hs hz t t'} : [t ⇒* t'] -> [tNatElim P hs hz t ⇒* tNatElim P hs hz t'].
+Lemma redalg_natElim {P hs hz t t'} : [t ⤳* t'] -> [tNatElim P hs hz t ⤳* tNatElim P hs hz t'].
 Proof.
 induction 1.
 + reflexivity.
@@ -220,7 +220,7 @@ induction 1.
   now econstructor.
 Qed.
 
-Lemma redalg_natEmpty {P t t'} : [t ⇒* t'] -> [tEmptyElim P t ⇒* tEmptyElim P t'].
+Lemma redalg_natEmpty {P t t'} : [t ⤳* t'] -> [tEmptyElim P t ⤳* tEmptyElim P t'].
 Proof.
 induction 1.
 + reflexivity.
@@ -228,23 +228,23 @@ induction 1.
   now econstructor.
 Qed.
 
-Lemma redalg_fst {t t'} : [t ⇒* t'] -> [tFst t ⇒* tFst t'].
+Lemma redalg_fst {t t'} : [t ⤳* t'] -> [tFst t ⤳* tFst t'].
 Proof.
   induction 1; [reflexivity|].
   econstructor; tea; now constructor.
 Qed.
 
-Lemma redalg_snd {t t'} : [t ⇒* t'] -> [tSnd t ⇒* tSnd t'].
+Lemma redalg_snd {t t'} : [t ⤳* t'] -> [tSnd t ⤳* tSnd t'].
 Proof.
   induction 1; [reflexivity|].
   econstructor; tea; now constructor.
 Qed.
 
-Lemma redalg_idElim {A x P hr y t t'} : [t ⇒* t'] -> [tIdElim A x P hr y t ⇒* tIdElim A x P hr y t'].
+Lemma redalg_idElim {A x P hr y t t'} : [t ⤳* t'] -> [tIdElim A x P hr y t ⤳* tIdElim A x P hr y t'].
 Proof.
   induction 1; [reflexivity|].
   econstructor; tea; now constructor.
 Qed.
 
-Lemma redalg_one_step {t t'} : [t ⇒ t'] -> [t ⇒* t'].
+Lemma redalg_one_step {t t'} : [t ⤳ t'] -> [t ⤳* t'].
 Proof. intros; econstructor;[tea|reflexivity]. Qed.

--- a/theories/UntypedValues.v
+++ b/theories/UntypedValues.v
@@ -4,16 +4,16 @@ From LogRel Require Import Utils BasicAst Notations Context NormalForms UntypedR
 Unset Elimination Schemes.
 
 Inductive snf (r : term) : Type :=
-  | snf_tSort {s} : [ r ⇒* tSort s ] -> snf r
-  | snf_tProd {A B} : [ r ⇒* tProd A B ] -> snf A -> snf B -> snf r
-  | snf_tLambda {A t} : [ r ⇒* tLambda A t ] -> snf A -> snf t -> snf r
-  | snf_tNat : [ r ⇒* tNat ] -> snf r
-  | snf_tZero : [ r ⇒* tZero ] -> snf r
-  | snf_tSucc {n} : [ r ⇒* tSucc n ] -> snf n -> snf r
-  | snf_tEmpty : [ r ⇒* tEmpty ] -> snf r
-  | snf_tSig {A B} : [r ⇒* tSig A B] -> snf A -> snf B -> snf r
-  | snf_tPair {A B a b} : [r ⇒* tPair A B a b] -> snf A -> snf B -> snf a -> snf b -> snf r
-  | snf_sne {n} : [ r ⇒* n ] -> sne n -> snf r
+  | snf_tSort {s} : [ r ⤳* tSort s ] -> snf r
+  | snf_tProd {A B} : [ r ⤳* tProd A B ] -> snf A -> snf B -> snf r
+  | snf_tLambda {A t} : [ r ⤳* tLambda A t ] -> snf A -> snf t -> snf r
+  | snf_tNat : [ r ⤳* tNat ] -> snf r
+  | snf_tZero : [ r ⤳* tZero ] -> snf r
+  | snf_tSucc {n} : [ r ⤳* tSucc n ] -> snf n -> snf r
+  | snf_tEmpty : [ r ⤳* tEmpty ] -> snf r
+  | snf_tSig {A B} : [r ⤳* tSig A B] -> snf A -> snf B -> snf r
+  | snf_tPair {A B a b} : [r ⤳* tPair A B a b] -> snf A -> snf B -> snf a -> snf b -> snf r
+  | snf_sne {n} : [ r ⤳* n ] -> sne n -> snf r
 with sne (r : term) : Type :=
   | sne_tRel {v} : r = tRel v -> sne r
   | sne_tApp {n t} : r = tApp n t -> sne n -> snf t -> sne r
@@ -56,7 +56,7 @@ Proof.
 apply sne_rect with (P := fun _ _ => True); intros; subst; constructor; assumption.
 Qed.
 
-Lemma snf_red : forall t u, [ t ⇒* u ] -> snf u -> snf t.
+Lemma snf_red : forall t u, [ t ⤳* u ] -> snf u -> snf t.
 Proof.
 intros t u Hr Hu; destruct Hu.
 + eapply snf_tSort.

--- a/theories/Validity.v
+++ b/theories/Validity.v
@@ -216,7 +216,7 @@ Section MoreDefs.
     {
       validRed : forall {Δ σ}
         (wfΔ : [|- Δ]) (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]),
-        [Δ |- t[σ] :⇒*: u[σ] : A[σ]]
+        [Δ |- t[σ] :⤳*: u[σ] : A[σ]]
     }.
 End MoreDefs.
 
@@ -244,7 +244,7 @@ Notation "[ Γ ||-v< l > t : A | VΓ | VA ]"     := (termValidity Γ l t A VΓ V
 Notation "[ Γ ||-v< l > A ≅ B | VΓ | VA ]"     := (typeEqValidity Γ l A B VΓ VA) (at level 0, Γ, l, A, B, VΓ, VA at level 50).
 Notation "[ Γ ||-v< l > t ≅ u : A | VΓ | VA ]" := (termEqValidity Γ l t u A VΓ VA) (at level 0, Γ, l, t, u, A, VΓ, VA at level 50).
 Notation "[ Γ ||-v< l > t ≅ u : A | VΓ ]"      := (tmEqValidity Γ l t u A VΓ) (at level 0, Γ, l, t, u, A, VΓ at level 50).
-Notation "[ Γ ||-v t :⇒*: u : A | VΓ ]"      := (redValidity Γ t u A VΓ) (at level 0, Γ, t, u, A, VΓ at level 50).
+Notation "[ Γ ||-v t :⤳*: u : A | VΓ ]"      := (redValidity Γ t u A VΓ) (at level 0, Γ, t, u, A, VΓ at level 50).
 
 Section Inductions.
   Context `{ta : tag} `{WfContext ta} `{WfType ta} `{Typing ta}


### PR DESCRIPTION
Also changes the notation for reduction steps from `⇒` to `⤳` in order to better match paper notations.