### PR TITLE
Strengthen expansion hypotheses in generic typing API 

### DIFF
--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -1137,18 +1137,16 @@ Qed.
     - intros_bn.
       1-3: now apply typing_wk.
       now apply algo_conv_wk.
-    - intros *; intros HRA HRt HRu _ _ _ _; revert HRA HRt HRu. intros_bn.
-      all: eapply algo_typing_sound in bun_red_ty_ty, bun_inf_conv_inf0, bun_inf_conv_inf ; tea.
-      + eapply subject_reduction_type, RedConvTyC in bun_red_ty ; tea.
-        symmetry in bun_red_ty.
-        now gen_typing.
-      + eapply subject_reduction_type, RedConvTyC in bun_red_ty ; tea.
-        symmetry in bun_red_ty.
-        now gen_typing.
+    - intros *; intros HRt HRu _ _ _ _; revert HRt HRu. intros_bn.
+      all: eapply algo_typing_sound in bun_inf_conv_inf0, bun_inf_conv_inf ; tea.
+      + gen_typing.
+      + gen_typing.
       + inversion bun_conv_tm ; subst ; clear bun_conv_tm.
         econstructor.
-        1-3: now etransitivity.
-        eassumption.
+        * eassumption.
+        * now etransitivity.
+        * now etransitivity.
+        * eassumption.
     - intros Γ n n' A [? ? ? ? ? A' Hconvn HconvA].
       assert [Γ |-[de] A] by boundary.
       assert [Γ |-[de] n : A'] by
@@ -1535,14 +1533,8 @@ Module IntermediateTypingProperties.
     - intros.
       apply (convtm_wk (ta := bn)) ; tea.
       now econstructor.
-    - intros * [] [] [] _ _ _ _ [].
+    - intros * [] [] _ _ _ _ [].
       econstructor ; tea.
-      + eapply subject_reduction_type, RedConvTyC in buni_red_ty ; tea.
-        symmetry in buni_red_ty.
-        now gen_typing.
-      + eapply subject_reduction_type, RedConvTyC in buni_red_ty ; tea.
-          symmetry in buni_red_ty.
-          now gen_typing.
       + inversion bun_conv_tm ; subst ; clear bun_conv_tm ; refold.
         econstructor.
         4: eassumption.

--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -1137,7 +1137,7 @@ Qed.
     - intros_bn.
       1-3: now apply typing_wk.
       now apply algo_conv_wk.
-    - intros_bn.
+    - intros *; intros HRA HRt HRu _ _; revert HRA HRt HRu. intros_bn.
       all: eapply algo_typing_sound in bun_red_ty_ty, bun_inf_conv_inf0, bun_inf_conv_inf ; tea.
       + eapply subject_reduction_type, RedConvTyC in bun_red_ty ; tea.
         symmetry in bun_red_ty.
@@ -1535,7 +1535,7 @@ Module IntermediateTypingProperties.
     - intros.
       apply (convtm_wk (ta := bn)) ; tea.
       now econstructor.
-    - intros * [] [] [] [].
+    - intros * [] [] [] _ _ [].
       econstructor ; tea.
       + eapply subject_reduction_type, RedConvTyC in buni_red_ty ; tea.
         symmetry in buni_red_ty.

--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -1137,7 +1137,7 @@ Qed.
     - intros_bn.
       1-3: now apply typing_wk.
       now apply algo_conv_wk.
-    - intros *; intros HRA HRt HRu _ _; revert HRA HRt HRu. intros_bn.
+    - intros *; intros HRA HRt HRu _ _ _ _; revert HRA HRt HRu. intros_bn.
       all: eapply algo_typing_sound in bun_red_ty_ty, bun_inf_conv_inf0, bun_inf_conv_inf ; tea.
       + eapply subject_reduction_type, RedConvTyC in bun_red_ty ; tea.
         symmetry in bun_red_ty.
@@ -1535,7 +1535,7 @@ Module IntermediateTypingProperties.
     - intros.
       apply (convtm_wk (ta := bn)) ; tea.
       now econstructor.
-    - intros * [] [] [] _ _ [].
+    - intros * [] [] [] _ _ _ _ [].
       econstructor ; tea.
       + eapply subject_reduction_type, RedConvTyC in buni_red_ty ; tea.
         symmetry in buni_red_ty.

--- a/theories/DeclarativeInstance.v
+++ b/theories/DeclarativeInstance.v
@@ -518,8 +518,7 @@ Module DeclarativeTypingProperties.
   - intros.
     now eapply typing_wk.
   - intros.
-    econstructor.
-    2: now eapply TypeSym, RedConvTyC.
+    econstructor; [|tea].
     eapply TermTrans ; [eapply TermTrans |..].
     2: eassumption.
     2: eapply TermSym.

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -341,8 +341,8 @@ Section GenericTyping.
       [|- Δ ] -> [Γ |- t ≅ u : A] -> [Δ |- t⟨ρ⟩ ≅ u⟨ρ⟩ : A⟨ρ⟩] ;
     convtm_exp {Γ A A' t t' u u'} :
       [Γ |- A ⤳* A'] -> [Γ |- t ⤳* t' : A'] -> [Γ |- u ⤳* u' : A'] ->
-      [Γ |- t' : A'] -> [Γ |- u' : A'] ->
-      [Γ |- t' ≅ u' : A'] -> [Γ |- t ≅ u : A] ;
+      [Γ |- A'] -> [Γ |- t' : A'] -> [Γ |- u' : A'] ->
+      [Γ |- A ≅ A'] -> [Γ |- t' ≅ u' : A'] -> [Γ |- t ≅ u : A] ;
     convtm_convneu {Γ n n' A} :
       [Γ |- n ~ n' : A] -> [Γ |- n ≅ n' : A] ;
     convtm_prod {Γ A A' B B'} :
@@ -991,8 +991,10 @@ Section GenericConsequences.
       1: now eapply lrefl.
       eapply ty_conv. 2: now symmetry.
       now eapply ty_var0.
+    - renToWk; tea; now eapply convty_wk.
     - now eapply ty_var0.
     - now eapply ty_var0.
+    - renToWk; tea; now eapply convty_wk.
     - eapply convtm_convneu. eapply convneu_var.
       now eapply ty_var0.
   Qed.
@@ -1054,6 +1056,7 @@ Section GenericConsequences.
     [Γ |- A] ->
     [Γ |- B] ->
     [Γ |- C] ->
+    [Γ |- C ≅ C] ->
     [Γ |- f : arr A B] ->
     [Γ |- f' : arr A B] ->
     [Γ |- g : arr B C] ->
@@ -1077,6 +1080,7 @@ Section GenericConsequences.
       4: erewrite <- arr_ren1; renToWk; eapply ty_wk; tea; gen_typing.
       1-3: now eapply wft_wk1.
       now eapply ty_var0.
+    - now eapply wft_wk1.
     - eapply @ty_simple_app with (A := B⟨↑⟩).
       + now eapply wft_wk1.
       + now eapply wft_wk1.
@@ -1089,6 +1093,7 @@ Section GenericConsequences.
       + erewrite <- arr_ren1; renToWk; eapply ty_wk; tea; gen_typing.
       + eapply @ty_simple_app with (A := A⟨↑⟩); [now eapply wft_wk1|now eapply wft_wk1| |now apply ty_var0].
         erewrite <- arr_ren1; renToWk; eapply ty_wk; tea; gen_typing.
+    - renToWk; apply convty_wk; gen_typing.
     - assumption.
   Qed.
 
@@ -1099,6 +1104,7 @@ Section GenericConsequences.
     [Γ |- A ≅ A] ->
     [Γ |- B] ->
     [Γ |- C] ->
+    [Γ |- C ≅ C] ->
     [Γ |- f : arr A B] ->
     [Γ |- f' : arr A B] ->
     [Γ |- g : arr B C] ->
@@ -1154,6 +1160,7 @@ Section GenericConsequences.
       now eapply convty_prod.
     - now constructor.
     - eapply @convtm_exp with (t' := t) (u' := t'); tea.
+      4: now eapply lrefl.
       1: now eapply redty_refl.
       2: eapply redtm_conv ; cbn ; [eapply redtm_meta_conv |..] ; [eapply redtm_beta |..].
       1: eapply redtm_meta_conv ; cbn ; [eapply redtm_beta |..].

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -339,10 +339,10 @@ Section GenericTyping.
     convtm_conv {Γ t u A A'} : [Γ |- t ≅ u : A] -> [Γ |- A ≅ A'] -> [Γ |- t ≅ u : A'] ;
     convtm_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
       [|- Δ ] -> [Γ |- t ≅ u : A] -> [Δ |- t⟨ρ⟩ ≅ u⟨ρ⟩ : A⟨ρ⟩] ;
-    convtm_exp {Γ A A' t t' u u'} :
-      [Γ |- A ⤳* A'] -> [Γ |- t ⤳* t' : A'] -> [Γ |- u ⤳* u' : A'] ->
-      [Γ |- A'] -> [Γ |- t' : A'] -> [Γ |- u' : A'] ->
-      [Γ |- A ≅ A'] -> [Γ |- t' ≅ u' : A'] -> [Γ |- t ≅ u : A] ;
+    convtm_exp {Γ A t t' u u'} :
+      [Γ |- t ⤳* t' : A] -> [Γ |- u ⤳* u' : A] ->
+      [Γ |- A] -> [Γ |- t' : A] -> [Γ |- u' : A] ->
+      [Γ |- A ≅ A] -> [Γ |- t' ≅ u' : A] -> [Γ |- t ≅ u : A] ;
     convtm_convneu {Γ n n' A} :
       [Γ |- n ~ n' : A] -> [Γ |- n ≅ n' : A] ;
     convtm_prod {Γ A A' B B'} :
@@ -978,7 +978,6 @@ Section GenericConsequences.
     assert [|- Γ,, A] by gen_typing.
     assert [Γ,, A |-[ ta ] A⟨@wk1 Γ A⟩] by now eapply wft_wk. 
     eapply convtm_exp.
-    - eapply redty_refl; now renToWk.
     - cbn. eapply redtm_id_beta.
       3: now eapply ty_var0.
       1,2: renToWk; tea; now eapply convty_wk.
@@ -1066,7 +1065,6 @@ Section GenericConsequences.
   Proof.
     intros.
     eapply convtm_exp.
-    - eapply redty_refl;  now eapply wft_wk1.
     - cbn.
       do 2 rewrite <- shift_upRen.
       eapply redtm_comp_beta.
@@ -1160,8 +1158,7 @@ Section GenericConsequences.
       now eapply convty_prod.
     - now constructor.
     - eapply @convtm_exp with (t' := t) (u' := t'); tea.
-      4: now eapply lrefl.
-      1: now eapply redty_refl.
+      3: now eapply lrefl.
       2: eapply redtm_conv ; cbn ; [eapply redtm_meta_conv |..] ; [eapply redtm_beta |..].
       1: eapply redtm_meta_conv ; cbn ; [eapply redtm_beta |..].
       + renToWk.

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -341,6 +341,7 @@ Section GenericTyping.
       [|- Δ ] -> [Γ |- t ≅ u : A] -> [Δ |- t⟨ρ⟩ ≅ u⟨ρ⟩ : A⟨ρ⟩] ;
     convtm_exp {Γ A A' t t' u u'} :
       [Γ |- A ⤳* A'] -> [Γ |- t ⤳* t' : A'] -> [Γ |- u ⤳* u' : A'] ->
+      [Γ |- t' : A'] -> [Γ |- u' : A'] ->
       [Γ |- t' ≅ u' : A'] -> [Γ |- t ≅ u : A] ;
     convtm_convneu {Γ n n' A} :
       [Γ |- n ~ n' : A] -> [Γ |- n ≅ n' : A] ;
@@ -990,6 +991,8 @@ Section GenericConsequences.
       1: now eapply lrefl.
       eapply ty_conv. 2: now symmetry.
       now eapply ty_var0.
+    - now eapply ty_var0.
+    - now eapply ty_var0.
     - eapply convtm_convneu. eapply convneu_var.
       now eapply ty_var0.
   Qed.
@@ -1074,6 +1077,18 @@ Section GenericConsequences.
       4: erewrite <- arr_ren1; renToWk; eapply ty_wk; tea; gen_typing.
       1-3: now eapply wft_wk1.
       now eapply ty_var0.
+    - eapply @ty_simple_app with (A := B⟨↑⟩).
+      + now eapply wft_wk1.
+      + now eapply wft_wk1.
+      + erewrite <- arr_ren1; renToWk; eapply ty_wk; tea; gen_typing.
+      + eapply @ty_simple_app with (A := A⟨↑⟩); [now eapply wft_wk1|now eapply wft_wk1| |now apply ty_var0].
+        erewrite <- arr_ren1; renToWk; eapply ty_wk; tea; gen_typing.
+    - eapply @ty_simple_app with (A := B⟨↑⟩).
+      + now eapply wft_wk1.
+      + now eapply wft_wk1.
+      + erewrite <- arr_ren1; renToWk; eapply ty_wk; tea; gen_typing.
+      + eapply @ty_simple_app with (A := A⟨↑⟩); [now eapply wft_wk1|now eapply wft_wk1| |now apply ty_var0].
+        erewrite <- arr_ren1; renToWk; eapply ty_wk; tea; gen_typing.
     - assumption.
   Qed.
 
@@ -1121,6 +1136,7 @@ Section GenericConsequences.
     [Γ |- A'] ->
     [Γ,, A |- B] ->
     [Γ,, A |- t : B] ->
+    [Γ,, A |- t' : B] ->
     [Γ,, A' |- t' : B'] ->
     [Γ |- A ≅ A'] ->
     [Γ,, A |- B ≅ B'] ->
@@ -1137,7 +1153,7 @@ Section GenericConsequences.
       symmetry.
       now eapply convty_prod.
     - now constructor.
-    - eapply convtm_exp ; tea.
+    - eapply @convtm_exp with (t' := t) (u' := t'); tea.
       1: now eapply redty_refl.
       2: eapply redtm_conv ; cbn ; [eapply redtm_meta_conv |..] ; [eapply redtm_beta |..].
       1: eapply redtm_meta_conv ; cbn ; [eapply redtm_beta |..].

--- a/theories/LogicalRelation/Escape.v
+++ b/theories/LogicalRelation/Escape.v
@@ -74,22 +74,29 @@ Section Escapes.
   Proof.
     pattern l, Γ, A, lr ; eapply LR_rect_TyUr.
     - intros ??? [] [[] []] ; cbn in *.
+      eapply (convtm_conv (A := U)).
       eapply convtm_exp ; tea.
       all: gen_typing.
-    - intros ??? [] [] ; cbn in *.
+    - intros ??? [ty] [] ; cbn in *.
+      eapply (convtm_conv (A := ty)).
       eapply convtm_exp ; tea.
       all: gen_typing.
-    - intros ??? [] * ?? [[termL] [termR]] ; cbn in *.
+    - intros ??? [dom cod] * ?? [[termL] [termR]] ; cbn in *.
+      eapply (convtm_conv (A := tProd dom cod)).
       eapply convtm_exp ; tea.
       all: gen_typing.
     - intros ??? [] []; cbn in *.
+      eapply (convtm_conv (A := tNat)); [|gen_typing].
       eapply convtm_exp; tea; gen_typing.
     - intros ??? [] []; cbn in *.
+      eapply (convtm_conv (A := tEmpty)); [|gen_typing].
       eapply convtm_exp; tea; gen_typing.
-    - intros ??? [] * ?? [[termL] [termR]] ; cbn in *.
+    - intros ??? [dom cod] * ?? [[termL] [termR]] ; cbn in *.
+      eapply (convtm_conv (A := tSig dom cod)).
       eapply convtm_exp ; tea.
       all: gen_typing.
-    - intros ??? [] _ _ []; unfold_id_outTy; cbn in *.
+    - intros ??? [ty lhs rhs] _ _ []; unfold_id_outTy; cbn in *.
+      eapply (convtm_conv (A := tId ty lhs rhs)); [|gen_typing].
       eapply convtm_exp; tea; gen_typing.
   Qed.
 

--- a/theories/LogicalRelation/SimpleArr.v
+++ b/theories/LogicalRelation/SimpleArr.v
@@ -279,7 +279,7 @@ Section SimpleArrow.
       eapply ty_comp; cycle 2; tea.
     - constructor; cbn.
       unshelve eapply escapeEq, reflLRTyEq; [|tea].
-    - cbn. eapply convtm_comp; cycle 4; tea.
+    - cbn. eapply convtm_comp; cycle 6; tea.
       erewrite <- wk1_ren_on.
       eapply escapeEqTerm.
       eapply reflLRTmEq.
@@ -287,6 +287,7 @@ Section SimpleArrow.
       eapply h.
       eapply var0; now bsimpl.
       { now eapply wfc_ty. }
+      unshelve eapply escapeEq, reflLRTyEq; tea.
       unshelve eapply escapeEq, reflLRTyEq; tea.
       Unshelve. 1: gen_typing.
       eapply wk; tea; gen_typing.

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -94,7 +94,7 @@ all: try (intros; split; apply WN_whnf; now constructor).
   - intros t u v [] []; now split.
 + intros * [] ?; now split.
 + intros * ? []; split; now apply WN_wk.
-+ intros * ? ? ? []; split; now eapply WN_exp.
++ intros * ? ? ? ? ? []; split; now eapply WN_exp.
 + intros * []; split; now apply WN_whnf, whnf_whne.
 + intros * ? ? ? ? ? ? []; split; now eapply WN_isFun, isWfFun_isFun.
 + intros; split; now eapply WN_isPair, isWfPair_isPair.

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -94,7 +94,7 @@ all: try (intros; split; apply WN_whnf; now constructor).
   - intros t u v [] []; now split.
 + intros * [] ?; now split.
 + intros * ? []; split; now apply WN_wk.
-+ intros * ? ? ? ? ? []; split; now eapply WN_exp.
++ intros * ? ? ? ? ? ? ? []; split; now eapply WN_exp.
 + intros * []; split; now apply WN_whnf, whnf_whne.
 + intros * ? ? ? ? ? ? []; split; now eapply WN_isFun, isWfFun_isFun.
 + intros; split; now eapply WN_isPair, isWfPair_isPair.

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -94,7 +94,7 @@ all: try (intros; split; apply WN_whnf; now constructor).
   - intros t u v [] []; now split.
 + intros * [] ?; now split.
 + intros * ? []; split; now apply WN_wk.
-+ intros * ? ? ? ? ? ? ? []; split; now eapply WN_exp.
++ intros * ? ? ? ? ? ? []; split; now eapply WN_exp.
 + intros * []; split; now apply WN_whnf, whnf_whne.
 + intros * ? ? ? ? ? ? []; split; now eapply WN_isFun, isWfFun_isFun.
 + intros; split; now eapply WN_isPair, isWfPair_isPair.

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -93,8 +93,10 @@ Proof.
       * fold ren_term; refine (ty_var _ (in_here _ _)); gen_typing.
     }
     eapply convtm_exp; tea.
-    1: now eapply redty_refl.
-    rewrite <- (eqσ t); eapply escapeEqTerm; now eapply reflLRTmEq.
+    - now eapply redty_refl.
+    - rewrite <- eqσ; tea.
+    - rewrite <- eqσ; tea.
+    - rewrite <- (eqσ t); eapply escapeEqTerm; now eapply reflLRTmEq.
   + eapply lamBetaRed; tea. 
   + pose proof (Vσa := consWkSubstS VF ρ h Vσ ha).
     pose proof (Vσb := consWkSubstS VF ρ h Vσ hb).
@@ -161,6 +163,9 @@ Proof.
         -- fold ren_term. eapply ty_conv.
            refine (ty_var _ (in_here _ _)). 1: gen_typing.
            cbn; renToWk; eapply convty_wk; tea; gen_typing.
+      * fold ren_term; rewrite <- eqσ; tea.
+      * fold ren_term; rewrite <- eqσ.
+        eapply ty_conv; [tea|symmetry; tea].
       * fold ren_term. 
         set (x := ren_term _ _); change x with (t[up_term_term σ]⟨upRen_term_term S⟩); clear x.
         set (x := ren_term _ _); change x with (t[up_term_term σ']⟨upRen_term_term S⟩); clear x.
@@ -210,7 +215,7 @@ Proof.
   by (intros; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
   eapply convtm_exp. 
   1: now eapply redty_refl.
-  3: rewrite eqσ; eapply escapeEqTerm; eapply reflLRTmEq; irrelevance.
+  5: rewrite eqσ; eapply escapeEqTerm; eapply reflLRTmEq; irrelevance.
   * eapply redtm_meta_conv. 3: reflexivity.
     1: eapply redtm_app.
     2: eapply (ty_var wfΔF (in_here _ _)).
@@ -224,6 +229,10 @@ Proof.
   * rewrite <- (wk1_ren_on Δ F[σ]); unshelve eapply redtmwf_refl.
     rewrite eqσ; eapply escapeTerm ; irrelevance.
     Unshelve. 2,4: rewrite <- eqσ; tea.
+  * rewrite eqσ; eapply escapeTerm ; irrelevance.
+    Unshelve. 2: rewrite <- eqσ; tea.
+  * rewrite eqσ; eapply escapeTerm ; irrelevance.
+    Unshelve. 2: rewrite <- eqσ; tea.
 Qed.
 
 

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -96,6 +96,7 @@ Proof.
     - now eapply redty_refl.
     - rewrite <- eqσ; tea.
     - rewrite <- eqσ; tea.
+    - unshelve eapply escapeEq, reflLRTyEq; [|tea].
     - rewrite <- (eqσ t); eapply escapeEqTerm; now eapply reflLRTmEq.
   + eapply lamBetaRed; tea. 
   + pose proof (Vσa := consWkSubstS VF ρ h Vσ ha).
@@ -163,9 +164,11 @@ Proof.
         -- fold ren_term. eapply ty_conv.
            refine (ty_var _ (in_here _ _)). 1: gen_typing.
            cbn; renToWk; eapply convty_wk; tea; gen_typing.
+      * tea.
       * fold ren_term; rewrite <- eqσ; tea.
       * fold ren_term; rewrite <- eqσ.
         eapply ty_conv; [tea|symmetry; tea].
+      * now eapply lrefl.
       * fold ren_term. 
         set (x := ren_term _ _); change x with (t[up_term_term σ]⟨upRen_term_term S⟩); clear x.
         set (x := ren_term _ _); change x with (t[up_term_term σ']⟨upRen_term_term S⟩); clear x.
@@ -215,7 +218,7 @@ Proof.
   by (intros; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
   eapply convtm_exp. 
   1: now eapply redty_refl.
-  5: rewrite eqσ; eapply escapeEqTerm; eapply reflLRTmEq; irrelevance.
+  7: rewrite eqσ; eapply escapeEqTerm; eapply reflLRTmEq; irrelevance.
   * eapply redtm_meta_conv. 3: reflexivity.
     1: eapply redtm_app.
     2: eapply (ty_var wfΔF (in_here _ _)).
@@ -229,10 +232,12 @@ Proof.
   * rewrite <- (wk1_ren_on Δ F[σ]); unshelve eapply redtmwf_refl.
     rewrite eqσ; eapply escapeTerm ; irrelevance.
     Unshelve. 2,4: rewrite <- eqσ; tea.
+  * tea.
   * rewrite eqσ; eapply escapeTerm ; irrelevance.
     Unshelve. 2: rewrite <- eqσ; tea.
   * rewrite eqσ; eapply escapeTerm ; irrelevance.
     Unshelve. 2: rewrite <- eqσ; tea.
+  * unshelve eapply escapeEq, reflLRTyEq; [|tea].
 Qed.
 
 

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -93,7 +93,6 @@ Proof.
       * fold ren_term; refine (ty_var _ (in_here _ _)); gen_typing.
     }
     eapply convtm_exp; tea.
-    - now eapply redty_refl.
     - rewrite <- eqσ; tea.
     - rewrite <- eqσ; tea.
     - unshelve eapply escapeEq, reflLRTyEq; [|tea].
@@ -150,7 +149,6 @@ Proof.
     + assert (eqσ : forall σ Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])
       by (intros; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
       eapply convtm_exp. 
-      * now eapply redty_refl.
       * rewrite (eqσ σ G). eapply redtm_beta.
         -- renToWk; eapply wft_wk; tea; gen_typing.
         -- renToWk; eapply ty_wk; tea.
@@ -217,7 +215,6 @@ Proof.
   assert (eqσ : forall σ Z, Z[up_term_term σ] = Z[up_term_term σ][(tRel 0) .: @wk1 Δ F[σ] >> tRel])
   by (intros; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
   eapply convtm_exp. 
-  1: now eapply redty_refl.
   7: rewrite eqσ; eapply escapeEqTerm; eapply reflLRTmEq; irrelevance.
   * eapply redtm_meta_conv. 3: reflexivity.
     1: eapply redtm_app.

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -519,7 +519,6 @@ Section PairRed.
       * enough [Γ |- tFst (tPair A B a b) ≅ a : A].
         1: transitivity a; tea; now symmetry.
         eapply convtm_exp.
-        - now eapply redtywf_refl.
         - now eapply redtm_fst_beta.
         - now eapply redtmwf_refl.
         - tea.
@@ -531,7 +530,6 @@ Section PairRed.
         1: transitivity b; tea; now symmetry.
         eapply convtm_conv; tea.
         eapply convtm_exp.
-        - now eapply redty_refl.
         - eapply redtm_conv; [| now symmetry]; now eapply redtm_snd_beta.
         - now eapply redtm_refl.
         - tea.

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -524,6 +524,8 @@ Section PairRed.
         - now eapply redtmwf_refl.
         - tea.
         - tea.
+        - tea.
+        - unshelve eapply escapeEq, reflLRTyEq; [|tea].
         - eapply escapeEqTerm; now eapply reflLRTmEq.
       * enough [Γ |- tSnd (tPair A B a b) ≅ b : B[(tFst (tPair A B a b))..]].
         1: transitivity b; tea; now symmetry.
@@ -534,6 +536,8 @@ Section PairRed.
         - now eapply redtm_refl.
         - tea.
         - tea.
+        - tea.
+        - unshelve eapply escapeEq, reflLRTyEq; [|tea].
         - eapply escapeEqTerm; now eapply reflLRTmEq.
     + intros ? ρ wfΔ.
       irrelevance0.

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -519,18 +519,22 @@ Section PairRed.
       * enough [Γ |- tFst (tPair A B a b) ≅ a : A].
         1: transitivity a; tea; now symmetry.
         eapply convtm_exp.
-        1: now eapply redtywf_refl.
-        1: now eapply redtm_fst_beta.
-        1: now eapply redtmwf_refl.
-        eapply escapeEqTerm; now eapply reflLRTmEq.
+        - now eapply redtywf_refl.
+        - now eapply redtm_fst_beta.
+        - now eapply redtmwf_refl.
+        - tea.
+        - tea.
+        - eapply escapeEqTerm; now eapply reflLRTmEq.
       * enough [Γ |- tSnd (tPair A B a b) ≅ b : B[(tFst (tPair A B a b))..]].
         1: transitivity b; tea; now symmetry.
         eapply convtm_conv; tea.
         eapply convtm_exp.
-        1: now eapply redty_refl.
-        1: eapply redtm_conv; [| now symmetry]; now eapply redtm_snd_beta.
-        1: now eapply redtm_refl.
-        eapply escapeEqTerm; now eapply reflLRTmEq.
+        - now eapply redty_refl.
+        - eapply redtm_conv; [| now symmetry]; now eapply redtm_snd_beta.
+        - now eapply redtm_refl.
+        - tea.
+        - tea.
+        - eapply escapeEqTerm; now eapply reflLRTmEq.
     + intros ? ρ wfΔ.
       irrelevance0.
       2: rewrite wk_snd; eapply wkTerm; now eapply pairSndRed.


### PR DESCRIPTION
We ask additional well-typedness and conversion invariants both for types and reducts ensured by the logical relation.

@MevenBertrand we could simplify the term conversion expansion API after this PR, since the reduction of types is now redundant and this part can be obtained directly by convtm_conv. I decided not to do it to make things clearer but if you want, I can perform the change.