### PR TITLE
Strengthen neutral congruence for Π / Σ types.

### DIFF
--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -1186,7 +1186,9 @@ Qed.
       + econstructor.
         1-3: reflexivity.
         econstructor.
-        1-2: now eapply isFun_whnf, (isWfFun_isFun (ta := bn)).
+        1-2: eapply isFun_whnf;
+          match goal with H : isWfFun _ _ _ ?f |- isFun ?f => destruct H end; constructor;
+          match goal with H : [_ |-[bn] ?f ~ ?f : _] |- whne ?f => apply H end.
         eassumption.
     - intros_bn.
       1-3: gen_typing.
@@ -1567,7 +1569,9 @@ Module IntermediateTypingProperties.
       + gen_typing.
       + boundary.
       + do 2 econstructor ; [| |gen_typing].
-        all: now eapply isFun_whnf, isWfFun_isFun.
+        all: eapply isFun_whnf;
+          match goal with H : isWfFun _ _ _ ?f |- isFun ?f => destruct H end; constructor;
+          match goal with H : [_ |-[bni] ?f ~ ?f : _] |- whne ?f => apply H end.
     - intros.
       eapply (convtm_nat (ta := bn)).
       now econstructor.

--- a/theories/AlgorithmicConvProperties.v
+++ b/theories/AlgorithmicConvProperties.v
@@ -1206,7 +1206,9 @@ Qed.
       + econstructor.
         1-3: reflexivity.
         econstructor; tea.
-        1-2: now eapply isPair_whnf, (isWfPair_isPair (ta := bn)).
+        1-2: eapply isPair_whnf;
+          match goal with H : isWfPair _ _ _ ?f |- isPair ?f => destruct H end; constructor;
+          match goal with H : [_ |-[bn] ?f ~ ?f : _] |- whne ?f => apply H end.
     - intros_bn.
       1-3: gen_typing.
       now do 2 econstructor.
@@ -1586,7 +1588,9 @@ Module IntermediateTypingProperties.
       + econstructor.
         1-3: reflexivity.
         econstructor; [| |gen_typing|gen_typing].
-        1-2: now eapply isPair_whnf, isWfPair_isPair.
+        all: eapply isPair_whnf;
+          match goal with H : isWfPair _ _ _ ?f |- isPair ?f => destruct H end; constructor;
+          match goal with H : [_ |-[bni] ?f ~ ?f : _] |- whne ?f => apply H end.
     - intros ? HΓ.
       eapply (convtm_empty (ta := bn)).
       now econstructor.

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -126,21 +126,11 @@ Section RedDefinitions.
 
   Inductive isWfFun (Γ : context) (A B : term) : term -> Set :=
     LamWfFun : forall A' t : term, [Γ |- A ≅ A'] -> isWfFun Γ A B (tLambda A' t)
-  | NeWfFun : forall f : term, whne f -> isWfFun Γ A B f.
+  | NeWfFun : forall f : term, [Γ |- f ~ f : tProd A B] -> isWfFun Γ A B f.
 
   Inductive isWfPair (Γ : context) (A B : term) : term -> Set :=
     PairWfPair : forall A' B' a b : term, [Γ |- A ≅ A'] -> isWfPair Γ A B (tPair A' B' a b)
   | NeWfPair : forall n : term, whne n -> isWfPair Γ A B n.
-
-  Lemma isWfFun_isFun : forall Γ A B t, isWfFun Γ A B t -> isFun t.
-  Proof.
-  intros * []; now constructor.
-  Qed.
-
-  Lemma isWfPair_isPair : forall Γ A B t, isWfPair Γ A B t -> isPair t.
-  Proof.
-  intros * []; now constructor.
-  Qed.
 
 End RedDefinitions.
 
@@ -1271,6 +1261,17 @@ Section GenericConsequences.
     intros [] [].
     eapply whred_det; tea.
     all: now eapply redty_sound.
+  Qed.
+
+
+  Lemma isWfFun_isFun : forall Γ A B t, isWfFun Γ A B t -> isFun t.
+  Proof.
+  intros * []; constructor; now eapply convneu_whne.
+  Qed.
+
+  Lemma isWfPair_isPair : forall Γ A B t, isWfPair Γ A B t -> isPair t.
+  Proof.
+  intros * []; now constructor.
   Qed.
 
 End GenericConsequences.

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -130,7 +130,7 @@ Section RedDefinitions.
 
   Inductive isWfPair (Γ : context) (A B : term) : term -> Set :=
     PairWfPair : forall A' B' a b : term, [Γ |- A ≅ A'] -> isWfPair Γ A B (tPair A' B' a b)
-  | NeWfPair : forall n : term, whne n -> isWfPair Γ A B n.
+  | NeWfPair : forall n : term, [Γ |- n ~ n : tSig A B] -> isWfPair Γ A B n.
 
 End RedDefinitions.
 
@@ -1271,7 +1271,7 @@ Section GenericConsequences.
 
   Lemma isWfPair_isPair : forall Γ A B t, isWfPair Γ A B t -> isPair t.
   Proof.
-  intros * []; now constructor.
+  intros * []; constructor; now eapply convneu_whne.
   Qed.
 
 End GenericConsequences.

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -470,7 +470,7 @@ Module SigRedTm.
 
   Record SigRedTm `{ta : tag} `{WfContext ta}
     `{WfType ta} `{ConvType ta} `{RedType ta}
-    `{Typing ta} `{ConvTerm ta} `{RedTerm ta}
+    `{Typing ta} `{ConvTerm ta} `{ConvNeuConv ta} `{RedTerm ta}
     {Γ : context} {A : term} {ΣA : SigRedTy Γ A} {t : term}
   : Type := {
     nf : term;
@@ -483,7 +483,7 @@ Module SigRedTm.
       [ΣA.(PolyRedPack.posRed) ρ h (fstRed ρ h) | Δ ||- tSnd nf⟨ρ⟩ : _] ;
   }.
 
-  Arguments SigRedTm {_ _ _ _ _ _ _ _ _ _}.
+  Arguments SigRedTm {_ _ _ _ _ _ _ _ _ _ _}.
 
 End SigRedTm.
 
@@ -494,7 +494,7 @@ Module SigRedTmEq.
 
   Record SigRedTmEq `{ta : tag} `{WfContext ta}
     `{WfType ta} `{ConvType ta} `{RedType ta}
-    `{Typing ta} `{ConvTerm ta} `{RedTerm ta}
+    `{Typing ta} `{ConvTerm ta} `{ConvNeuConv ta} `{RedTerm ta}
     {Γ : context} {A : term} {ΣA : SigRedTy Γ A} {t u : term}
   : Type := {
     redL : [ Γ ||-Σ t : A | ΣA ] ;
@@ -506,7 +506,7 @@ Module SigRedTmEq.
       [ΣA.(PolyRedPack.posRed) ρ h redfstL | Δ ||- tSnd redL.(SigRedTm.nf)⟨ρ⟩ ≅ tSnd redR.(SigRedTm.nf)⟨ρ⟩ : _] ;
   }.
 
-  Arguments SigRedTmEq {_ _ _ _ _ _ _ _ _ _}.
+  Arguments SigRedTmEq {_ _ _ _ _ _ _ _ _ _ _}.
 
 End SigRedTmEq.
 

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -404,7 +404,7 @@ Module PiRedTm.
 
   Record PiRedTm `{ta : tag} `{WfContext ta}
     `{WfType ta} `{ConvType ta} `{RedType ta}
-    `{Typing ta} `{ConvTerm ta} `{RedTerm ta}
+    `{Typing ta} `{ConvTerm ta} `{ConvNeuConv ta} `{RedTerm ta}
     {Γ : context} {t A : term} {ΠA : PiRedTy Γ A}
   : Type := {
     nf : term;
@@ -421,7 +421,7 @@ Module PiRedTm.
       : [ ΠA.(PolyRedPack.posRed) ρ h ha | Δ ||- tApp nf⟨ρ⟩ a ≅ tApp nf⟨ρ⟩ b : ΠA.(PiRedTy.cod)[a .: (ρ >> tRel)] ]
   }.
 
-  Arguments PiRedTm {_ _ _ _ _ _ _ _}.
+  Arguments PiRedTm {_ _ _ _ _ _ _ _ _}.
 
 End PiRedTm.
 
@@ -432,7 +432,7 @@ Module PiRedTmEq.
 
   Record PiRedTmEq `{ta : tag} `{WfContext ta}
     `{WfType ta} `{ConvType ta} `{RedType ta}
-    `{Typing ta} `{ConvTerm ta} `{RedTerm ta}
+    `{Typing ta} `{ConvTerm ta} `{ConvNeuConv ta} `{RedTerm ta}
     {Γ : context} {t u A : term} {ΠA : PiRedTy Γ A}
   : Type := {
     redL : [ Γ ||-Π t : A | ΠA ] ;
@@ -444,7 +444,7 @@ Module PiRedTmEq.
           tApp redL.(PiRedTm.nf)⟨ρ⟩ a ≅ tApp redR.(PiRedTm.nf)⟨ρ⟩ a : ΠA.(PiRedTy.cod)[a .: (ρ >> tRel)]]
   }.
 
-  Arguments PiRedTmEq {_ _ _ _ _ _ _ _}.
+  Arguments PiRedTmEq {_ _ _ _ _ _ _ _ _}.
 
 End PiRedTmEq.
 

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -182,7 +182,7 @@ Proof.
   - now eapply redtmwf_conv.
   - destruct isfun as [A₀ t₀|n Hn].
     + constructor; transitivity (PiRedTy.dom ΣA); [now symmetry|tea].
-    + now constructor.
+    + constructor; now eapply convneu_conv.
   - now eapply convtm_conv.
   - intros; unshelve eapply eqv.(eqvPos); now auto.
 Defined.

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -109,7 +109,7 @@ Proof.
   - now eapply redtmwf_conv.
   - destruct isfun as [A₀ t₀|n Hn].
     + constructor; transitivity (PiRedTy.dom ΠA); [now symmetry|tea].
-    + now constructor.
+    + constructor; now eapply convneu_conv.
   - eapply (convtm_conv refl).
     apply eqPi.
   - intros; unshelve eapply eqv.(eqvPos).

--- a/theories/LogicalRelation/Neutral.v
+++ b/theories/LogicalRelation/Neutral.v
@@ -196,7 +196,7 @@ Proof.
       }
       exists n hfst.
       + eapply redtmwf_refl; now eapply ty_conv.
-      + constructor; now eapply convneu_whne.
+      + constructor; now eapply convneu_conv.
       + eapply convtm_convneu; now eapply convneu_conv.
       + intros; irrelevanceRefl.
         eapply complete_reflect_simpl; [unshelve eapply ihcod|..]; tea.

--- a/theories/LogicalRelation/Neutral.v
+++ b/theories/LogicalRelation/Neutral.v
@@ -138,7 +138,7 @@ intros l Γ A ΠA0 ihdom ihcod; split.
   {
     intros. exists n; cbn.
     * eapply redtmwf_refl ; gen_typing.
-    * constructor; now eapply convneu_whne.
+    * constructor; now eapply convneu_conv.
     * eapply convtm_conv; [|eassumption].
       now apply convtm_convneu.
     * intros; apply complete_reflect_simpl; [apply ihcod| |..].

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -180,7 +180,8 @@ Section Weakenings.
   Proof.
   intros * ? []; constructor; tea.
   + now apply convty_wk.
-  + now eapply whne_ren.
+  + change [Δ |- f⟨ρ⟩ ~ f⟨ρ⟩ : (tProd A B)⟨ρ⟩].
+    now eapply convneu_wk.
   Qed.
 
   (* TODO: use program or equivalent to have only the first field non-opaque *)

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -219,7 +219,8 @@ Section Weakenings.
   Proof.
   intros * ? []; constructor; tea.
   + now apply convty_wk.
-  + now eapply whne_ren.
+  + change [Δ |- n⟨ρ⟩ ~ n⟨ρ⟩ : (tSig A B)⟨ρ⟩].
+    now eapply convneu_wk.
   Qed.
 
   Lemma wkΣTerm {Γ Δ u A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Σ< l > A]) 

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -96,7 +96,9 @@ all: try (intros; split; apply WN_whnf; now constructor).
 + intros * ? []; split; now apply WN_wk.
 + intros * ? ? ? ? ? ? []; split; now eapply WN_exp.
 + intros * []; split; now apply WN_whnf, whnf_whne.
-+ intros * ? ? ? ? ? ? []; split; now eapply WN_isFun, isWfFun_isFun.
++ intros * ? ? ? Hf ? Hg []; split.
+  - apply WN_isFun; destruct Hf as [|? []]; now constructor.
+  - apply WN_isFun; destruct Hg as [|? []]; now constructor.
 + intros; split; now eapply WN_isPair, isWfPair_isPair.
 Qed.
 

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -99,7 +99,9 @@ all: try (intros; split; apply WN_whnf; now constructor).
 + intros * ? ? ? Hf ? Hg []; split.
   - apply WN_isFun; destruct Hf as [|? []]; now constructor.
   - apply WN_isFun; destruct Hg as [|? []]; now constructor.
-+ intros; split; now eapply WN_isPair, isWfPair_isPair.
++ intros * ? ? ? Hp ? Hp' ?; split; apply WN_isPair.
+  - destruct Hp as [|? []]; now constructor.
+  - destruct Hp' as [|? []]; now constructor.
 Qed.
 
 #[export, refine] Instance ConvNeuDeclProperties : ConvNeuProperties (ta := nf) := {}.


### PR DESCRIPTION
We assume that the term is self-convertible as a neutral. This also implies being a whne once we have the generic typing properties, so we remove this field, although it makes some proofs slightly more annoying later on.

cc @MevenBertrand it might allow simplifying some of the stuff in the bidir dev?