### PR TITLE
Strengthen the eta rule for generic conversion at Π and Σ types.

### DIFF
--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -1199,13 +1199,14 @@ Qed.
     - intros_bn.
       1-2: gen_typing.
       now do 2 econstructor.
-    - intros_bn.
+   - intros * [] [] [] ? [] ? [] []; constructor; tea.
       + boundary.
       + eauto using inf_conv_decl.
       + eauto using inf_conv_decl.
       + econstructor.
         1-3: reflexivity.
-        econstructor; tea; gen_typing.
+        econstructor; tea.
+        1-2: now eapply isPair_whnf, (isWfPair_isPair (ta := bn)).
     - intros_bn.
       1-3: gen_typing.
       now do 2 econstructor.
@@ -1588,7 +1589,8 @@ Module IntermediateTypingProperties.
       + gen_typing.
       + econstructor.
         1-3: reflexivity.
-        econstructor; gen_typing.
+        econstructor; [| |gen_typing|gen_typing].
+        1-2: now eapply isPair_whnf, isWfPair_isPair.
     - intros ? HΓ.
       eapply (convtm_empty (ta := bn)).
       now econstructor.

--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -1181,14 +1181,14 @@ Qed.
         symmetry.
         now constructor.
       + now do 2 econstructor.
-    - intros_bn.
+    - intros * [] [] [] ? [] ? []; constructor; tea.
       + boundary.
       + eauto using inf_conv_decl.
       + eauto using inf_conv_decl.
       + econstructor.
         1-3: reflexivity.
         econstructor.
-        1-2: gen_typing.
+        1-2: now eapply isFun_whnf, (isWfFun_isFun (ta := bn)).
         eassumption.
     - intros_bn.
       1-3: gen_typing.
@@ -1573,7 +1573,8 @@ Module IntermediateTypingProperties.
       split ; tea.
       + gen_typing.
       + boundary.
-      + do 2 econstructor ; gen_typing.
+      + do 2 econstructor ; [| |gen_typing].
+        all: now eapply isFun_whnf, isWfFun_isFun.
     - intros.
       eapply (convtm_nat (ta := bn)).
       now econstructor.

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -123,7 +123,16 @@ Section RedDefinitions.
     | isterm A => [Γ |- t : A]
     end
   }.
-  
+
+  Inductive isWfFun (Γ : context) (A B : term) : term -> Set :=
+    LamWfFun : forall A' t : term, [Γ |- A ≅ A'] -> isWfFun Γ A B (tLambda A' t)
+  | NeWfFun : forall f : term, whne f -> isWfFun Γ A B f.
+
+  Lemma isWfFun_isFun : forall Γ A B t, isWfFun Γ A B t -> isFun t.
+  Proof.
+  intros * []; now constructor.
+  Qed.
+
 End RedDefinitions.
 
 Notation "[ Γ |- A ↘ B ]" := (TypeRedWhnf Γ A B) (only parsing) : typing_scope.
@@ -338,9 +347,9 @@ Section GenericTyping.
       [ Γ |- A ] ->
       [ Γ,, A |- B ] ->
       [ Γ |- f : tProd A B ] ->
-      isFun f ->
+      isWfFun Γ A B f ->
       [ Γ |- g : tProd A B ] ->
-      isFun g ->
+      isWfFun Γ A B g ->
       [ Γ ,, A |- eta_expand f ≅ eta_expand g : B ] ->
       [ Γ |- f ≅ g : tProd A B ] ;
     convtm_nat {Γ} :
@@ -954,7 +963,7 @@ Section GenericConsequences.
     2: eapply convty_simple_arr; cycle 1; tea.
     eapply convtm_eta; tea.
     { renToWk; apply wft_wk; [apply wfc_cons|]; tea. }
-    2,4: constructor.
+    2,4: constructor; first [now apply lrefl|tea].
     1,2: eapply ty_id; tea; now symmetry.
     assert [|- Γ,, A] by gen_typing.
     assert [Γ,, A |-[ ta ] A⟨@wk1 Γ A⟩] by now eapply wft_wk. 
@@ -1063,6 +1072,7 @@ Section GenericConsequences.
   Lemma convtm_comp {Γ A B C f f' g g'} :
     [|- Γ] ->
     [Γ |- A] ->
+    [Γ |- A ≅ A] ->
     [Γ |- B] ->
     [Γ |- C] ->
     [Γ |- f : arr A B] ->
@@ -1075,7 +1085,7 @@ Section GenericConsequences.
     intros.
     eapply convtm_eta; tea.
     { renToWk; apply wft_wk; [apply wfc_cons|]; tea. }
-    2,4: constructor.
+    2,4: now constructor.
     1,2: eapply ty_comp.
     4,5,9,10: tea.
     all: tea.
@@ -1111,11 +1121,13 @@ Section GenericConsequences.
     intros.
     assert [|- Γ,, A] by gen_typing.
     apply convtm_eta ; tea.
-    1-2,4: gen_typing.
+    - gen_typing.
+    - constructor; now eapply lrefl.
     - eapply ty_conv.
       1: eapply ty_lam ; tea.
       symmetry.
       now eapply convty_prod.
+    - now constructor.
     - eapply convtm_exp ; tea.
       1: now eapply redty_refl.
       2: eapply redtm_conv ; cbn ; [eapply redtm_meta_conv |..] ; [eapply redtm_beta |..].

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -128,7 +128,16 @@ Section RedDefinitions.
     LamWfFun : forall A' t : term, [Γ |- A ≅ A'] -> isWfFun Γ A B (tLambda A' t)
   | NeWfFun : forall f : term, whne f -> isWfFun Γ A B f.
 
+  Inductive isWfPair (Γ : context) (A B : term) : term -> Set :=
+    PairWfPair : forall A' B' a b : term, [Γ |- A ≅ A'] -> isWfPair Γ A B (tPair A' B' a b)
+  | NeWfPair : forall n : term, whne n -> isWfPair Γ A B n.
+
   Lemma isWfFun_isFun : forall Γ A B t, isWfFun Γ A B t -> isFun t.
+  Proof.
+  intros * []; now constructor.
+  Qed.
+
+  Lemma isWfPair_isPair : forall Γ A B t, isWfPair Γ A B t -> isPair t.
   Proof.
   intros * []; now constructor.
   Qed.
@@ -363,9 +372,9 @@ Section GenericTyping.
       [Γ |- A] ->
       [Γ ,, A |- B] ->
       [Γ |- p : tSig A B] ->
-      isPair p ->
+      isWfPair Γ A B p ->
       [Γ |- p' : tSig A B] ->
-      isPair p' ->
+      isWfPair Γ A B p' ->
       [Γ |- tFst p ≅ tFst p' : A] ->
       [Γ |- tSnd p ≅ tSnd p' : B[(tFst p)..]] ->
       [Γ |- p ≅ p' : tSig A B] ;

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -475,7 +475,7 @@ Module SigRedTm.
   : Type := {
     nf : term;
     red : [ Γ |- t :⤳*: nf : ΣA.(outTy) ];
-    isfun : isPair nf;
+    isfun : isWfPair Γ ΣA.(PiRedTy.dom) ΣA.(PiRedTy.cod) nf;
     refl : [ Γ |- nf ≅ nf : ΣA.(outTy) ];
     fstRed {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
       [ΣA.(PolyRedPack.shpRed) ρ h | Δ ||- tFst nf⟨ρ⟩ : ΣA.(ParamRedTyPack.dom)⟨ρ⟩] ;

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -343,6 +343,7 @@ Module ParamRedTyPack.
     cod : term ;
     outTy := T dom cod ;
     red : [Γ |- A :⤳*: T dom cod];
+    eqdom : [Γ |- dom ≅ dom];
     eq : [Γ |- T dom cod ≅ T dom cod];
     polyRed : PolyRedPack@{i} Γ dom cod
   }.
@@ -365,6 +366,7 @@ Module ParamRedTyEq.
     dom : term;
     cod : term;
     red : [Γ |- B :⤳*: T dom cod ];
+    eqdom : [Γ |- ΠA.(ParamRedTyPack.dom) ≅ dom];
     eq  : [Γ |- T ΠA.(ParamRedTyPack.dom) ΠA.(ParamRedTyPack.cod) ≅ T dom cod ];
     polyRed : PolyRedEq ΠA dom cod
   }.
@@ -407,7 +409,7 @@ Module PiRedTm.
   : Type := {
     nf : term;
     red : [ Γ |- t :⤳*: nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
-    isfun : isFun nf;
+    isfun : isWfFun Γ ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) nf;
     refl : [ Γ |- nf ≅ nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
     app {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
       (ha : [ ΠA.(PolyRedPack.shpRed) ρ h | Δ ||- a : ΠA.(PiRedTy.dom)⟨ρ⟩ ])
@@ -1172,6 +1174,7 @@ Section ParamRedTy.
       dom : term ;
       cod : term ;
       red : [Γ |- A :⤳*: T dom cod] ;
+      eqdom : [Γ |- dom ≅ dom];
       outTy := T dom cod ;
       eq : [Γ |- T dom cod ≅ T dom cod] ;
       polyRed :> PolyRed@{i j k l} Γ l dom cod
@@ -1183,6 +1186,7 @@ Section ParamRedTy.
   Proof.
     exists (ParamRedTyPack.dom PA) (ParamRedTyPack.cod PA).
     - eapply ParamRedTyPack.red.
+    - eapply ParamRedTyPack.eqdom.
     - eapply ParamRedTyPack.eq.
     - now eapply PolyRed.from.
   Defined.
@@ -1192,6 +1196,7 @@ Section ParamRedTy.
   Proof.
     exists (dom PA) (cod PA).
     - now eapply red.
+    - apply eqdom.
     - now eapply eq.
     - exact (PolyRed.toPack PA).
   Defined.

--- a/theories/LogicalRelation/Application.v
+++ b/theories/LogicalRelation/Application.v
@@ -92,7 +92,7 @@ Proof.
   set (h := invLRΠ _) in hΠ.
   epose proof (e := redtywf_whnf (PiRedTyPack.red h) whnf_tProd); 
   symmetry in e; injection e; clear e; 
-  destruct h as [????? [?? domRed codRed codExt]] ; clear RΠ Rtt'; 
+  destruct h as [?????? [?? domRed codRed codExt]] ; clear RΠ Rtt'; 
   intros; cbn in *; subst. 
   assert (wfΓ : [|-Γ]) by gen_typing.
   assert [Γ ||-<l> u' : F⟨@wk_id Γ⟩ | domRed _ (@wk_id Γ) wfΓ] by irrelevance.

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -87,13 +87,15 @@ Context {Γ lA A lA' A'}
   (ΠA' : ParamRedTy@{i' j' k' l'} tProd Γ lA' A')
   (RA := LRPi' ΠA)
   (RA' := LRPi' ΠA')
+  (eqDom : [Γ |- ΠA.(ParamRedTy.dom) ≅ ΠA'.(ParamRedTy.dom)])
   (eqPi : [Γ |- ΠA.(outTy) ≅ ΠA'.(outTy)])
   (eqv : equivPolyRed ΠA ΠA').
 
 Lemma ΠIrrelevanceTyEq B : [Γ ||-<lA> A ≅ B | RA] -> [Γ ||-<lA'> A' ≅ B | RA'].
 Proof.
-  intros  [???? []] ; cbn in *; econstructor; [| |econstructor].
+  intros  [????? []] ; cbn in *; econstructor; [| | |econstructor].
   - now gen_typing.
+  - transitivity (ParamRedTyPack.dom ΠA); [now symmetry|tea].
   - cbn; etransitivity; [|tea]; now symmetry.
   - intros; now apply eqv.(eqvShp).
   - intros; cbn; unshelve eapply eqv.(eqvPos).
@@ -105,6 +107,9 @@ Lemma ΠIrrelevanceTm t : [Γ ||-<lA> t : A | RA] -> [Γ ||-<lA'> t : A' | RA'].
 Proof.
   intros []; cbn in *; econstructor; tea.
   - now eapply redtmwf_conv.
+  - destruct isfun as [A₀ t₀|n Hn].
+    + constructor; transitivity (PiRedTy.dom ΠA); [now symmetry|tea].
+    + now constructor.
   - eapply (convtm_conv refl).
     apply eqPi.
   - intros; unshelve eapply eqv.(eqvPos).
@@ -132,6 +137,7 @@ Lemma ΠIrrelevanceLRPack@{i j k l i' j' k' l' v}
   (ΠA' : ParamRedTy@{i' j' k' l'} tProd Γ lA' A')
   (RA := LRPi' ΠA)
   (RA' := LRPi' ΠA')
+  (eqDom : [Γ |- ΠA.(ParamRedTy.dom) ≅ ΠA'.(ParamRedTy.dom)])
   (eqPi : [Γ |- ΠA.(outTy) ≅ ΠA'.(outTy) ])
   (eqv : equivPolyRed ΠA ΠA')
   : equivLRPack@{k k' v} RA RA'.
@@ -153,13 +159,15 @@ Context {Γ lA A lA' A'}
   (ΣA' : ParamRedTy@{i' j' k' l'} tSig Γ lA' A')
   (RA := LRSig' ΣA)
   (RA' := LRSig' ΣA')
+  (eqDom : [Γ |- ΣA.(ParamRedTy.dom) ≅ ΣA'.(ParamRedTy.dom)])
   (eqSig : [Γ |- ΣA.(outTy) ≅ ΣA'.(outTy)])
   (eqv : equivPolyRed ΣA ΣA').
 
 Lemma ΣIrrelevanceTyEq B : [Γ ||-<lA> A ≅ B | RA] -> [Γ ||-<lA'> A' ≅ B | RA'].
 Proof.
-  intros  [???? []] ; cbn in *; econstructor; [| |econstructor].
+  intros  [????? []] ; cbn in *; econstructor; [| | |econstructor].
   - now gen_typing.
+  - transitivity (ParamRedTyPack.dom ΣA); [now symmetry|tea].
   - cbn; etransitivity; [|tea]; now symmetry.
   - intros; now apply eqv.(eqvShp).
   - intros; cbn; unshelve eapply eqv.(eqvPos).
@@ -193,6 +201,7 @@ Lemma ΣIrrelevanceLRPack@{i j k l i' j' k' l' v}
   (ΣA' : ParamRedTy@{i' j' k' l'} tSig Γ lA' A')
   (RA := LRSig' ΣA)
   (RA' := LRSig' ΣA')
+  (eqDom : [Γ |- ΣA.(ParamRedTy.dom) ≅ ΣA'.(ParamRedTy.dom)])
   (eqSig : [Γ |- ΣA.(outTy) ≅ ΣA'.(outTy) ])
   (eqv : equivPolyRed ΣA ΣA')
   : equivLRPack@{k k' v} RA RA'.
@@ -484,11 +493,12 @@ Proof.
   - destruct lrA' as [| | ? A' ΠA' HAad'| | | |] ; try solve [destruct s] ; clear s.
     pose (PA := ParamRedTy.from HAad).
     pose (PA' := ParamRedTy.from HAad').
-    destruct he as [dom0 cod0 ?? [domRed codRed]], ΠA' as [dom1 cod1];
+    destruct he as [dom0 cod0 ??? [domRed codRed]], ΠA' as [dom1 cod1];
     assert (tProd dom0 cod0 = tProd dom1 cod1) as ePi
     by (eapply whredty_det ; gen_typing).
     inversion ePi ; subst ; clear ePi.
-    eapply (ΠIrrelevanceLRPack PA PA'); [|unshelve econstructor].
+    eapply (ΠIrrelevanceLRPack PA PA'); [| |unshelve econstructor].
+    + eassumption.
     + eassumption.
     + intros; unshelve eapply IHdom.
       2: eapply (LRAd.adequate (PolyRed.shpRed PA' _ _)).
@@ -503,11 +513,12 @@ Proof.
   - destruct lrA' as [| | | | |? A' ΠA' HAad'|] ; try solve [destruct s] ; clear s.
     pose (PA := ParamRedTy.from HAad).
     pose (PA' := ParamRedTy.from HAad').
-    destruct he as [dom0 cod0 ?? [domRed codRed]], ΠA' as [dom1 cod1];
+    destruct he as [dom0 cod0 ??? [domRed codRed]], ΠA' as [dom1 cod1];
     assert (tSig dom0 cod0 = tSig dom1 cod1) as ePi
     by (eapply whredty_det ; gen_typing).
     inversion ePi ; subst ; clear ePi.
-    eapply (ΣIrrelevanceLRPack PA PA'); [|unshelve econstructor].
+    eapply (ΣIrrelevanceLRPack PA PA'); [| |unshelve econstructor].
+    + eassumption.
     + eassumption.
     + intros; unshelve eapply IHdom.
       2: eapply (LRAd.adequate (PolyRed.shpRed PA' _ _)).
@@ -578,7 +589,7 @@ Proof.
   - intros; now eapply LRne_.
   - intros [] IHdom IHcod IH; cbn in *.
     eapply LRPi'; unshelve econstructor.
-    3,4: tea.
+    3,4,5: tea.
     unshelve eapply LRIrrelevantCumPolyRed; tea.
     + intros; now eapply IHdom.
     + intros; now eapply IHcod.
@@ -586,7 +597,7 @@ Proof.
   - intros; now eapply LREmpty_.
   - intros [] IHdom IHcod IH; cbn in *.
     eapply LRSig'; unshelve econstructor.
-    3,4: tea.
+    3,4,5: tea.
     unshelve eapply LRIrrelevantCumPolyRed; tea.
     + intros; now eapply IHdom.
     + intros; now eapply IHcod.

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -180,6 +180,9 @@ Proof.
   intros []; cbn in *; unshelve econstructor; tea.
   - intros; unshelve eapply eqv.(eqvShp); now auto.
   - now eapply redtmwf_conv.
+  - destruct isfun as [A₀ t₀|n Hn].
+    + constructor; transitivity (PiRedTy.dom ΣA); [now symmetry|tea].
+    + now constructor.
   - now eapply convtm_conv.
   - intros; unshelve eapply eqv.(eqvPos); now auto.
 Defined.

--- a/theories/LogicalRelation/Neutral.v
+++ b/theories/LogicalRelation/Neutral.v
@@ -138,7 +138,7 @@ intros l Γ A ΠA0 ihdom ihcod; split.
   {
     intros. exists n; cbn.
     * eapply redtmwf_refl ; gen_typing.
-    * now eapply NeFun, convneu_whne.
+    * constructor; now eapply convneu_whne.
     * eapply convtm_conv; [|eassumption].
       now apply convtm_convneu.
     * intros; apply complete_reflect_simpl; [apply ihcod| |..].

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -254,7 +254,7 @@ Proof.
     Unshelve. 2: tea.
   - intros ???????? [? red] red' ?.
     unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: now eapply isPair_whnf.
+    1: now eapply isPair_whnf, isWfPair_isPair.
     econstructor; tea.
     eapply redtmwf_refl; gen_typing.
   - intros ???????? [? red] red' ?.

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -178,8 +178,11 @@ Proof.
     eapply LRPi'. 
     unshelve erewrite (redtywf_det _ _ red' red); tea.
     1: constructor.
-    econstructor; tea.
-    eapply redtywf_refl; gen_typing.
+    econstructor.
+    + eapply redtywf_refl; gen_typing.
+    + eassumption.
+    + eassumption.
+    + eassumption.
   - intros ??? [red] ? red' ?.
     eapply LRNat_.
     unshelve erewrite (redtywf_det _ _ red' red); tea.
@@ -196,8 +199,11 @@ Proof.
     eapply LRSig'. 
     unshelve erewrite (redtywf_det _ _ red' red); tea.
     1: constructor.
-    econstructor; tea.
-    eapply redtywf_refl; gen_typing.
+    econstructor.
+    + eapply redtywf_refl; gen_typing.
+    + eassumption.
+    + eassumption.
+    + eassumption.
   - intros ??? [???? red] _ _ ? red' ?.
     eapply LRId'; unshelve erewrite (redtywf_det _ _ red' red); tea; [constructor|].
     econstructor; tea. eapply redtywf_refl; gen_typing.
@@ -232,7 +238,7 @@ Proof.
     eapply redtmwf_refl; gen_typing.
   - intros ???????? [? red] red' ?.
     unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: now eapply isFun_whnf.
+    1: now eapply isFun_whnf, isWfFun_isFun.
     econstructor; tea.
     eapply redtmwf_refl; gen_typing.
   - intros ?????? Rt red' ?; inversion Rt; subst.

--- a/theories/LogicalRelation/SimpleArr.v
+++ b/theories/LogicalRelation/SimpleArr.v
@@ -29,6 +29,7 @@ Section SimpleArrow.
     unshelve econstructor; [exact A| exact B⟨↑⟩|..]; tea.
     - eapply redtywf_refl.
       now eapply wft_simple_arr.
+    - now unshelve eapply escapeEq, reflLRTyEq.
     - eapply convty_simple_arr; tea.
       all: now unshelve eapply escapeEq, reflLRTyEq.
     - now eapply shiftPolyRed.
@@ -58,6 +59,7 @@ Section SimpleArrow.
     intros RAA' RBB'; escape.
     unshelve econstructor; cycle 2.
     + eapply redtywf_refl; now eapply wft_simple_arr.
+    + now cbn.
     + now eapply convty_simple_arr.
     + now eapply shiftPolyRedEq.
   Qed.
@@ -138,7 +140,7 @@ Section SimpleArrow.
     econstructor; cbn.
     - eapply redtmwf_refl.
       now eapply ty_id.
-    - constructor.
+    - now constructor.
     - eapply convtm_id; tea.
       eapply wfc_wft; now escape.
     - intros; cbn; irrelevance0.
@@ -275,8 +277,9 @@ Section SimpleArrow.
     econstructor.
     - eapply redtmwf_refl.
       eapply ty_comp; cycle 2; tea.
-    - constructor.
-    - cbn. eapply convtm_comp; cycle 3; tea.
+    - constructor; cbn.
+      unshelve eapply escapeEq, reflLRTyEq; [|tea].
+    - cbn. eapply convtm_comp; cycle 4; tea.
       erewrite <- wk1_ren_on.
       eapply escapeEqTerm.
       eapply reflLRTmEq.
@@ -284,6 +287,7 @@ Section SimpleArrow.
       eapply h.
       eapply var0; now bsimpl.
       { now eapply wfc_ty. }
+      unshelve eapply escapeEq, reflLRTyEq; tea.
       Unshelve. 1: gen_typing.
       eapply wk; tea; gen_typing.
     - intros; cbn.

--- a/theories/LogicalRelation/Transitivity.v
+++ b/theories/LogicalRelation/Transitivity.v
@@ -85,7 +85,7 @@ Lemma transEqTermΣ {Γ lA A t u v} {ΣA : [Γ ||-Σ<lA> A]}
 Proof.
   intros [tL ?? eqfst eqsnd] [? tR ? eqfst' eqsnd'];
   unshelve epose proof (e := redtmwf_det _ _ (SigRedTm.red redR) (SigRedTm.red redL)); tea.
-  1,2: apply isPair_whnf; apply SigRedTm.isfun.
+  1,2: eapply isPair_whnf, isWfPair_isPair; apply SigRedTm.isfun.
   exists tL tR.
   + etransitivity; tea. now rewrite e.
   + intros; eapply ihdom ; [eapply eqfst| rewrite e; eapply eqfst'].

--- a/theories/LogicalRelation/Transitivity.v
+++ b/theories/LogicalRelation/Transitivity.v
@@ -61,7 +61,7 @@ Lemma transEqTermΠ {Γ lA A t u v} {ΠA : [Γ ||-Π<lA> A]}
 Proof.
   intros [tL] [? tR];
   unshelve epose proof (e := redtmwf_det _ _ (PiRedTm.red redR) (PiRedTm.red redL)); tea.
-  1,2: apply isFun_whnf; apply PiRedTm.isfun.
+  1,2: apply isFun_whnf; eapply isWfFun_isFun, PiRedTm.isfun.
   exists tL tR.
   + etransitivity; tea. now rewrite e.
   + intros. eapply ihcod.

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -32,16 +32,18 @@ Section Weakenings.
     [Δ ||-Π< l > A⟨ρ⟩].
   Proof.
     destruct ΠA; econstructor.
-    3: now eapply wkPoly.
-    1,2: rewrite wk_prod; now eapply redtywf_wk + now eapply convty_wk.
+    4: now eapply wkPoly.
+    1,3: rewrite wk_prod; now eapply redtywf_wk + now eapply convty_wk.
+    now apply convty_wk.
   Defined.
 
   Lemma wkΣ  {Γ Δ A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΣA : [Γ ||-Σ< l > A]) :
     [Δ ||-Σ< l > A⟨ρ⟩].
   Proof.
     destruct ΣA; econstructor.
-    3: now eapply wkPoly.
-    1,2: rewrite wk_sig; now eapply redtywf_wk + now eapply convty_wk.
+    4: now eapply wkPoly.
+    1,3: rewrite wk_sig; now eapply redtywf_wk + now eapply convty_wk.
+    now apply convty_wk.
   Defined.
 
   Lemma wkNat {Γ A Δ} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) : [Γ ||-Nat A] -> [Δ ||-Nat A⟨ρ⟩].
@@ -147,8 +149,9 @@ Section Weakenings.
       1: gen_typing.
       cbn ; change U with U⟨ρ⟩; eapply convneu_wk; assumption.
     - intros * ?? * []; rewrite wkΠ_eq ; eexists.
-      3: now eapply wkPolyEq.
+      4: now eapply wkPolyEq.
       + rewrite wk_prod;  gen_typing.
+      + now eapply convty_wk.
       + rewrite wk_prod.
         replace (tProd _ _) with (ΠA.(outTy)⟨ρ⟩) by (cbn; now bsimpl).
         now eapply convty_wk.
@@ -157,8 +160,9 @@ Section Weakenings.
     - intros * []; constructor.
       change tEmpty with tEmpty⟨ρ⟩; gen_typing.
     - intros * ?? * []; rewrite wkΣ_eq ; eexists.
-      3: now eapply wkPolyEq.
+      4: now eapply wkPolyEq.
       + rewrite wk_sig;  gen_typing.
+      + now eapply convty_wk.
       + rewrite wk_sig.
         replace (tSig _ _) with (ΠA.(outTy)⟨ρ⟩) by (cbn; now bsimpl).
         now eapply convty_wk.
@@ -170,6 +174,15 @@ Section Weakenings.
       Unshelve. all: tea.
   Qed.
 
+  Lemma isWfFun_ren : forall Γ Δ A B t (ρ : Δ ≤ Γ),
+    [|- Δ] ->
+    isWfFun Γ A B t -> isWfFun Δ A⟨ρ⟩ B⟨upRen_term_term ρ⟩ t⟨ρ⟩.
+  Proof.
+  intros * ? []; constructor; tea.
+  + now apply convty_wk.
+  + now eapply whne_ren.
+  Qed.
+
   (* TODO: use program or equivalent to have only the first field non-opaque *)
   Lemma wkΠTerm {Γ Δ u A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Π< l > A]) 
     (ΠA' := wkΠ ρ wfΔ ΠA) : 
@@ -179,7 +192,7 @@ Section Weakenings.
     intros [t].
     exists (t⟨ρ⟩); try change (tProd _ _) with (ΠA.(outTy)⟨ρ⟩).
     + now eapply redtmwf_wk.
-    + apply isFun_ren; assumption.
+    + now apply isWfFun_ren.
     + now apply convtm_wk.
     + intros ? a ρ' ??.
       replace ((t ⟨ρ⟩)⟨ ρ' ⟩) with (t⟨ρ' ∘w ρ⟩) by now bsimpl.

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -212,6 +212,15 @@ Section Weakenings.
     intros []; constructor. all: gen_typing.
   Qed.  
   
+  Lemma isWfPair_ren : forall Γ Δ A B t (ρ : Δ ≤ Γ),
+    [|- Δ] ->
+    isWfPair Γ A B t -> isWfPair Δ A⟨ρ⟩ B⟨upRen_term_term ρ⟩ t⟨ρ⟩.
+  Proof.
+  intros * ? []; constructor; tea.
+  + now apply convty_wk.
+  + now eapply whne_ren.
+  Qed.
+
   Lemma wkΣTerm {Γ Δ u A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Σ< l > A]) 
     (ΠA' := wkΣ ρ wfΔ ΠA) : 
     [Γ||-Σ u : A | ΠA] -> 
@@ -223,7 +232,7 @@ Section Weakenings.
       2: now unshelve eapply fstRed.
       cbn; symmetry; apply wk_comp_ren_on.
     + now eapply redtmwf_wk.
-    + apply isPair_ren; assumption.
+    + apply isWfPair_ren; assumption.
     + eapply convtm_wk; eassumption.
     + intros ? ρ' ?;  irrelevance0.
       2: rewrite wk_comp_ren_on; now unshelve eapply sndRed.

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -96,7 +96,7 @@ all: try (intros; split; apply WN_whnf; now constructor).
 + intros * ? []; split; now apply WN_wk.
 + intros * ? ? ? []; split; now eapply WN_exp.
 + intros * []; split; now apply WN_whnf, whnf_whne.
-+ intros * ? ? ? ? ? ? []; split; now apply WN_isFun.
++ intros * ? ? ? ? ? ? []; split; now eapply WN_isFun, isWfFun_isFun.
 + intros; split; now apply WN_isPair.
 Qed.
 
@@ -249,7 +249,7 @@ Section NeutralConversion.
       1: eassumption.
       econstructor; eapply (convneu_whne eq).
     - intros ? ? ? ΠA IHdom IHcod m n mty Hconv ; cbn in *.
-      destruct ΠA  as [????? []]; cbn in *.
+      destruct ΠA  as [?????? []]; cbn in *.
       econstructor.
       1: gen_typing.
       1-2: reflexivity.

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -97,7 +97,7 @@ all: try (intros; split; apply WN_whnf; now constructor).
 + intros * ? ? ? []; split; now eapply WN_exp.
 + intros * []; split; now apply WN_whnf, whnf_whne.
 + intros * ? ? ? ? ? ? []; split; now eapply WN_isFun, isWfFun_isFun.
-+ intros; split; now apply WN_isPair.
++ intros; split; now eapply WN_isPair, isWfPair_isPair.
 Qed.
 
 #[export, refine] Instance ConvNeuDeclProperties : ConvNeuProperties (ta := nf) := {}.

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -79,9 +79,9 @@ Proof.
   assert [Δ |- (tLambda F t)[σ] : (tProd F G)[σ]] by (escape; cbn; gen_typing).
   exists (tLambda F t)[σ]; intros; cbn in *.
   + now eapply redtmwf_refl.
-  + constructor.
-  + eapply convtm_eta; tea. 
-    1,2: now constructor.
+  + constructor;  unshelve eapply escapeEq, reflLRTyEq; [|tea].
+  + eapply convtm_eta; tea.
+    1,2: constructor; unshelve eapply escapeEq, reflLRTyEq; [|tea].
     assert (eqσ : forall Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])
     by (intro; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
     assert [Δ,, F[σ] |-[ ta ] tApp (tLambda F[σ] t[up_term_term σ])⟨S⟩ (tRel 0) ⤳*  t[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0)..] : G[up_term_term σ]].
@@ -140,8 +140,8 @@ Proof.
     eapply LRTyEqSym. eapply (validTyExt VΠFG); tea.
     Unshelve. 2: now eapply validTy.
   - refold; cbn; escape.
-    eapply convtm_eta; tea. 
-    2,4: now constructor.
+    eapply convtm_eta; tea.
+    2,4: constructor; first [assumption|now eapply lrefl].
     + gen_typing.
     + eapply ty_conv; [gen_typing| now symmetry].
     + assert (eqσ : forall σ Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])
@@ -244,8 +244,9 @@ Proof.
     instValid Vσ; instValid VσUp; escape.
     destruct (PiRedTm.red p); destruct (PiRedTm.red p0); cbn in *.
     eapply convtm_eta; tea.
-    1,2: eapply PiRedTm.isfun.
-    etransitivity ; [symmetry| etransitivity]; tea; eapply ηeqEqTermConvNf.
+    + apply (PiRedTm.isfun p0).
+    + apply (PiRedTm.isfun p).
+    + etransitivity ; [symmetry| etransitivity]; tea; eapply ηeqEqTermConvNf.
   - match goal with H : [_ ||-Π f[σ] : _ | _] |- _ => rename H into Rfσ end.
     match goal with H : [_ ||-Π g[σ] : _ | _] |- _ => rename H into Rgσ end.
     cbn; intros ?? ρ' h ha.

--- a/theories/Substitution/Introductions/Pi.v
+++ b/theories/Substitution/Introductions/Pi.v
@@ -25,6 +25,7 @@ Section PolyRedPi.
   Proof.
     econstructor; tea; pose proof (polyRedId PAB) as []; escape.
     + eapply redtywf_refl; gen_typing.
+    + unshelve eapply escapeEq; tea; eapply reflLRTyEq.
     + eapply convty_prod; tea; unshelve eapply escapeEq; tea; eapply reflLRTyEq.
   Defined.
 
@@ -36,6 +37,7 @@ Section PolyRedPi.
   Proof.
     econstructor; cbn; tea.
     + eapply redtywf_refl; gen_typing.
+    + pose proof (polyRedEqId PAB Peq) as []; now escape.
     + pose proof (polyRedEqId PAB Peq) as []; escape.
       eapply convty_prod; tea.
       eapply escape; now apply (polyRedId PAB).
@@ -75,6 +77,7 @@ Section PiTyValidity.
     destruct (polyRedId p);
     destruct (polyRedEqId p (substPolyRedEq vΓ vF vG _ vσ vσ (reflSubst _ _ vσ))); escape.
     - apply redtywf_refl; gen_typing.
+    - gen_typing.
     - gen_typing.
   Defined.
 

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -510,12 +510,12 @@ Section PairRed.
       2: unshelve eapply pairFstRed; tea.
     + eapply redtmwf_refl; cbn.
       eapply ty_pair; tea.
-    + constructor.
+    + constructor; apply PiRedTyPack.eqdom.
     + eapply convtm_eta_sig; tea.
       * now eapply ty_pair.
-      * constructor.
+      * constructor; unshelve eapply escapeEq, reflLRTyEq; [|tea].
       * now eapply ty_pair.
-      * constructor.
+      * constructor; unshelve eapply escapeEq, reflLRTyEq; [|tea].
       * enough [Γ |- tFst (tPair A B a b) ≅ a : A].
         1: transitivity a; tea; now symmetry.
         eapply convtm_exp.
@@ -558,9 +558,9 @@ Section PairRed.
     exists Rp Rp'.
     - destruct (polyRedId (normRedΣ0 RΣ0)) as [_ RB].
       assert ([Γ ||-<l> SigRedTm.nf Rp : _ | RΣ] × [Γ ||-<l> p ≅ SigRedTm.nf Rp : _ | RΣ]) as [Rnf Rpnf].
-      1: eapply (redTmFwdConv Rp (SigRedTm.red Rp) (isPair_whnf _ (SigRedTm.isfun Rp))).
+      1: eapply (redTmFwdConv Rp (SigRedTm.red Rp)), isPair_whnf, isWfPair_isPair, SigRedTm.isfun.
       assert ([Γ ||-<l> SigRedTm.nf Rp' : _ | RΣ]× [Γ ||-<l> p' ≅ SigRedTm.nf Rp' : _ | RΣ]) as [Rnf' Rpnf'].
-      1: eapply (redTmFwdConv Rp' (SigRedTm.red Rp') (isPair_whnf _ (SigRedTm.isfun Rp'))).
+      1: eapply (redTmFwdConv Rp' (SigRedTm.red Rp')), isPair_whnf, isWfPair_isPair, SigRedTm.isfun.
       destruct (fstRed RΣ0 RA Rp) as [[Rfstp Rfsteq] Rfstnf].
       destruct (fstRed RΣ0 RA Rp') as [[Rfstp' Rfsteq'] Rfstnf'].
       destruct (sndRed RΣ0 RA Rp RBfst RBfstEq).

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -25,6 +25,7 @@ Section SigmaValidity.
     destruct (polyRedEqId p (substPolyRedEq VΓ VF VG _ Vσ Vσ (reflSubst _ _ Vσ))); escape.
     - apply redtywf_refl; gen_typing.
     - gen_typing.
+    - gen_typing.
   Defined.
 
   Lemma SigEqRed {Δ σ σ'} (tΔ : [ |-[ ta ] Δ])

--- a/theories/Substitution/SingleSubst.v
+++ b/theories/Substitution/SingleSubst.v
@@ -290,7 +290,7 @@ Proof.
   eapply singleSubstPoly2; tea.
   pose (hΠ := normRedΠ0 (invLRΠ ΠFG)).
   assert (heq : [Γ ||-<l> tProd F G ≅ tProd F' G' | LRPi' hΠ]) by irrelevance.
-  destruct heq as [?? red' ? polyRed]; cbn in *.
+  destruct heq as [?? red' ?? polyRed]; cbn in *.
   assert (h' :=redtywf_whnf red' whnf_tProd).
   symmetry in h'; injection h'; clear h'; intros ;  subst.
   exact polyRed.


### PR DESCRIPTION
We additionally require that the domain of lambdas (resp. pairs) are convertible to the domain of the Π (resp. Σ) type at which we compare them.

This invariant is preserved by the logical relation but there is no way to extract it early since it basically requires injectivity of Π and Σ types.