### PR TITLE
Split up dependency graph generation to part inside and part outside docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
             startGroup "Build project"
               opam exec -- make -j 2
               opam exec -- make coqdoc
+              opam exec -- make docs/dependency_graph.pre
             endGroup
           uninstall: |
             startGroup "Clean project"
@@ -56,11 +57,14 @@ jobs:
         # to avoid a warning at cleanup time
         if: ${{ always() }}
         run: sudo chown -R 1001:116 .  # <--
+
       - name: Install graphviz
         uses: ts-graphviz/setup-graphviz@v1
 
       - name: Build dependency graph
-        run: make depgraph
+        run: |
+          tred docs/dependency_graph.pre > docs/dependency_graph.dot
+          dot -T png docs/dependency_graph.dot -o docs/dependency_graph.png
 
       - name: Build doc overview
         uses: docker://pandoc/core:2.9
@@ -78,7 +82,6 @@ jobs:
         if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v1
         with:
-          # Upload entire repository
           path: 'docs'
       - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/master'

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -24,8 +24,12 @@ coqdoc: $(GLOBFILES) $(VFILES) $(HEADER) $(FOOTER) $(RESOURCES) $(FRONTPAGE)
 clean::
 	$(HIDE)rm -rf $(COQDOCDIR)/*.html
 
-$(DOCDIR)/dependency_graph.dot: $(VFILES)
-	coqdep -Q theories LogRel -R coq-partialfun/theories PartialFun $(VFILES) | perl generate_deps.pl | tred > $(DOCDIR)/dependency_graph.dot
+$(DOCDIR)/dependency_graph.pre: $(VFILES)
+	coqdep -Q theories LogRel -R coq-partialfun/theories PartialFun $(VFILES) | perl generate_deps.pl > $(DOCDIR)/dependency_graph.pre
+
+$(DOCDIR)/dependency_graph.dot: $(DOCDIR)/dependency_graph.pre
+	rm -f $(DOCDIR)/dependency_graph.dot
+	tred $(DOCDIR)/dependency_graph.pre > $(DOCDIR)/dependency_graph.dot           
 
 $(DOCDIR)/dependency_graph.png: $(DOCDIR)/dependency_graph.dot
 	dot -T png $(DOCDIR)/dependency_graph.dot -o $(DOCDIR)/dependency_graph.png


### PR DESCRIPTION
I split up the `Makefile.coq.local` targets to first run everything depending on Coq but not graphviz, and then everything depending on graphviz but not Coq.

That way we can run the things that depend on Coq inside the docker image, and everything else in the CI's VM that has graphviz installed