### PR TITLE
Saturate negative conversion rules with inversions

### DIFF
--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -125,7 +125,8 @@ Section RedDefinitions.
   }.
 
   Inductive isWfFun (Γ : context) (A B : term) : term -> Set :=
-    LamWfFun : forall A' t : term, [Γ |- A ≅ A'] -> isWfFun Γ A B (tLambda A' t)
+    LamWfFun : forall A' t : term,
+      [Γ |- A'] -> [Γ |- A ≅ A'] -> [Γ,, A |- t : B] -> [Γ,, A' |- t : B] -> isWfFun Γ A B (tLambda A' t)
   | NeWfFun : forall f : term, [Γ |- f ~ f : tProd A B] -> isWfFun Γ A B f.
 
   Inductive isWfPair (Γ : context) (A B : term) : term -> Set :=
@@ -963,7 +964,11 @@ Section GenericConsequences.
     2: eapply convty_simple_arr; cycle 1; tea.
     eapply convtm_eta; tea.
     { renToWk; apply wft_wk; [apply wfc_cons|]; tea. }
-    2,4: constructor; first [now apply lrefl|tea].
+    2:{ constructor; first [now eapply lrefl|now apply ty_var0|tea]. }
+    3:{ constructor; first [now eapply lrefl|now apply ty_var0|tea].
+        eapply ty_conv; [now apply ty_var0|].
+        do 2 rewrite <- (@wk1_ren_on Γ A'); apply convty_wk; [|now symmetry].
+        now apply wfc_cons. }
     1,2: eapply ty_id; tea; now symmetry.
     assert [|- Γ,, A] by gen_typing.
     assert [Γ,, A |-[ ta ] A⟨@wk1 Γ A⟩] by now eapply wft_wk. 
@@ -1101,9 +1106,22 @@ Section GenericConsequences.
     [Γ |- comp A g f ≅ comp A g' f' : arr A C].
   Proof.
     intros.
+    assert (Hup : forall X Y h, [Γ |- h : arr X Y] -> [Γ,, A |- h⟨↑⟩ : arr X⟨↑⟩ Y⟨↑⟩]).
+    { intros; rewrite <- arr_ren1, <- !(wk1_ren_on Γ A).
+      apply (ty_wk (@wk1 Γ A)); [|now rewrite wk1_ren_on].
+      now apply wfc_cons. }
     eapply convtm_eta; tea.
     { renToWk; apply wft_wk; [apply wfc_cons|]; tea. }
-    2,4: now constructor.
+    2:{ assert [Γ,, A |-[ ta ] tApp g⟨↑⟩ (tApp f⟨↑⟩ (tRel 0)) : C⟨↑⟩].
+        { eapply (ty_simple_app (A := B⟨↑⟩)); first [now apply wft_wk1|now apply Hup|idtac].
+          eapply (ty_simple_app (A := A⟨↑⟩)); first [now apply wft_wk1|now apply Hup|idtac].
+          now apply ty_var0. }
+        constructor; tea. }
+    3:{ assert [Γ,, A |-[ ta ] tApp g'⟨↑⟩ (tApp f'⟨↑⟩ (tRel 0)) : C⟨↑⟩].
+        { eapply (ty_simple_app (A := B⟨↑⟩)); first [now apply wft_wk1|now apply Hup|idtac].
+          eapply (ty_simple_app (A := A⟨↑⟩)); first [now apply wft_wk1|now apply Hup|idtac].
+          now apply ty_var0. }
+        constructor; tea. }
     1,2: eapply ty_comp.
     4,5,9,10: tea.
     all: tea.
@@ -1134,6 +1152,7 @@ Section GenericConsequences.
     [Γ,, A' |- t' : B'] ->
     [Γ |- A ≅ A'] ->
     [Γ,, A |- B ≅ B'] ->
+    [Γ,, A' |- B ≅ B'] ->
     [Γ,, A |- t ≅ t' : B] ->
     [Γ |- tLambda A t ≅ tLambda A' t' : tProd A B].
   Proof.
@@ -1141,12 +1160,13 @@ Section GenericConsequences.
     assert [|- Γ,, A] by gen_typing.
     apply convtm_eta ; tea.
     - gen_typing.
-    - constructor; now eapply lrefl.
+    - constructor; first[now eapply lrefl|tea].
     - eapply ty_conv.
       1: eapply ty_lam ; tea.
       symmetry.
       now eapply convty_prod.
-    - now constructor.
+    - constructor; tea.
+      now eapply ty_conv.
     - eapply @convtm_exp with (t' := t) (u' := t'); tea.
       3: now eapply lrefl.
       2: eapply redtm_conv ; cbn ; [eapply redtm_meta_conv |..] ; [eapply redtm_beta |..].

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -130,7 +130,19 @@ Section RedDefinitions.
   | NeWfFun : forall f : term, [Γ |- f ~ f : tProd A B] -> isWfFun Γ A B f.
 
   Inductive isWfPair (Γ : context) (A B : term) : term -> Set :=
-    PairWfPair : forall A' B' a b : term, [Γ |- A ≅ A'] -> isWfPair Γ A B (tPair A' B' a b)
+    PairWfPair : forall A' B' a b : term,
+      [Γ |- A'] -> [Γ |- A ≅ A'] ->
+      [Γ,, A' |- B] ->
+      [Γ,, A' |- B'] ->
+      [Γ,, A |- B'] ->
+      [Γ,, A |- B ≅ B'] ->
+      [Γ,, A' |- B ≅ B'] ->
+      [Γ |- a : A] ->
+      [Γ |- B[a..]] ->
+      [Γ |- B'[a..]] ->
+      [Γ |- B[a..] ≅ B'[a..]] ->
+      [Γ |- b : B[a..]] ->
+      isWfPair Γ A B (tPair A' B' a b)
   | NeWfPair : forall n : term, [Γ |- n ~ n : tSig A B] -> isWfPair Γ A B n.
 
 End RedDefinitions.

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -478,6 +478,17 @@ Definition SigRedTyEq `{ta : tag}
   {Γ : context} {A : term} (ΠA : SigRedTy Γ A) (B : term) :=
   ParamRedTyEq (T:=tSig) Γ A B ΠA.
 
+Module SigRedTy := ParamRedTyPack.
+
+Inductive isLRPair `{ta : tag} `{WfContext ta}
+  `{WfType ta} `{ConvType ta} `{RedType ta} `{Typing ta} `{ConvTerm ta} `{ConvNeuConv ta}
+  {Γ : context} {A : term} (ΣA : SigRedTy Γ A) : term -> Type :=
+| PairLRpair : forall A' B' a b : term,
+  (forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) (domRed:= ΣA.(PolyRedPack.shpRed) ρ h),
+      [domRed | Δ ||- (SigRedTy.dom ΣA)⟨ρ⟩ ≅ A'⟨ρ⟩]) ->
+  isLRPair ΣA (tPair A' B' a b)
+| NeLRPair : forall p : term, [Γ |- p ~ p : tSig (SigRedTy.dom ΣA) (SigRedTy.cod ΣA)] -> isLRPair ΣA p.
+
 Module SigRedTm.
 
   Record SigRedTm `{ta : tag} `{WfContext ta}
@@ -487,7 +498,7 @@ Module SigRedTm.
   : Type := {
     nf : term;
     red : [ Γ |- t :⤳*: nf : ΣA.(outTy) ];
-    isfun : isWfPair Γ ΣA.(PiRedTy.dom) ΣA.(PiRedTy.cod) nf;
+    ispair : isLRPair ΣA nf;
     refl : [ Γ |- nf ≅ nf : ΣA.(outTy) ];
     fstRed {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
       [ΣA.(PolyRedPack.shpRed) ρ h | Δ ||- tFst nf⟨ρ⟩ : ΣA.(ParamRedTyPack.dom)⟨ρ⟩] ;

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -483,10 +483,19 @@ Module SigRedTy := ParamRedTyPack.
 Inductive isLRPair `{ta : tag} `{WfContext ta}
   `{WfType ta} `{ConvType ta} `{RedType ta} `{Typing ta} `{ConvTerm ta} `{ConvNeuConv ta}
   {Γ : context} {A : term} (ΣA : SigRedTy Γ A) : term -> Type :=
-| PairLRpair : forall A' B' a b : term,
-  (forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) (domRed:= ΣA.(PolyRedPack.shpRed) ρ h),
-      [domRed | Δ ||- (SigRedTy.dom ΣA)⟨ρ⟩ ≅ A'⟨ρ⟩]) ->
+| PairLRpair : forall (A' B' a b : term)
+  (rdom : forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]),
+      [ΣA.(PolyRedPack.shpRed) ρ h | Δ ||- (SigRedTy.dom ΣA)⟨ρ⟩ ≅ A'⟨ρ⟩])
+  (rcod : forall {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
+    (ha : [ ΣA.(PolyRedPack.shpRed) ρ h | Δ ||- a : ΣA.(PiRedTy.dom)⟨ρ⟩ ]),
+      [ΣA.(PolyRedPack.posRed) ρ h ha | Δ ||- (SigRedTy.cod ΣA)[a .: (ρ >> tRel)] ≅ B'[a .: (ρ >> tRel)]])
+  (rfst : forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]),
+      [ΣA.(PolyRedPack.shpRed) ρ h | Δ ||- a⟨ρ⟩ : (SigRedTy.dom ΣA)⟨ρ⟩])
+  (rsnd : forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]),
+      [ΣA.(PolyRedPack.posRed) ρ h (rfst ρ h) | Δ ||- b⟨ρ⟩ : (SigRedTy.cod ΣA)[a⟨ρ⟩ .: (ρ >> tRel)] ]),
+
   isLRPair ΣA (tPair A' B' a b)
+
 | NeLRPair : forall p : term, [Γ |- p ~ p : tSig (SigRedTy.dom ΣA) (SigRedTy.cod ΣA)] -> isLRPair ΣA p.
 
 Module SigRedTm.

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -406,6 +406,9 @@ Inductive isLRFun `{ta : tag} `{WfContext ta}
 | LamLRFun : forall A' t : term,
   (forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) (domRed:= ΠA.(PolyRedPack.shpRed) ρ h),
       [domRed | Δ ||- (PiRedTy.dom ΠA)⟨ρ⟩ ≅ A'⟨ρ⟩]) ->
+  (forall {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
+    (ha : [ ΠA.(PolyRedPack.shpRed) ρ h | Δ ||- a : ΠA.(PiRedTy.dom)⟨ρ⟩ ]),
+      [ΠA.(PolyRedPack.posRed) ρ h ha | Δ ||- t[a .: (ρ >> tRel)] : ΠA.(PiRedTy.cod)[a .: (ρ >> tRel)]]) ->
   isLRFun ΠA (tLambda A' t)
 | NeLRFun : forall f : term, [Γ |- f ~ f : tProd (PiRedTy.dom ΠA) (PiRedTy.cod ΠA)] -> isLRFun ΠA f.
 

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -400,6 +400,15 @@ Definition PiRedTyEq `{ta : tag}
 Module PiRedTyEq := ParamRedTyEq.
 Notation "[ Γ ||-Π A ≅ B | ΠA ]" := (PiRedTyEq (Γ:=Γ) (A:=A) ΠA B).
 
+Inductive isLRFun `{ta : tag} `{WfContext ta}
+  `{WfType ta} `{ConvType ta} `{RedType ta} `{Typing ta} `{ConvTerm ta} `{ConvNeuConv ta}
+  {Γ : context} {A : term} (ΠA : PiRedTy Γ A) : term -> Type :=
+| LamLRFun : forall A' t : term,
+  (forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) (domRed:= ΠA.(PolyRedPack.shpRed) ρ h),
+      [domRed | Δ ||- (PiRedTy.dom ΠA)⟨ρ⟩ ≅ A'⟨ρ⟩]) ->
+  isLRFun ΠA (tLambda A' t)
+| NeLRFun : forall f : term, [Γ |- f ~ f : tProd (PiRedTy.dom ΠA) (PiRedTy.cod ΠA)] -> isLRFun ΠA f.
+
 Module PiRedTm.
 
   Record PiRedTm `{ta : tag} `{WfContext ta}
@@ -409,7 +418,7 @@ Module PiRedTm.
   : Type := {
     nf : term;
     red : [ Γ |- t :⤳*: nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
-    isfun : isWfFun Γ ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) nf;
+    isfun : isLRFun ΠA nf;
     refl : [ Γ |- nf ≅ nf : tProd ΠA.(PiRedTy.dom) ΠA.(PiRedTy.cod) ];
     app {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
       (ha : [ ΠA.(PolyRedPack.shpRed) ρ h | Δ ||- a : ΠA.(PiRedTy.dom)⟨ρ⟩ ])

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -73,7 +73,6 @@ Proof.
   - eapply symLRPack; eapply eqv.(eqvPos).
 Qed.
 
-
 (** *** Lemmas for product types *)
 
 (** A difficulty is that we need to show the equivalence right away, rather than only an implication,
@@ -108,7 +107,8 @@ Proof.
   intros []; cbn in *; econstructor; tea.
   - now eapply redtmwf_conv.
   - destruct isfun as [A₀ t₀|n Hn].
-    + constructor; transitivity (PiRedTy.dom ΠA); [now symmetry|tea].
+    + constructor.
+      intros; now eapply eqv.(eqvShp).
     + constructor; now eapply convneu_conv.
   - eapply (convtm_conv refl).
     apply eqPi.

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -182,8 +182,9 @@ Proof.
   intros []; cbn in *; unshelve econstructor; tea.
   - intros; unshelve eapply eqv.(eqvShp); now auto.
   - now eapply redtmwf_conv.
-  - destruct isfun as [A₀ t₀|n Hn].
-    + constructor; transitivity (PiRedTy.dom ΣA); [now symmetry|tea].
+  - destruct ispair as [A₀ B₀ a b|n Hn].
+    + constructor.
+      * intros; now eapply eqv.(eqvShp).
     + constructor; now eapply convneu_conv.
   - now eapply convtm_conv.
   - intros; unshelve eapply eqv.(eqvPos); now auto.

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -183,8 +183,12 @@ Proof.
   - intros; unshelve eapply eqv.(eqvShp); now auto.
   - now eapply redtmwf_conv.
   - destruct ispair as [A₀ B₀ a b|n Hn].
-    + constructor.
+    + unshelve econstructor.
+      * intros; now unshelve eapply eqv.(eqvShp).
       * intros; now eapply eqv.(eqvShp).
+      * intros; unshelve eapply eqv.(eqvPos); [|now eauto].
+        now unshelve eapply eqv.(eqvShp).
+      * intros; now eapply eqv.(eqvPos).
     + constructor; now eapply convneu_conv.
   - now eapply convtm_conv.
   - intros; unshelve eapply eqv.(eqvPos); now auto.

--- a/theories/LogicalRelation/Irrelevance.v
+++ b/theories/LogicalRelation/Irrelevance.v
@@ -108,7 +108,9 @@ Proof.
   - now eapply redtmwf_conv.
   - destruct isfun as [A₀ t₀|n Hn].
     + constructor.
-      intros; now eapply eqv.(eqvShp).
+      * intros; now eapply eqv.(eqvShp).
+      * intros; unshelve eapply eqv.(eqvPos); [|eauto].
+        now apply eqv.(eqvShp).
     + constructor; now eapply convneu_conv.
   - eapply (convtm_conv refl).
     apply eqPi.

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -238,7 +238,7 @@ Proof.
     eapply redtmwf_refl; gen_typing.
   - intros ???????? [? red] red' ?.
     unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: now eapply isFun_whnf, isWfFun_isFun.
+    1: eapply isFun_whnf; destruct isfun; constructor; tea; now eapply convneu_whne.
     econstructor; tea.
     eapply redtmwf_refl; gen_typing.
   - intros ?????? Rt red' ?; inversion Rt; subst.

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -254,7 +254,7 @@ Proof.
     Unshelve. 2: tea.
   - intros ???????? [? red] red' ?.
     unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: now eapply isPair_whnf, isWfPair_isPair.
+    1: eapply isPair_whnf; destruct ispair; constructor; tea; now eapply convneu_whne.
     econstructor; tea.
     eapply redtmwf_refl; gen_typing.
   - intros ???????? [? red] red' ?.

--- a/theories/LogicalRelation/SimpleArr.v
+++ b/theories/LogicalRelation/SimpleArr.v
@@ -140,7 +140,8 @@ Section SimpleArrow.
     econstructor; cbn.
     - eapply redtmwf_refl.
       now eapply ty_id.
-    - now constructor.
+    - constructor.
+      intros; cbn; apply reflLRTyEq.
     - eapply convtm_id; tea.
       eapply wfc_wft; now escape.
     - intros; cbn; irrelevance0.
@@ -277,8 +278,8 @@ Section SimpleArrow.
     econstructor.
     - eapply redtmwf_refl.
       eapply ty_comp; cycle 2; tea.
-    - constructor; cbn.
-      unshelve eapply escapeEq, reflLRTyEq; [|tea].
+    - constructor; intros; cbn.
+      apply reflLRTyEq.
     - cbn. eapply convtm_comp; cycle 6; tea.
       erewrite <- wk1_ren_on.
       eapply escapeEqTerm.

--- a/theories/LogicalRelation/SimpleArr.v
+++ b/theories/LogicalRelation/SimpleArr.v
@@ -141,7 +141,10 @@ Section SimpleArrow.
     - eapply redtmwf_refl.
       now eapply ty_id.
     - constructor.
-      intros; cbn; apply reflLRTyEq.
+      + intros; cbn; apply reflLRTyEq.
+      + intros; cbn.
+        irrelevance0; [|apply ha].
+        cbn; bsimpl; now rewrite rinstInst'_term.
     - eapply convtm_id; tea.
       eapply wfc_wft; now escape.
     - intros; cbn; irrelevance0.
@@ -279,7 +282,11 @@ Section SimpleArrow.
     - eapply redtmwf_refl.
       eapply ty_comp; cycle 2; tea.
     - constructor; intros; cbn.
-      apply reflLRTyEq.
+      + apply reflLRTyEq.
+      + assert (Hrw : forall t, t⟨↑⟩[a .: ρ >> tRel] = t⟨ρ⟩).
+        { intros; bsimpl; symmetry; now apply rinstInst'_term. }
+        do 2 rewrite Hrw; irrelevance0; [symmetry; apply Hrw|].
+        unshelve eapply h; tea.
     - cbn. eapply convtm_comp; cycle 6; tea.
       erewrite <- wk1_ren_on.
       eapply escapeEqTerm.
@@ -303,6 +310,6 @@ Section SimpleArrow.
       + eapply LRTmEqSym.
         unshelve eapply beta; tea.
       + cbn; bsimpl; now rewrite rinstInst'_term.
-  Qed. 
+  Qed.
 
 End SimpleArrow.

--- a/theories/LogicalRelation/Transitivity.v
+++ b/theories/LogicalRelation/Transitivity.v
@@ -86,9 +86,12 @@ Lemma transEqTermΣ {Γ lA A t u v} {ΣA : [Γ ||-Σ<lA> A]}
   [Γ ||-Σ u ≅ v : A | ΣA ] ->
   [Γ ||-Σ t ≅ v : A | ΣA ].
 Proof.
-  intros [tL ?? eqfst eqsnd] [? tR ? eqfst' eqsnd'];
+  intros [tL ?? eqfst eqsnd] [? tR ? eqfst' eqsnd'].
+  assert (forall t (red : [Γ ||-Σ t : _ | ΣA]), whnf (SigRedTm.nf red)).
+  { intros ? [? ? ispair]; simpl; destruct ispair; constructor; tea.
+    now eapply convneu_whne. }
   unshelve epose proof (e := redtmwf_det _ _ (SigRedTm.red redR) (SigRedTm.red redL)); tea.
-  1,2: eapply isPair_whnf, isWfPair_isPair; apply SigRedTm.isfun.
+  1,2: now eauto.
   exists tL tR.
   + etransitivity; tea. now rewrite e.
   + intros; eapply ihdom ; [eapply eqfst| rewrite e; eapply eqfst'].

--- a/theories/LogicalRelation/Transitivity.v
+++ b/theories/LogicalRelation/Transitivity.v
@@ -59,9 +59,12 @@ Lemma transEqTermΠ {Γ lA A t u v} {ΠA : [Γ ||-Π<lA> A]}
   [Γ ||-Π u ≅ v : A | ΠA ] ->
   [Γ ||-Π t ≅ v : A | ΠA ].
 Proof.
-  intros [tL] [? tR];
+  intros [tL] [? tR].
+  assert (forall t (red : [Γ ||-Π t : _ | ΠA]), whnf (PiRedTm.nf red)).
+  { intros ? [? ? isfun]; simpl; destruct isfun; constructor; tea.
+    now eapply convneu_whne. }
   unshelve epose proof (e := redtmwf_det _ _ (PiRedTm.red redR) (PiRedTm.red redL)); tea.
-  1,2: apply isFun_whnf; eapply isWfFun_isFun, PiRedTm.isfun.
+  1,2: now eauto.
   exists tL tR.
   + etransitivity; tea. now rewrite e.
   + intros. eapply ihcod.

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -174,13 +174,16 @@ Section Weakenings.
       Unshelve. all: tea.
   Qed.
 
-  Lemma isWfFun_ren : forall Γ Δ A B t (ρ : Δ ≤ Γ),
-    [|- Δ] ->
-    isWfFun Γ A B t -> isWfFun Δ A⟨ρ⟩ B⟨upRen_term_term ρ⟩ t⟨ρ⟩.
+  Lemma isLRFun_ren : forall Γ Δ t A l (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Π< l > A]),
+    isLRFun ΠA t -> isLRFun (wkΠ ρ wfΔ ΠA) t⟨ρ⟩.
   Proof.
-  intros * ? []; constructor; tea.
-  + now apply convty_wk.
-  + change [Δ |- f⟨ρ⟩ ~ f⟨ρ⟩ : (tProd A B)⟨ρ⟩].
+  intros * [A' t' Hdom|]; constructor; tea.
+  + intros Ξ ρ' *; cbn.
+    assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
+    irrelevance0; [apply eq|].
+    rewrite <- eq.
+    now unshelve apply Hdom.
+  + change [Δ |- f⟨ρ⟩ ~ f⟨ρ⟩ : (tProd (PiRedTy.dom ΠA) (PiRedTy.cod ΠA))⟨ρ⟩].
     now eapply convneu_wk.
   Qed.
 
@@ -193,7 +196,7 @@ Section Weakenings.
     intros [t].
     exists (t⟨ρ⟩); try change (tProd _ _) with (ΠA.(outTy)⟨ρ⟩).
     + now eapply redtmwf_wk.
-    + now apply isWfFun_ren.
+    + now apply isLRFun_ren.
     + now apply convtm_wk.
     + intros ? a ρ' ??.
       replace ((t ⟨ρ⟩)⟨ ρ' ⟩) with (t⟨ρ' ∘w ρ⟩) by now bsimpl.

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -233,6 +233,19 @@ Section Weakenings.
     now eapply convneu_wk.
   Qed.
 
+  Lemma isLRPair_ren : forall Γ Δ t A l (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΣA : [Γ ||-Σ< l > A]),
+    isLRPair ΣA t -> isLRPair (wkΣ ρ wfΔ ΣA) t⟨ρ⟩.
+  Proof.
+  intros * [A' B' a b Hdom|]; constructor; tea.
+  + intros Ξ ρ' *; cbn.
+    assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
+    irrelevance0; [apply eq|].
+    rewrite <- eq.
+    now unshelve apply Hdom.
+  + change [Δ |- p⟨ρ⟩ ~ p⟨ρ⟩ : (tSig (SigRedTy.dom ΣA) (SigRedTy.cod ΣA))⟨ρ⟩].
+    now eapply convneu_wk.
+  Qed.
+
   Lemma wkΣTerm {Γ Δ u A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Σ< l > A]) 
     (ΠA' := wkΣ ρ wfΔ ΠA) : 
     [Γ||-Σ u : A | ΠA] -> 
@@ -244,7 +257,7 @@ Section Weakenings.
       2: now unshelve eapply fstRed.
       cbn; symmetry; apply wk_comp_ren_on.
     + now eapply redtmwf_wk.
-    + apply isWfPair_ren; assumption.
+    + apply isLRPair_ren; assumption.
     + eapply convtm_wk; eassumption.
     + intros ? ρ' ?;  irrelevance0.
       2: rewrite wk_comp_ren_on; now unshelve eapply sndRed.

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -236,12 +236,28 @@ Section Weakenings.
   Lemma isLRPair_ren : forall Γ Δ t A l (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΣA : [Γ ||-Σ< l > A]),
     isLRPair ΣA t -> isLRPair (wkΣ ρ wfΔ ΣA) t⟨ρ⟩.
   Proof.
-  intros * [A' B' a b Hdom|]; constructor; tea.
+  intros * [A' B' a b Hdom Hcod Hfst Hsnd|]; unshelve econstructor; tea.
+  + refold; intros Ξ ρ' wfΞ.
+    assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
+    rewrite <- eq; irrelevance0; [|now unshelve apply Hfst].
+    now bsimpl.
   + intros Ξ ρ' *; cbn.
     assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
     irrelevance0; [apply eq|].
     rewrite <- eq.
     now unshelve apply Hdom.
+  + intros Ξ a' ρ' wfΞ ha'; cbn.
+    assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
+    unshelve eassert (Hcod0 := Hcod Ξ a' (ρ' ∘w ρ) wfΞ _).
+    { cbn in ha'; irrelevance0; [symmetry; apply eq|tea]. }
+    replace (B'⟨upRen_term_term ρ⟩[a' .: ρ' >> tRel]) with B'[a' .: (ρ' ∘w ρ) >> tRel] by now bsimpl.
+    irrelevance0; [|apply Hcod0].
+    now bsimpl.
+  + refold; intros Ξ ρ' wfΞ.
+    assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
+    rewrite <- eq.
+    irrelevance0; [|now unshelve apply Hsnd].
+    now bsimpl.
   + change [Δ |- p⟨ρ⟩ ~ p⟨ρ⟩ : (tSig (SigRedTy.dom ΣA) (SigRedTy.cod ΣA))⟨ρ⟩].
     now eapply convneu_wk.
   Qed.

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -223,16 +223,6 @@ Section Weakenings.
     intros []; constructor. all: gen_typing.
   Qed.  
   
-  Lemma isWfPair_ren : forall Γ Δ A B t (ρ : Δ ≤ Γ),
-    [|- Δ] ->
-    isWfPair Γ A B t -> isWfPair Δ A⟨ρ⟩ B⟨upRen_term_term ρ⟩ t⟨ρ⟩.
-  Proof.
-  intros * ? []; constructor; tea.
-  + now apply convty_wk.
-  + change [Δ |- n⟨ρ⟩ ~ n⟨ρ⟩ : (tSig A B)⟨ρ⟩].
-    now eapply convneu_wk.
-  Qed.
-
   Lemma isLRPair_ren : forall Γ Δ t A l (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΣA : [Γ ||-Σ< l > A]),
     isLRPair ΣA t -> isLRPair (wkΣ ρ wfΔ ΣA) t⟨ρ⟩.
   Proof.

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -177,12 +177,19 @@ Section Weakenings.
   Lemma isLRFun_ren : forall Γ Δ t A l (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Π< l > A]),
     isLRFun ΠA t -> isLRFun (wkΠ ρ wfΔ ΠA) t⟨ρ⟩.
   Proof.
-  intros * [A' t' Hdom|]; constructor; tea.
+  intros * [A' t' Hdom Ht|]; constructor; tea.
   + intros Ξ ρ' *; cbn.
     assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
     irrelevance0; [apply eq|].
     rewrite <- eq.
     now unshelve apply Hdom.
+  + intros Ξ a ρ' wfΞ *; cbn.
+    assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
+    unshelve eassert (Ht0 := Ht Ξ a (ρ' ∘w ρ) wfΞ _).
+    { cbn in ha; irrelevance0; [symmetry; apply eq|tea]. }
+    replace (t'⟨upRen_term_term ρ⟩[a .: ρ' >> tRel]) with (t'[a .: (ρ' ∘w ρ) >> tRel]) by now bsimpl.
+    irrelevance0; [|apply Ht0].
+    now bsimpl.
   + change [Δ |- f⟨ρ⟩ ~ f⟨ρ⟩ : (tProd (PiRedTy.dom ΠA) (PiRedTy.cod ΠA))⟨ρ⟩].
     now eapply convneu_wk.
   Qed.

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -79,9 +79,10 @@ Proof.
   assert [Δ |- (tLambda F t)[σ] : (tProd F G)[σ]] by (escape; cbn; gen_typing).
   exists (tLambda F t)[σ]; intros; cbn in *.
   + now eapply redtmwf_refl.
-  + constructor;  unshelve eapply escapeEq, reflLRTyEq; [|tea].
+  + constructor; cbn; intros.
+    apply reflLRTyEq.
   + eapply convtm_eta; tea.
-    1,2: constructor; unshelve eapply escapeEq, reflLRTyEq; [|tea].
+    1,2: constructor; eapply escapeEq, reflLRTyEq.
     assert (eqσ : forall Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])
     by (intro; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
     assert [Δ,, F[σ] |-[ ta ] tApp (tLambda F[σ] t[up_term_term σ])⟨S⟩ (tRel 0) ⤳*  t[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0)..] : G[up_term_term σ]].
@@ -142,13 +143,14 @@ Proof.
     eapply LRTyEqSym. eapply (validTyExt VΠFG); tea.
     Unshelve. 2: now eapply validTy.
   - refold; cbn; escape.
-    eapply convtm_eta; tea.
-    2,4: constructor; first [assumption|now eapply lrefl].
+    eapply convtm_eta; refold; tea.
+    2,4: constructor; first [assumption|now eapply lrefl|idtac].
     + gen_typing.
-    + eapply ty_conv; [gen_typing| now symmetry].
+    + eapply ty_conv; [now eapply ty_lam|].
+      symmetry; now eapply convty_prod.
     + assert (eqσ : forall σ Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])
       by (intros; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
-      eapply convtm_exp. 
+      eapply convtm_exp.
       * rewrite (eqσ σ G). eapply redtm_beta.
         -- renToWk; eapply wft_wk; tea; gen_typing.
         -- renToWk; eapply ty_wk; tea.
@@ -237,6 +239,17 @@ Proof.
   * unshelve eapply escapeEq, reflLRTyEq; [|tea].
 Qed.
 
+Lemma isLRFun_isWfFun : forall {σ Δ f} (wfΔ : [|- Δ]) (RΠFG : [Δ ||-< l > (tProd F G)[σ]])
+  (p : [Δ ||-Π f[σ] : tProd F[σ] G[up_term_term σ] | normRedΠ0 (Induction.invLRΠ RΠFG)]),
+  isWfFun Δ F[σ] G[up_term_term σ] (PiRedTm.nf p).
+Proof.
+intros.
+destruct RΠFG; simpl in *.
+destruct p as [nf ? isfun]; simpl in *.
+destruct isfun as [A t vA|]; simpl in *; constructor; tea.
+rewrite <- (wk_id_ren_on Δ F[σ]), <- (wk_id_ren_on Δ A).
+now unshelve eapply escapeEq, vA.
+Qed.
 
 Lemma ηeqEqTerm {σ Δ f g} (ρ := @wk1 Γ F)
   (Vfg : [Γ ,, F ||-v<l> tApp f⟨ρ⟩ (tRel 0) ≅ tApp g⟨ρ⟩ (tRel 0) : G | VΓF | VG ])
@@ -253,10 +266,11 @@ Proof.
   - change [Δ ||-<l> g[σ] : (tProd F G)[σ] | RΠ ]; irrelevance.
   - cbn; pose (VσUp :=  liftSubstS' VF Vσ).
     instValid Vσ; instValid VσUp; escape.
-    destruct (PiRedTm.red p); destruct (PiRedTm.red p0); cbn in *.
     eapply convtm_eta; tea.
-    + apply (PiRedTm.isfun p0).
-    + apply (PiRedTm.isfun p).
+    + destruct (PiRedTm.red p0); cbn in *; tea.
+    + now apply isLRFun_isWfFun.
+    + destruct (PiRedTm.red p); cbn in *; tea.
+    + now apply isLRFun_isWfFun.
     + etransitivity ; [symmetry| etransitivity]; tea; eapply ηeqEqTermConvNf.
   - match goal with H : [_ ||-Π f[σ] : _ | _] |- _ => rename H into Rfσ end.
     match goal with H : [_ ||-Π g[σ] : _ | _] |- _ => rename H into Rgσ end.

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -80,7 +80,15 @@ Proof.
   exists (tLambda F t)[σ]; intros; cbn in *.
   + now eapply redtmwf_refl.
   + constructor; cbn; intros.
-    apply reflLRTyEq.
+    - apply reflLRTyEq.
+    - rewrite Poly.eq_subst_2.
+      irrelevance0; [symmetry; apply Poly.eq_subst_2|].
+      unshelve apply Vt; tea.
+      eapply consSubstS.
+      irrelevance0; [|tea].
+      now bsimpl.
+      Unshelve.
+      now unshelve eapply wkSubstS.
   + eapply convtm_eta; tea.
     1,2: constructor; eapply escapeEq, reflLRTyEq.
     assert (eqσ : forall Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -90,7 +90,7 @@ Proof.
       Unshelve.
       now unshelve eapply wkSubstS.
   + eapply convtm_eta; tea.
-    1,2: constructor; eapply escapeEq, reflLRTyEq.
+    1,2: constructor; tea; eapply escapeEq, reflLRTyEq.
     assert (eqσ : forall Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])
     by (intro; bsimpl; cbn; now rewrite rinstInst'_term_pointwise).
     assert [Δ,, F[σ] |-[ ta ] tApp (tLambda F[σ] t[up_term_term σ])⟨S⟩ (tRel 0) ⤳*  t[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0)..] : G[up_term_term σ]].
@@ -154,6 +154,13 @@ Proof.
     eapply convtm_eta; refold; tea.
     2,4: constructor; first [assumption|now eapply lrefl|idtac].
     + gen_typing.
+    + eapply ty_conv; [tea|now symmetry].
+    + eapply ty_conv; [tea|].
+      assert (Vσ'σ := symmetrySubstEq _ _ _ _ _ Vσ' Vσσ').
+      assert (Vupσ'σ := liftSubstSEq' VF Vσ'σ).
+      unshelve eassert (VG' := validTyExt VG _ _ _ Vupσ'σ).
+      { eapply liftSubstSrealign'; tea. }
+      eapply escapeEq, VG'.
     + eapply ty_conv; [now eapply ty_lam|].
       symmetry; now eapply convty_prod.
     + assert (eqσ : forall σ Z, Z[up_term_term σ] = Z[up_term_term σ]⟨upRen_term_term S⟩[(tRel 0) ..])
@@ -247,16 +254,57 @@ Proof.
   * unshelve eapply escapeEq, reflLRTyEq; [|tea].
 Qed.
 
-Lemma isLRFun_isWfFun : forall {σ Δ f} (wfΔ : [|- Δ]) (RΠFG : [Δ ||-< l > (tProd F G)[σ]])
+Lemma isLRFun_isWfFun : forall {σ Δ f} (wfΔ : [|- Δ]) (vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) (RΠFG : [Δ ||-< l > (tProd F G)[σ]])
   (p : [Δ ||-Π f[σ] : tProd F[σ] G[up_term_term σ] | normRedΠ0 (Induction.invLRΠ RΠFG)]),
   isWfFun Δ F[σ] G[up_term_term σ] (PiRedTm.nf p).
 Proof.
 intros.
+instValid vσ.
 destruct RΠFG; simpl in *.
 destruct p as [nf ? isfun]; simpl in *.
-destruct isfun as [A t vA|]; simpl in *; constructor; tea.
-rewrite <- (wk_id_ren_on Δ F[σ]), <- (wk_id_ren_on Δ A).
-now unshelve eapply escapeEq, vA.
+destruct isfun as [A t vA vt|]; simpl in *; constructor; tea.
++ rewrite <- (@wk_id_ren_on Δ).
+  unshelve eapply escapeConv, vA; tea.
++ rewrite <- (wk_id_ren_on Δ F[σ]), <- (wk_id_ren_on Δ A).
+  now unshelve eapply escapeEq, vA.
++ assert (Hrw : forall t, t[tRel 0 .: @wk1 Δ A >> tRel] = t).
+  { intros; bsimpl; apply idSubst_term; intros []; reflexivity. }
+  assert [Δ |- F[σ]] by now eapply escape.
+  assert (wfΔF : [|- Δ,, F[σ]]) by now apply wfc_cons.
+  unshelve eassert (vt0 := vt _ (tRel 0) (@wk1 Δ F[σ]) _ _); tea.
+  { eapply var0; [now bsimpl|tea]. }
+  eapply escapeTerm in vt0.
+  now rewrite !Hrw in vt0.
++ assert (Hrw : forall t, t[tRel 0 .: @wk1 Δ A >> tRel] = t).
+  { intros; bsimpl; apply idSubst_term; intros []; reflexivity. }
+  assert [Δ |- A].
+  { rewrite <- (@wk_id_ren_on Δ).
+    unshelve eapply escapeConv, vA; tea. }
+  assert (wfΔA : [|- Δ,, A]) by now apply wfc_cons.
+  assert [Δ |-[ ta ] A ≅ F[σ]].
+  { rewrite <- (wk_id_ren_on Δ F[σ]), <- (wk_id_ren_on Δ A).
+    symmetry; now unshelve eapply escapeEq, vA. }
+  assert [Δ,, A ||-< l > G[up_term_term σ]].
+  { eapply validTy with (wfΔ := wfΔA); tea.
+    unshelve econstructor; [shelve|]; cbn.
+    apply var0conv; [|tea].
+    replace F[↑ >> up_term_term σ] with F[σ]⟨@wk1 Δ A⟩ by now bsimpl.
+    rewrite <- (wk1_ren_on Δ A); eapply convty_wk; tea.
+    Unshelve.
+    eapply irrelevanceSubstExt with (σ := σ⟨@wk1 Δ A⟩).
+    { now bsimpl. }
+    now eapply wkSubstS.
+  }
+  rewrite <- (Hrw t); eapply escapeTerm.
+  irrelevance0; [apply Hrw|unshelve apply vt].
+  - apply wfc_cons; tea.
+  - apply var0conv; tea.
+    rewrite <- (wk1_ren_on Δ A A).
+    apply convty_wk; [now apply wfc_cons|].
+    rewrite <- (wk_id_ren_on Δ F[σ]), <- (wk_id_ren_on Δ A).
+    symmetry; now unshelve eapply escapeEq, vA.
+  Unshelve.
+  all: tea.
 Qed.
 
 Lemma ηeqEqTerm {σ Δ f g} (ρ := @wk1 Γ F)
@@ -276,9 +324,9 @@ Proof.
     instValid Vσ; instValid VσUp; escape.
     eapply convtm_eta; tea.
     + destruct (PiRedTm.red p0); cbn in *; tea.
-    + now apply isLRFun_isWfFun.
+    + now eapply isLRFun_isWfFun.
     + destruct (PiRedTm.red p); cbn in *; tea.
-    + now apply isLRFun_isWfFun.
+    + now eapply isLRFun_isWfFun.
     + etransitivity ; [symmetry| etransitivity]; tea; eapply ηeqEqTermConvNf.
   - match goal with H : [_ ||-Π f[σ] : _ | _] |- _ => rename H into Rfσ end.
     match goal with H : [_ ||-Π g[σ] : _ | _] |- _ => rename H into Rgσ end.

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -510,7 +510,8 @@ Section PairRed.
       2: unshelve eapply pairFstRed; tea.
     + eapply redtmwf_refl; cbn.
       eapply ty_pair; tea.
-    + constructor; apply PiRedTyPack.eqdom.
+    + constructor; cbn; intros.
+      apply reflLRTyEq.
     + eapply convtm_eta_sig; tea.
       * now eapply ty_pair.
       * constructor; unshelve eapply escapeEq, reflLRTyEq; [|tea].
@@ -544,6 +545,22 @@ Section PairRed.
       Unshelve. all: tea.
   Qed.
 
+  Lemma isLRPair_isWfPair {Γ A B l p} (wfΓ : [|- Γ]) (ΣA : [Γ ||-Σ<l> tSig A B]) (Rp : [Γ ||-Σ p : _ | normRedΣ0 ΣA]) :
+    isWfPair Γ A B (SigRedTm.nf Rp).
+  Proof.
+  destruct Rp; simpl; intros.
+  destruct ispair as [A' B' a b HA|]; constructor; tea.
+  rewrite <- (wk_id_ren_on Γ A), <- (wk_id_ren_on Γ A').
+  eapply escapeEq; now unshelve apply HA.
+  Qed.
+
+  Lemma isLRPair_isPair {Γ A B l p} (ΣA : [Γ ||-Σ<l> tSig A B]) (Rp : [Γ ||-Σ p : _ | normRedΣ0 ΣA]) :
+    isPair (SigRedTm.nf Rp).
+  Proof.
+  destruct Rp; simpl; intros.
+  destruct ispair; constructor; tea.
+  now eapply convneu_whne.
+  Qed.
 
   Lemma sigEtaRed {Γ A B l p p'}
     (RΣ0 : [Γ ||-Σ<l> tSig A B])
@@ -564,16 +581,17 @@ Section PairRed.
     exists Rp Rp'.
     - destruct (polyRedId (normRedΣ0 RΣ0)) as [_ RB].
       assert ([Γ ||-<l> SigRedTm.nf Rp : _ | RΣ] × [Γ ||-<l> p ≅ SigRedTm.nf Rp : _ | RΣ]) as [Rnf Rpnf].
-      1: eapply (redTmFwdConv Rp (SigRedTm.red Rp)), isPair_whnf, isWfPair_isPair, SigRedTm.isfun.
+      1: eapply (redTmFwdConv Rp (SigRedTm.red Rp)), isPair_whnf, isLRPair_isPair.
       assert ([Γ ||-<l> SigRedTm.nf Rp' : _ | RΣ]× [Γ ||-<l> p' ≅ SigRedTm.nf Rp' : _ | RΣ]) as [Rnf' Rpnf'].
-      1: eapply (redTmFwdConv Rp' (SigRedTm.red Rp')), isPair_whnf, isWfPair_isPair, SigRedTm.isfun.
+      1: eapply (redTmFwdConv Rp' (SigRedTm.red Rp')), isPair_whnf, isLRPair_isPair.
       destruct (fstRed RΣ0 RA Rp) as [[Rfstp Rfsteq] Rfstnf].
       destruct (fstRed RΣ0 RA Rp') as [[Rfstp' Rfsteq'] Rfstnf'].
       destruct (sndRed RΣ0 RA Rp RBfst RBfstEq).
       destruct (sndRed RΣ0 RA Rp' RBfst' RBfstEq').
       escape.
+      assert [|- Γ] by now eapply wfc_wft.
       eapply convtm_eta_sig; tea.
-      1,2: now eapply SigRedTm.isfun.
+      1, 2: now eapply isLRPair_isWfPair.
       + transitivity (tFst p).
         1: now symmetry.
         transitivity (tFst p'); tea.

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -510,8 +510,16 @@ Section PairRed.
       2: unshelve eapply pairFstRed; tea.
     + eapply redtmwf_refl; cbn.
       eapply ty_pair; tea.
-    + constructor; cbn; intros.
-      apply reflLRTyEq.
+    + unshelve econstructor; cbn; intros.
+      - irrelevance0; [reflexivity|eapply wkTerm].
+        apply Ra.
+        Unshelve. tea.
+      - apply reflLRTyEq.
+      - apply reflLRTyEq.
+      - assert (Hrw : B[a⟨ρ⟩ .: ρ >> tRel] = B[a..]⟨ρ⟩) by now bsimpl.
+        irrelevance0; [symmetry; apply Hrw|eapply wkTerm].
+        apply Rb.
+        Unshelve. tea.
     + eapply convtm_eta_sig; tea.
       * now eapply ty_pair.
       * constructor; unshelve eapply escapeEq, reflLRTyEq; [|tea].


### PR DESCRIPTION
We dive into paranoïa for the side-conditions of η-rules for functions and pairs. That is, we saturate the isWfFun and isWfPair with everything we have at hand about the considered subterms. This is done by semantizing the corresponding predicates in the logical relation, introducing the semantic counterparts isLRFun and isLRPair.

- Functions could even be a tad more paranoid (asking for inversions on the codomain type) but it would require more work and it's already better now.
- Some self-convertibility hypotheses in prod / sigma term reducibility are probably redundant now since the semantic predicates imply them once we have escape, I didn't look into that.
