### PR TITLE
Adding execution examples

### DIFF
--- a/theories/Decidability/Execution.v
+++ b/theories/Decidability/Execution.v
@@ -1,0 +1,90 @@
+(** * LogRel.Decidability.Execution: example executions of the type checker, in Coq. *)
+From LogRel.AutoSubst Require Import core unscoped Ast Extra.
+From LogRel Require Import Utils Notations BasicAst Context GenericTyping DeclarativeTyping DeclarativeInstance BundledAlgorithmicTyping AlgorithmicTypingProperties.
+From PartialFun Require Import Monad PartialFun.
+From LogRel.Decidability Require Import Functions Soundness.
+
+Import DeclarativeTypingProperties.
+Import IndexedDefinitions.
+
+#[local] Definition infer (Γ : context) (t : term) : Fueled (result term) :=
+  (fueled typing 1000 (inf_state;Γ;tt;t)).
+
+#[local] Definition check (Γ : context) (T t : term) : Fueled (result unit) := 
+  (fueled typing 1000 (check_state;Γ;T;t)).
+
+#[local] Definition check_ty (Γ : context) (t : term) : Fueled (result unit) := 
+  (fueled typing 1000 (wf_ty_state;Γ;tt;t)).
+
+#[local] Definition conv_tm (Γ : context) (T: term) (t1 : term) (t2 : term) : Fueled _ :=
+  (fueled conv 1000 (tm_state;Γ;T;t1;t2)).
+
+
+Ltac infer_auto :=
+  match goal with
+  | |- [ε |- ?t : ?T] =>
+    assert [|- ε] by econstructor ;
+      eassert (graph typing (inf_state;ε;tt;t) (ok _))
+        as ?%implem_typing_sound%algo_typing_sound
+        by (apply (fueled_graph_sound typing 1000 (inf_state;_)) ; reflexivity)
+  end ; auto.
+
+Ltac wf_ty_auto :=
+  match goal with
+  | |- [ε |- ?T] =>
+      assert [|- ε] by econstructor ;
+      eassert (graph typing (wf_ty_state;ε;tt;T) (ok _))
+        as ?%implem_typing_sound%algo_typing_sound
+        by (apply (fueled_graph_sound typing 1000 (wf_ty_state;_)) ; reflexivity)
+  end ; auto.
+
+Ltac check_auto :=
+  match goal with
+  | |- [ε |- ?t : ?T] =>
+    assert [|- ε] by econstructor ;
+    eassert (graph typing (check_state;ε;T;t) (ok _))
+      as ?%implem_typing_sound%algo_typing_sound
+      by (apply (fueled_graph_sound typing 1000 (check_state;_)) ; reflexivity) ;
+    eassert (graph typing (wf_ty_state;ε;tt;T) (ok _))
+      as ?%implem_typing_sound%algo_typing_sound
+      by (apply (fueled_graph_sound typing 1000 (wf_ty_state;_)) ; reflexivity) ;
+    auto
+end.
+
+(*** A series of example, each time the term in Coq first, then a proof that it type-checks
+  in our system, proven via reification. *)
+
+Check ((0;0) : ∑ x : nat, nat).
+
+Goal [ε |- tPair tNat tNat tZero tZero : tSig tNat tNat].
+Proof.
+  infer_auto.
+Qed.
+
+Check ((fun x => nat_rec (fun _ => nat) 0 (fun _ ih => S (S ih)) x) : nat -> nat).
+
+Goal [ε |-
+  (tLambda tNat (tNatElim
+    tNat
+    tZero
+    (tLambda tNat (tLambda tNat (tSucc (tSucc (tRel 0)))))
+    (tSucc (tSucc tZero))))
+  : arr tNat tNat].
+Proof.
+  infer_auto.
+Qed.
+
+Check (eq_refl : (nat_rect (fun _ => Type) nat (fun _ ih => nat -> ih) 3) = (nat -> nat -> nat -> nat)).
+
+Goal [ε |-
+  tRefl U (arr tNat (arr tNat (arr tNat tNat))) : 
+  tId U
+    (arr tNat (arr tNat (arr tNat tNat)))
+    (tNatElim
+      U
+      tNat
+      (tLambda tNat (tLambda U (arr tNat (tRel 0))))
+    (tSucc (tSucc (tSucc (tZero)))))].
+Proof.
+  check_auto.
+Qed.

--- a/theories/Decidability/Functions.v
+++ b/theories/Decidability/Functions.v
@@ -611,9 +611,9 @@ Definition typing_full_dom := ∑ (c : typing_state), typing_dom c.
 Definition typing_cod (c : typing_state) := result (tstate_output c).
 Definition typing_full_cod (x : typing_full_dom) := typing_cod (x.π1).
 
-Definition ϕ := (binary_store wh_red conv).
-Definition wh_red_key := true.
-Definition conv_key := false.
+#[local]Definition ϕ := (binary_store wh_red conv).
+#[local]Definition wh_red_key := true.
+#[local]Definition conv_key := false.
 
 #[local]
 Notation M0 := (irec ϕ (typing_full_dom) (typing_full_cod)).
@@ -778,34 +778,16 @@ Equations typing_wf_ty : typing_stmt wf_ty_state :=
 
 End Typing.
 
+Section CtxTyping.
 
+  #[local] Instance: forall x, PFun (singleton_store typing x) := singleton_pfun typing.
 
-(* #[local] Definition infer (Γ : context) (t : term) : Fueled (result term) := 
-  (fueled typing 1000 (inf_state;Γ;tt;t)).
+  #[local] Instance: Monad (errrec (singleton_store typing) (A:=context) (B:=(fun _ => result unit))) := monad_erec.
 
-#[local] Definition check (Γ : context) (T t : term) : Fueled (result unit) := 
-  (fueled typing 1000 (check_state;Γ;T;t)).
-
-#[local] Definition check_ty (Γ : context) (t : term) : Fueled (result unit) := 
-  (fueled typing 1000 (wf_ty_state;Γ;tt;t)).
-
-Check (eq_refl :
-  (infer ε
-  (tNatElim
-    tNat
-    tZero
-  (tLambda tNat (tLambda tNat (tSucc (tSucc (tRel 0)))))
-  (tSucc (tSucc tZero))))
-  = (Success (ok tNat))).
-
-Check (eq_refl : (infer ε (tProd U (tRel 0))) = (Success (error type_error))).
-Check (eq_refl : (check_ty ε (tProd U (tRel 0))) = (Success (ok tt))).
-
-Check (eq_refl :
-  (infer ε
-    (tLambda tNat (tNatElim
-      tNat
-      tZero
-    (tLambda tNat (tLambda tNat (tSucc (tSucc (tRel 0)))))
-    (tRel 0))))
-  = (Success (ok (tProd tNat tNat)))). *)
+  Equations check_ctx : context ⇀[singleton_store typing] result unit :=
+    check_ctx ε := ret tt ;
+    check_ctx (Γ,,A) :=
+      rec Γ ;;
+      call tt (wf_ty_state;Γ;tt;A).
+  
+End CtxTyping.

--- a/theories/Decidability/Soundness.v
+++ b/theories/Decidability/Soundness.v
@@ -278,3 +278,29 @@ Section TypingCorrect.
   Qed.
 
 End TypingCorrect.
+
+Section CtxTypingSound.
+
+  Lemma _check_ctx_sound :
+    funrect check_ctx (fun _ => True) (fun Γ r => if r then [|- Γ] else True).
+  Proof.
+    intros ? _.
+    funelim (check_ctx _) ; cbn.
+    - now constructor.
+    - split ; [easy|].
+      intros [|] ; cbn ; try easy.
+      intros ? [] ?%implem_typing_sound ; cbn in *.
+      2: easy.
+      now econstructor.
+  Qed.
+     
+  Lemma check_ctx_sound Γ :
+    graph check_ctx Γ (ok tt) ->
+    [|-[al] Γ].
+  Proof.
+    eintros ?%funrect_graph.
+    2: eapply _check_ctx_sound.
+    all: easy.
+  Qed.
+
+End CtxTypingSound.


### PR DESCRIPTION
We add a bunch of examples of typing derivations, obtained by running the fueled checker and using its soundness, aka reflection proofs.