### PR TITLE
Replace term reducibility in the logical relation by the diagonal of reducible term conversion

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -31,6 +31,7 @@ theories/LogicalRelation/Weakening.v
 theories/LogicalRelation/Universe.v
 theories/LogicalRelation/Neutral.v
 theories/LogicalRelation/Transitivity.v
+theories/LogicalRelation/InstKripke.v
 theories/LogicalRelation/EqRedRight.v
 theories/LogicalRelation/Reduction.v
 theories/LogicalRelation/NormalRed.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -36,7 +36,7 @@ theories/LogicalRelation/EqRedRight.v
 theories/LogicalRelation/Reduction.v
 theories/LogicalRelation/NormalRed.v
 theories/LogicalRelation/Application.v
-# theories/LogicalRelation/SimpleArr.v
+theories/LogicalRelation/SimpleArr.v
 theories/LogicalRelation/Id.v
 
 theories/Validity.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -31,10 +31,11 @@ theories/LogicalRelation/Weakening.v
 theories/LogicalRelation/Universe.v
 theories/LogicalRelation/Neutral.v
 theories/LogicalRelation/Transitivity.v
+theories/LogicalRelation/EqRedRight.v
 theories/LogicalRelation/Reduction.v
 theories/LogicalRelation/NormalRed.v
 theories/LogicalRelation/Application.v
-theories/LogicalRelation/SimpleArr.v
+# theories/LogicalRelation/SimpleArr.v
 theories/LogicalRelation/Id.v
 
 theories/Validity.v

--- a/theories/Consequences.v
+++ b/theories/Consequences.v
@@ -56,20 +56,20 @@ Section NatCanonicityInduction.
   Qed.
 
   Lemma nat_red_empty_ind :
-    (forall t, [ε ||-Nat t : tNat | red_nat_empty] ->
+    (forall t u, [ε ||-Nat t ≅ u : tNat | red_nat_empty] ->
     ∑ n : nat, [ε |- t ≅ n : tNat]) ×
-    (forall t, NatProp red_nat_empty t -> ∑ n : nat, [ε |- t ≅ n : tNat]).
+    (forall t u, NatPropEq red_nat_empty t u -> ∑ n : nat, [ε |- t ≅ n : tNat]).
   Proof.
-    apply NatRedInduction.
-    - intros * [? []] ? _ [n] ; refold.
+    apply NatRedEqInduction.
+    - intros * [? []] ? ? _ [n] ; refold.
       exists n.
       now etransitivity.
     - exists 0 ; cbn.
       now repeat constructor.
-    - intros ? _ [n].
+    - intros ? ? _ [n].
       exists (S n) ; simpl.
       now econstructor.
-    - intros ? [? [? _ _]].
+    - intros ? ? [? ? []].
       exfalso.
       now eapply no_neutral_empty_ctx.
   Qed.
@@ -80,7 +80,7 @@ Section NatCanonicityInduction.
     intros Ht.
     assert [LRNat_ one red_nat_empty | ε ||- t : tNat] as ?%nat_red_empty_ind.
     {
-      apply Fundamental in Ht as [?? Vt%reducibleTm].
+      apply Fundamental in Ht as [?? Vt%reducibleTmEq].
       irrelevance.
     }
     now assumption.

--- a/theories/DeclarativeSubst.v
+++ b/theories/DeclarativeSubst.v
@@ -7,7 +7,7 @@ From LogRel Require Import LogicalRelation Validity Fundamental.
 From LogRel.LogicalRelation Require Import Induction Escape Irrelevance Transitivity.
 From LogRel.Substitution Require Import Properties Irrelevance.
 
-(** Currently, this is obtained as a consequence of the fundamental lemma. 
+(** Currently, this is obtained as a consequence of the fundamental lemma.
 However, it could be alternatively proven much earlier, by a direct induction. *)
 
 Set Printing Primitive Projection Parameters.
@@ -44,20 +44,14 @@ Proof.
     unshelve eapply transEq.
     4: now apply Vconv.
     2-3: unshelve eapply VB ; tea.
-    all: irrValid.
+    eapply urefl; now eapply irrelevanceSubstEq.
   - intros * Ht * HΔ Hσ.
     unshelve eapply Fundamental_subst_conv in Hσ as [].
     1,3: boundary.
-    apply Fundamental in Ht as [VΓ VA Vt Vu Vtu] ; cbn in *.
+    apply Fundamental in Ht as [VΓ VA Vtu] ; cbn in *.
     unshelve eapply escapeEqTerm.
     2: now unshelve eapply VA ; tea ; irrValid.
-    cbn.
-    eapply transEqTerm.
-    + cbn.
-      unshelve eapply Vtu.
-    + cbn.
-      eapply Vu.
-      all: irrValid.
+    cbn. unshelve eapply Vtu.
 Qed.
 
 
@@ -149,16 +143,16 @@ Section MoreSubst.
 
   Theorem typing_substmap1 Γ T :
   (forall (t : term), [Γ ,, T |- t : T⟨↑⟩] ->
-    forall (A : term), [Γ,, T |- A] -> 
+    forall (A : term), [Γ,, T |- A] ->
       [Γ,, T |- A[t]⇑]) ×
   (forall (t : term), [Γ ,, T |- t : T⟨↑⟩] ->
-    forall (A u : term), [Γ,, T |- u : A] -> 
+    forall (A u : term), [Γ,, T |- u : A] ->
       [Γ,, T |- u[t]⇑ : A[t]⇑]) ×
   (forall (t t' : term), [Γ ,, T |- t ≅ t' : T⟨↑⟩] ->
     forall (A B : term), [Γ,, T |- A ≅ B] ->
       [Γ,, T |- A[t]⇑ ≅ B[t']⇑]) ×
   (forall (t t' : term), [Γ ,, T |- t ≅ t' : T⟨↑⟩] ->
-    forall (A u v : term), [Γ,, T |- u ≅ v : A] -> 
+    forall (A u v : term), [Γ,, T |- u ≅ v : A] ->
       [Γ,, T |- u[t]⇑ ≅ v[t']⇑ : A[t]⇑]).
   Proof.
     repeat match goal with |- _ × _ => split end.

--- a/theories/GenericTyping.v
+++ b/theories/GenericTyping.v
@@ -11,7 +11,7 @@ times with different instances of this abstract notion of typing, gathering more
 and more properties. *)
 
 (**
-More precisely, an instance consists of giving notions of 
+More precisely, an instance consists of giving notions of
 - context well-formation [|- Γ]
 - type well-formation [Γ |- A]
 - term well-formation [Γ |- t : A]
@@ -48,7 +48,7 @@ Section RedDefinitions.
     }.
 
   Record TypeConvWf (Γ : context) (A B : term) : Type :=
-    { 
+    {
       tyc_wf_l : [Γ |- A] ;
       tyc_wf_r : [Γ |- B] ;
       tyc_wf_conv :> [Γ |- A ≅ B]
@@ -151,7 +151,7 @@ Notation "[ Γ |- A ↘ B ]" := (TypeRedWhnf Γ A B) (only parsing) : typing_sco
 Notation "[ Γ |-[ ta  ] A ↘ B ]" := (TypeRedWhnf (ta := ta) Γ A B) : typing_scope.
 Notation "[ Γ |- t ↘ u : A ]" := (TermRedWhnf Γ A t u) (only parsing ): typing_scope.
 Notation "[ Γ |-[ ta  ] t ↘ u : A ]" := (TermRedWhnf (ta := ta) Γ A t u) : typing_scope.
-Notation "[ Γ |- A :≅: B ]" := (TypeConvWf Γ A B) (only parsing) : typing_scope.  
+Notation "[ Γ |- A :≅: B ]" := (TypeConvWf Γ A B) (only parsing) : typing_scope.
 Notation "[ Γ |-[ ta  ] A :≅: B ]" := (TypeConvWf (ta := ta) Γ A B) : typing_scope.
 Notation "[ Γ |- t :≅: u : A ]" := (TermConvWf Γ A t u) (only parsing) : typing_scope.
 Notation "[ Γ |-[ ta  ] t :≅: u : A ]" := (TermConvWf (ta := ta) Γ A t u) : typing_scope.
@@ -209,16 +209,16 @@ Section GenericTyping.
   {
     wft_wk {Γ Δ A} (ρ : Δ ≤ Γ) :
       [|- Δ ] -> [Γ |- A] -> [Δ |- A⟨ρ⟩] ;
-    wft_U {Γ} : 
+    wft_U {Γ} :
       [ |- Γ ] ->
       [ Γ |- U ] ;
-    wft_prod {Γ} {A B} : 
-      [ Γ |- A ] -> 
-      [Γ ,, A |- B ] -> 
+    wft_prod {Γ} {A B} :
+      [ Γ |- A ] ->
+      [Γ ,, A |- B ] ->
       [ Γ |- tProd A B ] ;
-    wft_sig {Γ} {A B} : 
-      [ Γ |- A ] -> 
-      [Γ ,, A |- B ] -> 
+    wft_sig {Γ} {A B} :
+      [ Γ |- A ] ->
+      [Γ ,, A |- B ] ->
       [ Γ |- tSig A B ] ;
     wft_Id {Γ} {A x y} :
       [Γ |- A] ->
@@ -226,7 +226,7 @@ Section GenericTyping.
       [Γ |- y : A] ->
       [Γ |- tId A x y] ;
     wft_term {Γ} {A} :
-      [ Γ |- A : U ] -> 
+      [ Γ |- A : U ] ->
       [ Γ |- A ] ;
   }.
 
@@ -239,16 +239,16 @@ Section GenericTyping.
       in_ctx Γ n decl ->
       [ Γ |- tRel n : decl ] ;
     ty_prod {Γ} {A B} :
-        [ Γ |- A : U] -> 
+        [ Γ |- A : U] ->
         [Γ ,, A |- B : U ] ->
         [ Γ |- tProd A B : U ] ;
     ty_lam {Γ}  {A B t} :
         [ Γ |- A ] ->
-        [ Γ ,, A |- t : B ] -> 
+        [ Γ ,, A |- t : B ] ->
         [ Γ |- tLambda A t : tProd A B] ;
     ty_app {Γ}  {f a A B} :
-        [ Γ |- f : tProd A B ] -> 
-        [ Γ |- a : A ] -> 
+        [ Γ |- f : tProd A B ] ->
+        [ Γ |- a : A ] ->
         [ Γ |- tApp f a : B[a ..] ] ;
     ty_nat {Γ} :
         [|-Γ] ->
@@ -273,11 +273,11 @@ Section GenericTyping.
       [Γ |- e : tEmpty] ->
       [Γ |- tEmptyElim P e : P[e..]] ;
     ty_sig {Γ} {A B} :
-        [ Γ |- A : U] -> 
+        [ Γ |- A : U] ->
         [Γ ,, A |- B : U ] ->
         [ Γ |- tSig A B : U ] ;
     ty_pair {Γ} {A B a b} :
-        [ Γ |- A ] -> 
+        [ Γ |- A ] ->
         [Γ ,, A |- B ] ->
         [Γ |- a : A] ->
         [Γ |- b : B[a..]] ->
@@ -528,7 +528,7 @@ Section GenericTyping.
       [Γ |- y : A] ->
       [Γ |- e ⤳* e' : tId A x y] ->
       [Γ |- tIdElim A x P hr y e ⤳* tIdElim A x P hr y e' : P[e .: y..]];
-    redtm_conv {Γ t u A A'} : 
+    redtm_conv {Γ t u A A'} :
       [Γ |- t ⤳* u : A] ->
       [Γ |- A ≅ A'] ->
       [Γ |- t ⤳* u : A'] ;
@@ -662,8 +662,8 @@ Ltac renToWk :=
   fold ren_term;
   repeat change (ren_term ?x ?y) with y⟨x⟩;
   repeat change S with ↑;
-  repeat lazymatch goal with 
-  | [ _ : _ |- ?G] => renToWk0 G 
+  repeat lazymatch goal with
+  | [ _ : _ |- ?G] => renToWk0 G
   end.
 
 
@@ -723,7 +723,7 @@ Section GenericConsequences.
     A' = A ->
     [Γ |- t :⤳*: u : A'].
   Proof.
-    now intros ? ->. 
+    now intros ? ->.
   Qed.
 
   (** *** Properties of well-typed reduction *)
@@ -732,7 +732,7 @@ Section GenericConsequences.
   Proof.
     intros []; now eapply redty_ty_src.
   Qed.
-  
+
   Lemma tmr_wf_l {Γ t u A} : [Γ |- t :⤳*: u : A] -> [Γ |- t : A].
   Proof.
     intros []; now eapply redtm_ty_src.
@@ -746,11 +746,11 @@ Section GenericConsequences.
   Lemma redty_red {Γ A B} :
       [Γ |- A ⤳* B] -> [ A ⤳* B ].
   Proof.
-    intros ?%redty_sound. 
+    intros ?%redty_sound.
     assumption.
   Qed.
 
-  Lemma redtm_red {Γ t u A} : 
+  Lemma redtm_red {Γ t u A} :
       [Γ |- t ⤳* u : A] ->
       [t ⤳* u].
   Proof.
@@ -770,7 +770,7 @@ Section GenericConsequences.
   Proof.
     intros []; now eapply redty_red.
   Qed.
-  
+
   Lemma redtywf_term {Γ A B} :
       [ Γ |- A :⤳*: B : U] -> [Γ |- A :⤳*: B ].
   Proof.
@@ -786,10 +786,10 @@ Section GenericConsequences.
     intros ??? [] []; unshelve econstructor; try etransitivity; tea.
   Qed.
 
-  (** Almost all of the RedTermProperties can be derived 
+  (** Almost all of the RedTermProperties can be derived
     for the well-formed reduction [Γ |- t :⤳*: u : A]
     but for application (which requires stability of typing under substitution). *)
-    
+
   Definition redtmwf_wk {Γ Δ t u A} (ρ : Δ ≤ Γ) :
       [|- Δ ] -> [Γ |- t :⤳*: u : A] -> [Δ |- t⟨ρ⟩ :⤳*: u⟨ρ⟩ : A⟨ρ⟩].
   Proof.  intros ? []; constructor; gen_typing. Qed.
@@ -827,7 +827,7 @@ Section GenericConsequences.
   Proof.
     intros [] ?; constructor; gen_typing.
   Qed.
-  
+
   Lemma redtmwf_appwk {Γ Δ A B B' t u a} (ρ : Δ ≤ Γ) :
     [Γ |- t :⤳*: u : tProd A B] ->
     [Δ |- a : A⟨ρ⟩] ->
@@ -874,10 +874,10 @@ Section GenericConsequences.
 
   (** *** Derived typing, reduction and conversion judgements *)
 
-  Lemma ty_var0 {Γ A} : 
+  Lemma ty_var0 {Γ A} :
     [Γ |- A] ->
     [Γ ,, A |- tRel 0 : A⟨↑⟩].
-  Proof. 
+  Proof.
     intros; refine (ty_var _ (in_here _ _)); gen_typing.
   Qed.
 
@@ -923,8 +923,8 @@ Section GenericConsequences.
 
   #[local]
   Hint Resolve ty_simple_app : gen_typing.
-  
-  Lemma ty_id {Γ A B C} : 
+
+  Lemma ty_id {Γ A B C} :
     [Γ |- A] ->
     [Γ |- A ≅ B] ->
     [Γ |- A ≅ C] ->
@@ -937,7 +937,7 @@ Section GenericConsequences.
     now eapply ty_var0.
   Qed.
 
-  Lemma ty_id' {Γ A} : 
+  Lemma ty_id' {Γ A} :
     [Γ |- A] ->
     [Γ |- idterm A : arr A A].
   Proof.
@@ -947,7 +947,7 @@ Section GenericConsequences.
     eapply ty_lam; tea.
     now eapply ty_var0.
   Qed.
-  
+
   Lemma redtm_id_beta {Γ a A} :
     [Γ |- A] ->
     [Γ |- A ≅ A] ->
@@ -962,7 +962,7 @@ Section GenericConsequences.
     + now asimpl.
   Qed.
 
-  Lemma convtm_id {Γ A A' B C} : 
+  Lemma convtm_id {Γ A A' B C} :
     [|- Γ] ->
     [Γ |- A] ->
     [Γ |- A'] ->
@@ -985,14 +985,14 @@ Section GenericConsequences.
         now apply wfc_cons. }
     1,2: eapply ty_id; tea; now symmetry.
     assert [|- Γ,, A] by gen_typing.
-    assert [Γ,, A |-[ ta ] A⟨@wk1 Γ A⟩] by now eapply wft_wk. 
+    assert [Γ,, A |-[ ta ] A⟨@wk1 Γ A⟩] by now eapply wft_wk.
     eapply convtm_exp.
     - cbn. eapply redtm_id_beta.
       3: now eapply ty_var0.
       1,2: renToWk; tea; now eapply convty_wk.
-    - cbn. 
+    - cbn.
       assert [Γ,, A |- A'⟨↑⟩ ≅ A⟨↑⟩]
-        by (renToWk; symmetry; now eapply convty_wk). 
+        by (renToWk; symmetry; now eapply convty_wk).
       eapply redtm_conv; tea.
       eapply redtm_id_beta.
       1: renToWk; now eapply wft_wk.
@@ -1014,28 +1014,28 @@ Section GenericConsequences.
     [Γ |- f : arr B C] ->
     [Γ |- comp A f g : arr A C].
   Proof.
-    intros tyA tyB **. 
+    intros tyA tyB **.
     eapply ty_lam; tea.
     assert [|- Γ,, A] by gen_typing.
     pose (r := @wk1 Γ A).
     eapply ty_simple_app; renToWk.
-    - unshelve eapply (wft_wk _ _ tyB) ; tea. 
+    - unshelve eapply (wft_wk _ _ tyB) ; tea.
     - now eapply wft_wk.
     - replace (arr _ _) with (arr B C)⟨r⟩ by (unfold r; now bsimpl).
       now eapply ty_wk.
     - eapply ty_simple_app; renToWk.
-      + unshelve eapply (wft_wk _ _ tyA) ; tea. 
+      + unshelve eapply (wft_wk _ _ tyA) ; tea.
       + now eapply wft_wk.
       + replace (arr _ _) with (arr A B)⟨r⟩ by (unfold r; now bsimpl).
         now eapply ty_wk.
       + unfold r; rewrite wk1_ren_on; now refine (ty_var _ (in_here _ _)).
   Qed.
-  
+
   Lemma wft_wk1 {Γ A B} : [Γ |- A] -> [Γ |- B] -> [Γ ,, A |- B⟨↑⟩].
   Proof.
     intros; renToWk; eapply wft_wk; gen_typing.
   Qed.
-  
+
   Lemma redtm_comp_beta {Γ A B C f g a} :
     [Γ |- A] ->
     [Γ |- B] ->
@@ -1218,8 +1218,8 @@ Section GenericConsequences.
       rewrite scons_eta'.
       now bsimpl.
   Qed.
-  
-  
+
+
   (** *** Lifting determinism properties from untyped reduction to typed reduction. *)
 
   Lemma redtm_whnf {Γ t u A} : [Γ |- t ⤳* u : A] -> whnf t -> t = u.

--- a/theories/LogicalRelation.v
+++ b/theories/LogicalRelation.v
@@ -291,9 +291,9 @@ Module PolyRedEq.
     `{WfType ta} `{ConvType ta}
     {Γ : context} {shp pos: term} {PA : PolyRedPack Γ shp pos} {shp' pos' : term}
   : Type := {
-    shpRed {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
+    shpRed [Δ] (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
       [ PA.(PolyRedPack.shpRed) ρ h | Δ ||- shp⟨ρ⟩ ≅ shp'⟨ρ⟩ ];
-    posRed {Δ a b} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
+    posRed [Δ a b] (ρ : Δ ≤ Γ) (h : [ |- Δ ])
       (ha : [ PA.(PolyRedPack.shpRed) ρ h | Δ ||- a ≅ b : shp⟨ρ⟩]) :
       [ PA.(PolyRedPack.posRed) ρ h ha | Δ ||- pos[a .: (ρ >> tRel)] ≅ pos'[a .: (ρ >> tRel)] ];
   }.
@@ -498,9 +498,9 @@ Module SigRedTmEq.
     redL : SigRedTm ΣA t ;
     redR : SigRedTm ΣA u ;
     eq : [ Γ |- redL.(nf) ≅ redR.(nf) : ΣA.(outTy) ];
-    eqFst {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
+    eqFst [Δ] (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
       [ΣA.(PolyRedPack.shpRed) ρ h | Δ ||- tFst redL.(nf)⟨ρ⟩ ≅ tFst redR.(nf)⟨ρ⟩ : ΣA.(ParamRedTyPack.dom)⟨ρ⟩] ;
-    eqSnd {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
+    eqSnd [Δ] (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
       [ΣA.(PolyRedPack.posRed) ρ h (eqFst ρ h) | Δ ||- tSnd redL.(nf)⟨ρ⟩ ≅ tSnd redR.(nf)⟨ρ⟩ : _] ;
   }.
 
@@ -977,12 +977,12 @@ Section PolyRed.
     {
       shpTy : [Γ |- shp] ;
       posTy : [Γ,, shp |- pos] ;
-      shpRed {Δ} (ρ : Δ ≤ Γ) : [ |- Δ ] -> [ LogRel@{i j k l} l | Δ ||- shp⟨ρ⟩ ] ;
-      posRed {Δ} {a b} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
+      shpRed [Δ] (ρ : Δ ≤ Γ) : [ |- Δ ] -> [ LogRel@{i j k l} l | Δ ||- shp⟨ρ⟩ ] ;
+      posRed [Δ a b] (ρ : Δ ≤ Γ) (h : [ |- Δ ]) :
           [ (shpRed ρ h) |  Δ ||- a ≅ b : shp⟨ρ⟩] ->
           [ LogRel@{i j k l} l | Δ ||- pos[a .: (ρ >> tRel)]] ;
       posExt
-        {Δ a b}
+        [Δ a b]
         (ρ : Δ ≤ Γ)
         (h :  [ |- Δ ])
         (hab : [ (shpRed ρ h) | Δ ||- a ≅ b : shp⟨ρ⟩]) :

--- a/theories/LogicalRelation/EqRedRight.v
+++ b/theories/LogicalRelation/EqRedRight.v
@@ -10,6 +10,12 @@ Set Universe Polymorphism.
 Section Consequence.
 Context `{GenericTypingProperties}.
 
+Lemma eq_id_subst_scons {Γ A} B : B = B[tRel 0 .: @wk1 Γ A >> tRel].
+Proof.
+  clear; bsimpl; rewrite scons_eta'; now bsimpl.
+Qed.
+
+
 
 Lemma PolyRedEqRedRight {Γ l A B A' B'} (PA : PolyRed Γ l A B)
   (ihA : forall (Δ : context) (ρ : Δ ≤ Γ) (h : [|- Δ]) X,
@@ -36,12 +42,9 @@ Proof.
   assert [Γ |- A'] by now eapply escape, instKripke.
   assert [|-Γ,,A'] by gen_typing.
   unshelve econstructor; tea.
-  - unshelve epose proof (hcod (Γ,,A') (tRel 0) (tRel 0) (wk1 _) _ _); tea.
+  - unshelve epose proof (X := hcod (Γ,,A') (tRel 0) (tRel 0) (wk1 _) _ _); tea.
     1: eapply var0; tea; now bsimpl.
-    escape.
-    (* These should be lemmas... *)
-    replace B' with B'[tRel 0 .: wk1 (Γ := Γ) A' >> tRel]; tea.
-    clear; bsimpl; rewrite scons_eta'; now bsimpl.
+    escape; now rewrite <- eq_id_subst_scons in EscX.
   - intros.
     assert [hdom Δ ρ h | _ ||- _ ≅ A⟨ρ⟩].
     1: eapply LRTyEqSym ; unshelve eauto; tea.

--- a/theories/LogicalRelation/EqRedRight.v
+++ b/theories/LogicalRelation/EqRedRight.v
@@ -1,0 +1,116 @@
+(** * LogRel.EqRedRight: Reducibility of the rhs of a reducible conversion between types. *)
+From Coq Require Import CRelationClasses.
+From LogRel.AutoSubst Require Import core unscoped Ast Extra.
+From LogRel Require Import Utils BasicAst Notations Context NormalForms UntypedReduction Weakening GenericTyping LogicalRelation.
+From LogRel.LogicalRelation Require Import Induction Reflexivity Escape Irrelevance Weakening Transitivity Neutral.
+
+Set Universe Polymorphism.
+
+
+Section Consequence.
+Context `{GenericTypingProperties}.
+
+
+Lemma PolyRedEqRedRight {Γ l A B A' B'} (PA : PolyRed Γ l A B)
+  (ihA : forall (Δ : context) (ρ : Δ ≤ Γ) (h : [|- Δ]) X,
+    [PolyRed.shpRed PA ρ h | Δ ||- A⟨ρ⟩ ≅ X] -> [Δ ||-< l > X])
+  (ihB : forall (Δ : context) (a b : term) (ρ : Δ ≤ Γ) (h : [|- Δ])
+    (ha : [PolyRed.shpRed PA ρ h | Δ ||- a ≅ b : A⟨ρ⟩]) X,
+    [PolyRed.posRed PA ρ h ha | Δ ||- B[a .: ρ >> tRel] ≅ X] ->
+    [Δ ||-< l > X]) :
+  PolyRedEq PA A' B' -> PolyRed Γ l A' B'.
+Proof.
+  destruct PA; intros []; cbn in *.
+  assert [|-Γ] by gen_typing.
+  assert (hdom: forall (Δ : context) (ρ : Δ ≤ Γ), [ |-[ ta ] Δ] -> [Δ ||-< l > A'⟨ρ⟩]).
+  1:{ intros; eapply ihA; eauto. Unshelve. tea. }
+  assert (hcod: forall (Δ : context) (a b : term) (ρ : Δ ≤ Γ)
+    (h : [ |-[ ta ] Δ]), [hdom Δ ρ h | Δ ||- a ≅ b : A'⟨ρ⟩] ->
+    [Δ ||-< l > B'[a .: ρ >> tRel]]).
+  1:{
+    intros; eapply ihB; eauto. Unshelve.
+    2: tea.
+    2: eapply LRTmEqConv; tea.
+    unshelve eapply LRTyEqSym; cycle 1 ; eauto.
+  }
+  assert [Γ |- A'] by now eapply escape, instKripke.
+  assert [|-Γ,,A'] by gen_typing.
+  unshelve econstructor; tea.
+  - unshelve epose proof (hcod (Γ,,A') (tRel 0) (tRel 0) (wk1 _) _ _); tea.
+    1: eapply var0; tea; now bsimpl.
+    escape.
+    (* These should be lemmas... *)
+    replace B' with B'[tRel 0 .: wk1 (Γ := Γ) A' >> tRel]; tea.
+    clear; bsimpl; rewrite scons_eta'; now bsimpl.
+  - intros.
+    assert [hdom Δ ρ h | _ ||- _ ≅ A⟨ρ⟩].
+    1: eapply LRTyEqSym ; unshelve eauto; tea.
+    assert [shpRed Δ ρ h | _ ||- a ≅ b : _].
+    1: eapply LRTmEqConv; tea.
+    eapply LRTransEq; [eapply LRTyEqSym, LRTransEq|].
+    2,3: eauto.
+    unshelve eauto; tea; now symmetry.
+    Unshelve.
+    2,3,5: tea.
+    2: now symmetry.
+Qed.
+
+#[program]
+Definition mkIdRedTy {Γ l A} ty lhs rhs (outTy := tId ty lhs rhs)
+    (red : [Γ |- A :⤳*: outTy])
+    (tyRed : [ LogRel l | Γ ||- ty ])
+    (lhsRed : [ tyRed | Γ ||- lhs : _ ])
+    (rhsRed : [ tyRed | Γ ||- rhs : _ ]) : [Γ ||-Id<l> A] :=
+  {| IdRedTy.ty := ty ;
+     IdRedTy.lhs := lhs ;
+     IdRedTy.rhs := rhs |}.
+Next Obligation.
+  pose proof (reflLRTyEq tyRed).
+  escape. timeout 1 gen_typing.
+Qed.
+Next Obligation. apply LRTmEqPER. Qed.
+Next Obligation. now apply wk. Qed.
+Next Obligation.
+  irrelevance0. 2: now eapply wkEq.
+  match goal with [ H : _ =1 _ |- _] =>
+    clear -H; bsimpl; rewrite H; now bsimpl
+  end.
+  Unshelve. tea.
+Qed.
+Next Obligation.
+  irrelevance0. 2: now eapply wkTermEq.
+  match goal with [ H : _ =1 _ |- _] =>
+    clear -H; bsimpl; rewrite H; now bsimpl
+  end.
+  Unshelve. tea.
+Qed.
+
+Lemma LRTyEqRedRight {Γ l A B} (RA : [Γ ||-<l> A]) :
+  [RA | Γ ||- A ≅ B] -> [Γ ||-<l> B].
+Proof.
+  revert B; pattern l, Γ, A, RA.
+  apply LR_rect_TyUr; clear l Γ A RA.
+  - intros ??? [l0] ? []; eapply LRU_; exists l0; tea.
+  - intros ??? [] ? [nf']; eapply LRne_; exists nf'; tea.
+    cbn in *; now eapply urefl.
+  - intros ??? [] ??? [A' B']; cbn in *; eapply LRPi'.
+    exists A' B'; tea.
+    1,2: now eapply urefl.
+    now eapply PolyRedEqRedRight.
+  - intros ????? []; eapply LRNat_; now constructor.
+  - intros ????? []; eapply LREmpty_; now constructor.
+  - intros ??? [] ??? [A' B']; cbn in *; eapply LRSig'.
+    exists A' B'; tea.
+    1,2: now eapply urefl.
+    now eapply PolyRedEqRedRight.
+  - intros ??? [] ??? [tynf l r]; cbn in *; eapply LRId', (mkIdRedTy tynf l r); tea.
+    all: eapply LRTmEqConv;[| now eapply urefl]; tea.
+    Unshelve. eauto.
+  Qed.
+
+End Consequence.
+
+Ltac eqty_escape_right RA H ::=
+  let X := fresh "EscR" H in
+  pose proof (X := escape (LRTyEqRedRight RA H)).
+

--- a/theories/LogicalRelation/EqRedRight.v
+++ b/theories/LogicalRelation/EqRedRight.v
@@ -15,6 +15,18 @@ Proof.
   clear; bsimpl; rewrite scons_eta'; now bsimpl.
 Qed.
 
+Set Printing Primitive Projection Parameters.
+
+Lemma posRedExt {Γ l A B A' B'} {PA : PolyRed Γ l A B} (PA' : PolyRedEq PA A' B') [Δ a b]
+  (ρ : Δ ≤ Γ) (h : [|- Δ]) (ha : [PolyRed.shpRed PA ρ h | Δ ||- a ≅ b : A⟨ρ⟩]) :
+    [PolyRed.posRed PA ρ h ha | Δ ||- B[a .: ρ >> tRel] ≅ B'[b .: ρ >> tRel]].
+Proof.
+  eapply LRTransEq.
+  1: eapply (PolyRed.posExt PA).
+  unshelve eapply (PolyRedEq.posRed PA').
+  2: tea.
+  2: now symmetry.
+Qed.
 
 
 Lemma PolyRedEqRedRight {Γ l A B A' B'} (PA : PolyRed Γ l A B)
@@ -23,10 +35,10 @@ Lemma PolyRedEqRedRight {Γ l A B A' B'} (PA : PolyRed Γ l A B)
   (ihB : forall (Δ : context) (a b : term) (ρ : Δ ≤ Γ) (h : [|- Δ])
     (ha : [PolyRed.shpRed PA ρ h | Δ ||- a ≅ b : A⟨ρ⟩]) X,
     [PolyRed.posRed PA ρ h ha | Δ ||- B[a .: ρ >> tRel] ≅ X] ->
-    [Δ ||-< l > X]) :
-  PolyRedEq PA A' B' -> PolyRed Γ l A' B'.
+    [Δ ||-< l > X])
+  (PA' : PolyRedEq PA A' B') : PolyRed Γ l A' B'.
 Proof.
-  destruct PA; intros []; cbn in *.
+  destruct PA; pose proof PA' as []; cbn in *.
   assert [|-Γ] by gen_typing.
   assert (hdom: forall (Δ : context) (ρ : Δ ≤ Γ), [ |-[ ta ] Δ] -> [Δ ||-< l > A'⟨ρ⟩]).
   1:{ intros; eapply ihA; eauto. Unshelve. tea. }
@@ -50,12 +62,9 @@ Proof.
     1: eapply LRTyEqSym ; unshelve eauto; tea.
     assert [shpRed Δ ρ h | _ ||- a ≅ b : _].
     1: eapply LRTmEqConv; tea.
-    eapply LRTransEq; [eapply LRTyEqSym, LRTransEq|].
-    2,3: eauto.
-    unshelve eauto; tea; now symmetry.
-    Unshelve.
-    2,3,5: tea.
-    2: now symmetry.
+    eapply LRTransEq.
+    + unshelve eapply LRTyEqSym, (posRedExt PA'); [|tea|now symmetry].
+    + unshelve eapply (PolyRedEq.posRed PA'); [|tea|now symmetry].
 Qed.
 
 #[program]

--- a/theories/LogicalRelation/Escape.v
+++ b/theories/LogicalRelation/Escape.v
@@ -33,7 +33,7 @@ Section Escapes.
       [Γ |- A ≅ B].
   Proof.
     pattern l, Γ, A, lr ; eapply LR_rect_TyUr.
-    + intros ??? [] []. 
+    + intros ??? [] [].
       gen_typing.
     + intros ??? [] [].
       cbn in *.
@@ -45,26 +45,26 @@ Section Escapes.
     + intros ??? [] []; gen_typing.
     + intros ??? [] * ? ? []; cbn in *.
       eapply convty_exp. all: gen_typing.
-    + intros ??? [???? red] ?? [???? red']; cbn in *. 
+    + intros ??? [???? red] ?? [???? red']; cbn in *.
       eapply convty_exp; tea;[eapply red | eapply red'].
   Qed.
 
-  Definition escapeTerm {l Γ t A} (lr : [Γ ||-< l > A ]) :
-    [Γ ||-< l > t : A | lr ] ->
+  Definition escapeTerm {l Γ t u A} (lr : [Γ ||-< l > A ]) :
+    [Γ ||-< l > t ≅ u : A | lr ] ->
     [Γ |- t : A].
   Proof.
     pattern l, Γ, A, lr ; eapply LR_rect_TyUr.
-    - intros ??? [] [] ; cbn in *.
+    - intros ??? [] [[]] ; cbn in *.
       gen_typing.
     - intros ??? [] [] ; cbn in *.
       gen_typing.
-    - intros ??? [] * ?? [] ; cbn in *.
+    - intros ??? [] * ?? [[]] ; cbn in *.
       gen_typing.
     - intros ??? [] []; gen_typing.
     - intros ??? [] []; gen_typing.
-    - intros ??? [] * ?? [] ; cbn in *.
+    - intros ??? [] * ?? [[]] ; cbn in *.
       gen_typing.
-    - intros ??? IA _ _ []. 
+    - intros ??? IA _ _ [].
       unfold_id_outTy; destruct IA; cbn in *; gen_typing.
   Qed.
 
@@ -81,7 +81,7 @@ Section Escapes.
       assert (isPosType ty).
       {
       constructor.
-      now eapply convneu_whne. 
+      now eapply convneu_whne.
       }
       eapply (convtm_conv (A := ty)).
       eapply convtm_exp ; tea.
@@ -119,25 +119,34 @@ Section Escapes.
     - intros * ??? []; gen_typing.
     - intros * _ _ ? []; gen_typing.
   Qed.
-  
+
 End Escapes.
+
+
+(* hack to redefine the symmetric version for term later *)
+Ltac sym_escape RA H := idtac.
+Ltac eqty_escape_right RA H := idtac.
 
 Ltac escape :=
   repeat lazymatch goal with
-  | [H : [_ ||-< _ > _] |- _] => 
-    let X := fresh "Esc" H in
-    try pose proof (X := escape H) ;
+  | [H : [_ ||-< _ > _] |- _] =>
+    try
+     (let X := fresh "Esc" H in
+     pose proof (X := escape H));
     block H
   | [H : [_ ||-<_> _ ≅ _ | ?RA ] |- _] =>
-    let X := fresh "Esc" H in
-    try pose proof (X := escapeEq RA H) ;
+    try
+      (let X := fresh "Esc" H in
+      pose proof (X := escapeEq RA H)) ;
+    try (eqty_escape_right RA H) ;
     block H
-  | [H : [_ ||-<_> _ : _ | ?RA] |- _] =>
+  (* | [H : [_ ||-<_> _ : _ | ?RA] |- _] =>
     let X := fresh "R" H in
     try pose proof (X := escapeTerm RA H) ;
-    block H
+    block H *)
   | [H : [_ ||-<_> _ ≅ _ : _ | ?RA] |- _] =>
-    let X := fresh "R" H in
-    try pose proof (X := escapeEqTerm RA H) ;
+    try (let X := fresh "R" H in pose proof (X := escapeEqTerm RA H)) ;
+    try (let X := fresh "Rl" H in pose proof (X := escapeTerm RA H)) ;
+    try (sym_escape RA H) ;
     block H
   end; unblock.

--- a/theories/LogicalRelation/Id.v
+++ b/theories/LogicalRelation/Id.v
@@ -1,38 +1,12 @@
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Notations Utils BasicAst Context NormalForms Weakening GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Irrelevance Weakening Neutral Escape Reflexivity NormalRed Reduction Transitivity Universe.
+From LogRel.LogicalRelation Require Import Induction Escape Irrelevance Weakening Neutral Reflexivity NormalRed Reduction Transitivity Universe EqRedRight.
 
 Set Universe Polymorphism.
 Set Printing Primitive Projection Parameters.
 
 Section IdRed.
   Context `{GenericTypingProperties}.
-
-  Lemma mkIdRedTy {Γ l A} :
-    forall (ty lhs rhs  : term)
-      (tyRed : [Γ ||-<l> ty]),
-      [Γ |- A :⤳*: tId ty lhs rhs] ->
-      [tyRed | Γ ||- lhs : _] ->
-      [tyRed | Γ ||- rhs : _] ->
-      [Γ ||-Id<l> A].
-  Proof.
-    intros; unshelve econstructor; cycle 3; tea.
-    1: intros; now eapply wk.
-    2,3: now eapply reflLRTmEq.
-    2: apply perLRTmEq.
-    - eapply  convty_Id. 
-      1: eapply escapeEq; now eapply reflLRTyEq.
-      1,2: eapply escapeEqTerm; now eapply reflLRTmEq.
-    - cbn; intros; irrelevance0; [|now eapply wkEq].
-      bsimpl; rewrite H11; now bsimpl.
-      Unshelve. all:tea.
-    - cbn; intros; irrelevance0; [| now eapply wkTerm].
-      bsimpl; rewrite H11; now bsimpl.
-      Unshelve. all:tea.
-    - cbn; intros; irrelevance0; [| now eapply wkTermEq].
-      bsimpl; rewrite H11; now bsimpl.
-      Unshelve. all:tea.
-  Defined.
 
   Lemma IdRed0 {Γ l A t u} (RA : [Γ ||-<l> A]) :
       [RA | Γ ||- t : _] ->
@@ -43,20 +17,20 @@ Section IdRed.
     1: eapply redtywf_refl; escape; gen_typing.
     all: tea.
   Defined.
-  
+
   Lemma IdRed {Γ l A t u} (RA : [Γ ||-<l> A]) :
       [RA | Γ ||- t : _] ->
       [RA | Γ ||- u : _] ->
       [Γ ||-<l> tId A t u].
   Proof. intros; apply LRId'; now eapply IdRed0. Defined.
-  
+
   Lemma IdRedTy_inv {Γ l A t u} (RIA : [Γ ||-Id<l> tId A t u]) :
     [× A = RIA.(IdRedTy.ty), t = RIA.(IdRedTy.lhs) & u = RIA.(IdRedTy.rhs)].
   Proof.
     pose proof (redtywf_whnf RIA.(IdRedTy.red) whnf_tId) as e; injection e; now split.
   Qed.
 
-  Lemma IdCongRed {Γ l A A' t t' u u'} 
+  Lemma IdCongRed {Γ l A A' t t' u u'}
     (RA : [Γ ||-<l> A])
     (RIA : [Γ ||-<l> tId A t u]) :
     [Γ |- tId A' t' u'] ->
@@ -74,70 +48,60 @@ Section IdRed.
     + irrelevance.
     + cbn; rewrite <- elhs; irrelevance.
     + cbn; rewrite <- erhs; irrelevance.
-  Qed. 
-    
-  Lemma IdRedU@{i j k l} {Γ l A t u}
+  Qed.
+
+  (* Lemma IdRedU@{i j k l} {Γ l A t u}
       (RU : [LogRel@{i j k l} l | Γ ||- U])
       (RU' := invLRU RU)
       (RA : [LogRel@{i j k l} (URedTy.level RU') | Γ ||- A]) :
-      [RU | Γ ||- A : U] ->
-      [RA | Γ ||- t : _] ->
-      [RA | Γ ||- u : _] ->
+      [RU | Γ ||- A ≅ A' : U] ->
+      [RA | Γ ||- t ≅ t': _] ->
+      [RA | Γ ||- u ≅: _] ->
       [RU | Γ ||- tId A t u : U].
   Proof.
     intros RAU Rt Ru.
     enough [LRU_ RU' | _ ||- tId A t u : U] by irrelevance.
     econstructor.
-    - eapply redtmwf_refl; escape; now eapply ty_Id.
+    (* - eapply redtmwf_refl; escape; now eapply ty_Id. *)
     - constructor.
     - eapply convtm_Id; eapply escapeEq + eapply escapeEqTerm; now eapply reflLRTmEq + eapply reflLRTyEq.
     - eapply RedTyRecBwd. eapply IdRed; irrelevanceCum.
     Unshelve. irrelevanceCum.
-  Qed.
-  
-  Lemma IdCongRedU@{i j k l} {Γ l A A' t t' u u'} 
+  Qed. *)
+
+  Lemma IdCongRedU@{i j k l} {Γ l A A' t t' u u'}
       (RU : [LogRel@{i j k l} l | Γ ||- U])
       (RU' := invLRU RU)
-      (RA : [LogRel@{i j k l} (URedTy.level RU') | Γ ||- A])
-      (RA' : [LogRel@{i j k l} (URedTy.level RU') | Γ ||- A']) :
+      (RA : [LogRel@{i j k l} (URedTy.level RU') | Γ ||- A]) :
     [RU | Γ ||- A : U] ->
-    [RU | Γ ||- A' : U] ->
     [RU | _ ||- A ≅ A' : U] ->
-    [RA | _ ||- t : _] ->
-    [RA' | _ ||- t' : _] ->
     [RA | _ ||- t ≅ t' : _] ->
-    [RA | _ ||- u : _] ->
-    [RA' | _ ||- u' : _] ->
     [RA | _ ||- u ≅ u' : _] ->
     [RU | _ ||- tId A t u ≅ tId A' t' u' : U].
   Proof.
-    intros RAU RAU' RAAU' Rt Rt' Rtt' Ru Ru' Ruu'.
+    intros RAU RAAU' Rtt' Ruu'.
     enough [LRU_ RU' | _ ||- tId A t u ≅ tId A' t' u': U] by irrelevance.
-    opector.
-    - change [LRU_ RU' | _ ||- tId A t u : _].
-      enough [RU | _ ||- tId A t u : _] by irrelevance. 
-      now unshelve eapply IdRedU.
-    - change [LRU_ RU' | _ ||- tId A' t' u' : _]. 
-      enough [RU | _ ||- tId A' t' u' : _] by irrelevance. 
-      now unshelve eapply IdRedU.
-    - eapply RedTyRecBwd. eapply IdRed; irrelevanceCum.
-      Unshelve. clear dependent RA'; irrelevanceCum.
+    assert (hAA' : [RA | _ ||- A ≅ A']).
+    1: unshelve eapply UnivEqEq; try irrelevance + irrelevanceCum0.
+    escape. opector.
+    1,2: eexists (tId _ _ _); [eapply redtmwf_refl; gen_typing| constructor].
+    - eapply RedTyRecBwd; unshelve eapply IdRed.
+      all: try eapply lrefl; irrelevanceCum.
     - pose proof (redtmwf_whnf (URedTm.red u0) whnf_tId) as <-.
       pose proof (redtmwf_whnf (URedTm.red u1) whnf_tId) as <-.
-      eapply convtm_Id; now escape.
-    - eapply RedTyRecBwd. eapply IdRed; irrelevanceCum.
-      Unshelve. irrelevanceCum.
+      now eapply convtm_Id.
+    - eapply RedTyRecBwd; unshelve eapply IdRed.
+      1: unshelve eapply UnivEq; [| |irrelevanceCum0| symmetry; irrelevanceCum].
+      all: eapply urefl; eapply LRTmEqConv; tea.
     - eapply TyEqRecFwd.
-      eapply LRTyEqIrrelevantCum.
-      unshelve eapply IdCongRed; tea.
-      + escape; gen_typing.
-      + now eapply UnivEqEq.
-      Unshelve. now eapply IdRed.
+      unshelve eapply LRTyEqIrrelevantCum.
+      2: eapply RedTyRecFwd in l0 ; irrelevanceCum.
+      unshelve eapply IdCongRed; tea; gen_typing.
   Qed.
 
 
 
-Lemma reflRed {Γ l A x} (RA : [Γ ||-<l> A]) (Rx : [RA | _ ||- x : _]) (RIA : [Γ ||-<l> tId A x x]) :
+(* Lemma reflRed {Γ l A x} (RA : [Γ ||-<l> A]) (Rx : [RA | _ ||- x : _]) (RIA : [Γ ||-<l> tId A x x]) :
   [RIA | _ ||- tRefl A x : _].
 Proof.
   set (RIA' := invLRId RIA).
@@ -157,374 +121,162 @@ Proof.
   Unshelve.  all: tea.
 Qed.
 
-Lemma reflRed' {Γ l A x} (RA : [Γ ||-<l> A]) (Rx : [RA | _ ||- x : _]) 
+Lemma reflRed' {Γ l A x} (RA : [Γ ||-<l> A]) (Rx : [RA | _ ||- x : _])
   (RIA := IdRed RA Rx Rx): [RIA | _ ||- tRefl A x : _].
-Proof. now eapply reflRed. Qed.
+Proof. now eapply reflRed. Qed. *)
 
-
-Lemma reflCongRed {Γ l A A' x x'} 
+Lemma reflCongRed {Γ l A A' x x'}
   (RA : [Γ ||-<l> A])
-  (TA' : [Γ |- A'])
-  (RAA' : [RA | _ ||- _ ≅ A'])
-  (Rx : [RA | _ ||- x : _]) 
-  (Tx' : [Γ |- x' : A'])
-  (Rxx' : [RA | _ ||- x ≅ x' : _]) 
+  (RAA : [RA | _ ||- _ ≅ A'])
+  (Rxx : [RA | _ ||- x ≅ x' : _])
   (RIA : [Γ ||-<l> tId A x x]) :
   [RIA | _ ||- tRefl A x ≅ tRefl A' x' : _].
 Proof.
-  set (RIA' := invLRId RIA).
-  enough [LRId' RIA' | _ ||- tRefl A x ≅ tRefl A' x' : _] by irrelevance.
-  pose proof (IdRedTy_inv RIA') as [eA ex ex'].
-  assert (e : tId (IdRedTy.ty RIA') (IdRedTy.lhs RIA') (IdRedTy.rhs RIA') = tId A x x).
-  1: f_equal; now symmetry.
-  assert [Γ |- tId A x x ≅ tId A' x' x'] by (escape ; gen_typing).
-  econstructor; unfold_id_outTy; cbn; rewrite ?e.
-  1,2: eapply redtmwf_refl.
-  1: escape; gen_typing.
-  - eapply ty_conv; [| now symmetry]; now eapply ty_refl.
-  - eapply convtm_refl; now escape.
-  - constructor; cbn.
-    1-4: now escape.  
-    all: irrelevance0; tea.
-    1: apply reflLRTyEq.
-    1,2: rewrite <- ex; tea; now eapply reflLRTmEq.
-    1,2: rewrite <- ex'; tea; now eapply reflLRTmEq.
-  Unshelve. all: tea.
+  set (RIA' := normRedId RIA).
+  enough [RIA' | _ ||- tRefl A x ≅ tRefl A' x' : _] by irrelevance.
+  escape.
+  assert [Γ |- tId A' x' x' ≅ tId A x x] by (symmetry; timeout 1 gen_typing).
+  (* assert [Γ |- tId Ar xr xr ≅ tId A x x] by (symmetry; timeout 1 gen_typing). *)
+  exists (tRefl A x) (tRefl A' x').
+  1,2: eapply redtmwf_refl; unfold_id_outTy; cbn.
+  1: gen_typing.
+  1: eapply ty_conv; [|tea]; gen_typing.
+  1:  unfold_id_outTy; cbn; timeout 1 gen_typing.
+  constructor; tea.
+  1: eapply ty_conv; tea.
+  all: try irrelevance.
+  2,3: eapply lrefl; cbn; irrelevance.
+  eapply reflLRTyEq.
 Qed.
 
-Definition idElimProp {Γ l} (A x P hr y e : term) {IA : [Γ ||-Id<l> tId A x y]} (Pe : IdProp IA e) : term :=
-  match Pe with
-  | IdRedTm.reflR _ _ _ _ _ => hr
-  | IdRedTm.neR _ => tIdElim A x P hr y e
-  end.
 
-Lemma idElimPropIrr {Γ l} {A x P hr y e : term} {IA : [Γ ||-Id<l> tId A x y]} (Pe Pe' : IdProp IA e) :
-  idElimProp A x P hr y e Pe = idElimProp A x P hr y e Pe'.
-Proof.
-  destruct Pe; cbn.
-  2: dependent inversion Pe'; try reflexivity.
-  2:  subst; match goal with H : [_ ||-NeNf _ : _] |- _ => destruct H as [_ ?%convneu_whne]; inv_whne end; tea.
-  refine (match Pe' as Pe0  in IdRedTm.IdProp _ e return match e as e return IdProp _ e -> Type with | tRefl A0 x0 => fun Pe0 => hr = idElimProp A x P hr y (tRefl A0 x0) Pe0 | _ => fun _ => unit end Pe0 with | IdRedTm.reflR _ _ _ _ _ => _ | IdRedTm.neR r  => _ end).
-  1: reflexivity.
-  1: match type of r with [_ ||-NeNf ?t : _] =>  destruct t ; try easy end. 
-  exfalso; destruct r as [_ ?%convneu_whne]; inv_whne.
-Qed.
-
-Lemma IdProp_refl_inv {Γ l A x y A' x'} {IA : [Γ ||-Id<l> tId A x y]} (Pe : IdProp IA (tRefl A' x')) :
-  IdProp IA (tRefl A' x').
-Proof.
-  econstructor; inversion Pe.
-  all: try match goal with H : [_ ||-NeNf _ : _] |- _ => destruct H as [_ ?%convneu_whne]; inv_whne end; tea.
-Defined.
-
-Lemma IdRedTm_whnf_prop {Γ l A x y e} {IA : [Γ ||-Id<l> tId A x y]} (Re : [_ ||-Id<l> e : _ | IA]) :
-  whnf e -> IdProp IA e.
-Proof.
-  intros wh; rewrite (redtmwf_whnf (IdRedTm.red Re) wh).
-  exact (IdRedTm.prop Re).
-Qed.
-
-Lemma idElimPropRed {Γ l A x P hr y e}
+Lemma reflCongRed' {Γ l A Al Ar x xl xr}
   (RA : [Γ ||-<l> A])
-  (Rx : [RA | _ ||- x : _])
-  (RP0 : [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) ||-<l> P])
-  (RP : forall y e (Ry : [RA | Γ ||- y : _]) (RIAxy : [Γ ||-<l> tId A x y]),
-    [ RIAxy | _ ||- e : _] -> [Γ ||-<l> P[e .: y..]])
-  (RPeq : forall A' x' y y' e e' 
-    (RA' : [Γ ||-<l> A'])
-    (RAA' : [RA | _ ||- _ ≅ A'])
-    (Rx' : [RA | _ ||- x' : _])
-    (Rxx' : [RA | _ ||- x ≅ x' : _])
-    (Ry : [RA | Γ ||- y : _])
-    (Ry' : [RA' | _ ||- y' : _])
-    (Ryy' : [RA | Γ ||- y ≅ y' : _])
-    (RIAxy : [Γ ||-<l> tId A x y])
-    (RIAxy' : [Γ ||-<l> tId A x y'])
-    (Re : [ RIAxy | _ ||- e : _])
-    (Re' : [ RIAxy' | _ ||- e' : _])
-    (Ree' : [ RIAxy | _ ||- e ≅ e' : _]),
-    [RP y e Ry RIAxy Re | Γ ||- P[e .: y..] ≅ P[e' .: y' ..]])
-  (Rhr : [RP x (tRefl A x) Rx (IdRed RA Rx Rx) (reflRed' RA Rx) | _ ||- hr : _])
-  (Ry : [RA | _ ||- y : _])
-  (RIAxy : [Γ ||-<l> tId A x y])
-  (Re : [RIAxy | _ ||- e : _]) 
-  (RIAxy0 : [Γ ||-Id<l> tId A x y])
-  (Pe : IdProp RIAxy0 e) :
-  [RP y e Ry _ Re | _ ||- tIdElim A x P hr y e : _] ×
-  [RP y e Ry _ Re | _ ||- tIdElim A x P hr y e ≅ idElimProp A x P hr y e Pe : _].
-Proof.
-  pose proof (IdRedTy_inv RIAxy0) as [eA ex ey].
-  eapply redSubstTerm.
-  - destruct Pe; cbn in *.
-    + eapply LRTmRedConv; tea.
-      unshelve eapply RPeq; cycle 3; tea.
-      2,3: eapply transEqTerm; [|eapply LRTmEqSym]; rewrite ?ex, ?ey; irrelevance.
-      * eapply reflLRTyEq.
-      * eapply reflCongRed; tea.
-        1: irrelevance0; [symmetry; tea|]; tea.
-        rewrite ex; irrelevance.
-    + eapply neuTerm.
-      * escape; eapply ty_IdElim; tea.
-      * destruct r.
-        pose proof (reflLRTyEq RA).
-        pose proof (reflLRTyEq RP0).
-        pose proof Rx as ?%reflLRTmEq.
-        pose proof Ry as ?%reflLRTmEq.
-        pose proof Rhr as ?%reflLRTmEq.
-        escape; eapply convneu_IdElim; tea.
-        eapply convneu_conv; tea. unfold_id_outTy.
-        rewrite <- eA, <- ex, <- ey; eapply convty_Id; tea.
-  - destruct Pe; cbn in *.
-    + escape; eapply redtm_idElimRefl; tea.
-      * eapply ty_conv; tea; rewrite eA; now symmetry.
-      * now rewrite eA.
-      * rewrite eA, ex, ey; etransitivity; tea; now symmetry.
-      * now rewrite eA, ex.
-    + eapply redtm_refl; escape; now eapply ty_IdElim.
-Qed.
-
-
-Lemma idElimRed {Γ l A x P hr y e}
-  (RA : [Γ ||-<l> A])
-  (Rx : [RA | _ ||- x : _])
-  (RP0 : [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) ||-<l> P])
-  (RP : forall y e (Ry : [RA | Γ ||- y : _]) (RIAxy : [Γ ||-<l> tId A x y]),
-    [ RIAxy | _ ||- e : _] -> [Γ ||-<l> P[e .: y..]])
-  (RPeq : forall A' x' y y' e e' 
-    (RA' : [Γ ||-<l> A'])
-    (RAA' : [RA | _ ||- _ ≅ A'])
-    (Rx' : [RA | _ ||- x' : _])
-    (Rxx' : [RA | _ ||- x ≅ x' : _])
-    (Ry : [RA | Γ ||- y : _])
-    (Ry' : [RA' | _ ||- y' : _])
-    (Ryy' : [RA | Γ ||- y ≅ y' : _])
-    (RIAxy : [Γ ||-<l> tId A x y])
-    (RIAxy' : [Γ ||-<l> tId A x y'])
-    (Re : [ RIAxy | _ ||- e : _])
-    (Re' : [ RIAxy' | _ ||- e' : _])
-    (Ree' : [ RIAxy | _ ||- e ≅ e' : _]),
-    [RP y e Ry RIAxy Re | Γ ||- P[e .: y..] ≅ P[e' .: y' ..]])
-  (Rhr : [RP x (tRefl A x) Rx (IdRed RA Rx Rx) (reflRed' RA Rx) | _ ||- hr : _])
-  (Ry : [RA | _ ||- y : _])
-  (RIAxy : [Γ ||-<l> tId A x y])
-  (RIAxy' := LRId' (invLRId RIAxy))
-  (Re : [RIAxy' | _ ||- e : _]) :
-  [RP y e Ry _ Re | _ ||- tIdElim A x P hr y e : _] ×
-  [RP y e Ry _ Re | _ ||- tIdElim A x P hr y e ≅ tIdElim A x P hr y (IdRedTm.nf Re) : _].
-Proof.
-  pose proof (IdRedTy_inv (invLRId RIAxy)) as [eA ex ey].
-  pose proof (hred := Re.(IdRedTm.red)); unfold_id_outTy; rewrite <-eA,<-ex,<-ey in hred.
-  eapply redSubstTerm.
-  - pose proof (redTmFwdConv Re hred (IdProp_whnf _ _ (IdRedTm.prop Re))) as [Rnf Rnfeq].
-    eapply LRTmRedConv.
-    2: eapply idElimPropRed; tea; exact (IdRedTm.prop Re).
-    unshelve eapply LRTyEqSym.
-    2: now eapply RP.
-    eapply RPeq; cycle 2; first [eapply reflLRTyEq | now eapply reflLRTmEq | tea].
-    Unshelve. all: tea.
-  - escape; eapply redtm_idElim; tea; apply hred.
-Qed.
+  (RAAl : [RA | _ ||- _ ≅ Al])
+  (RAAr : [RA | _ ||- _ ≅ Ar])
+  (Rxxl : [RA | _ ||- x ≅ xl : _])
+  (Rxxr : [RA | _ ||- x ≅ xr : _])
+  (RIA : [Γ ||-<l> tId A x x]) :
+  [RIA | _ ||- tRefl Al xl ≅ tRefl Ar xr : _].
+Proof. etransitivity; [symmetry|]; now eapply reflCongRed. Qed.
 
 
 Lemma idElimPropCongRed {Γ l A A' x x' P P' hr hr' y y' e e'}
   (RA : [Γ ||-<l> A])
   (RA' : [Γ ||-<l> A'])
   (RAA' : [RA | Γ ||- A ≅ A'])
-  (Rx : [RA | _ ||- x : _])
-  (Rx' : [RA' | _ ||- x' : _])
   (Rxx' : [RA | _ ||- x ≅ x' : _])
-  (RP0 : [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) ||-<l> P])
-  (RP0' : [Γ ,, A' ,, tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0) ||-<l> P'])
-  (RPP0 : [RP0 | _ ||- _ ≅ P'])
-  (RP : forall y e (Ry : [RA | Γ ||- y : _]) (RIAxy : [Γ ||-<l> tId A x y]),
-    [ RIAxy | _ ||- e : _] -> [Γ ||-<l> P[e .: y..]])
-  (RP' : forall y' e' (Ry' : [RA' | Γ ||- y' : _]) (RIAxy' : [Γ ||-<l> tId A' x' y']),
-    [ RIAxy' | _ ||- e' : _] -> [Γ ||-<l> P'[e' .: y'..]])
-  (RPP' : forall y y' e e' 
-    (Ry : [RA | Γ ||- y : _])
-    (Ry' : [RA' | Γ ||- y' : _])
+  (RIAxx : [Γ ||-<l> tId A x x])
+  (RP0 : [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P])
+  (RP0' : [Γ ,, A' ,, tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0) |- P'])
+  (RPP0 : [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P ≅ P'])
+  (RP : forall {y y' e e'} (Ryy' : [RA | Γ ||- y ≅ y' : _]) {RIAxy : [Γ ||-<l> tId A x y]},
+    [ RIAxy | _ ||- e ≅ e' : _] -> [Γ ||-<l> P[e .: y..]])
+  (RPP' : forall y y' e e'
     (Ryy' : [RA | _ ||- y ≅ y' : _])
     (RIAxy : [Γ ||-<l> tId A x y])
-    (RIAxy' : [Γ ||-<l> tId A' x' y'])
-    (Re : [ RIAxy | _ ||- e : _])
-    (Re' : [ RIAxy' | _ ||- e' : _])
     (Ree' : [ RIAxy | _ ||- e ≅ e' : _]),
-    [RP y e Ry _ Re | _ ||- P[e .: y..] ≅ P'[e' .: y'..]])
-  (RPeq : forall A' x' y y' e e' 
-    (RA' : [Γ ||-<l> A'])
+    [RP Ryy' Ree' | _ ||- P[e .: y..] ≅ P'[e' .: y'..]])
+  (RPeq : forall A' x' y y' e e'
     (RAA' : [RA | _ ||- _ ≅ A'])
-    (Rx' : [RA | _ ||- x' : _])
     (Rxx' : [RA | _ ||- x ≅ x' : _])
-    (Ry : [RA | Γ ||- y : _])
-    (Ry' : [RA' | _ ||- y' : _])
     (Ryy' : [RA | Γ ||- y ≅ y' : _])
     (RIAxy : [Γ ||-<l> tId A x y])
-    (RIAxy' : [Γ ||-<l> tId A x y'])
-    (Re : [ RIAxy | _ ||- e : _])
-    (Re' : [ RIAxy' | _ ||- e' : _])
     (Ree' : [ RIAxy | _ ||- e ≅ e' : _]),
-    [RP y e Ry RIAxy Re | Γ ||- P[e .: y..] ≅ P[e' .: y' ..]])
-  (RPeq' : forall A1 x1 y' y1 e' e1 
-    (RA1 : [Γ ||-<l> A1])
-    (RAA1 : [RA' | _ ||- _ ≅ A1])
-    (Rx1 : [RA' | _ ||- x1 : _])
-    (Rxx1 : [RA' | _ ||- x' ≅ x1 : _])
-    (Ry' : [RA' | Γ ||- y' : _])
-    (Ry1 : [RA1 | _ ||- y1 : _])
-    (Ryy1 : [RA' | Γ ||- y' ≅ y1 : _])
-    (RIAxy' : [Γ ||-<l> tId A' x' y'])
-    (RIAxy1 : [Γ ||-<l> tId A' x' y1])
-    (Re' : [ RIAxy' | _ ||- e' : _])
-    (Re1 : [ RIAxy1 | _ ||- e1 : _])
-    (Ree1 : [ RIAxy' | _ ||- e' ≅ e1 : _]),
-    [RP' y' e' Ry' RIAxy' Re' | Γ ||- P'[e' .: y'..] ≅ P'[e1 .: y1 ..]])
-  (Rhr : [RP x (tRefl A x) Rx (IdRed RA Rx Rx) (reflRed' RA Rx) | _ ||- hr : _])
-  (Rhr' : [RP' x' (tRefl A' x') Rx' (IdRed RA' Rx' Rx') (reflRed' RA' Rx') | _ ||- hr' : _])
-  (Rhrhr' : [RP x (tRefl A x) Rx (IdRed RA Rx Rx) (reflRed' RA Rx) | _ ||- hr ≅ hr' : _])
-  (Ry : [RA | _ ||- y : _])
-  (Ry' : [RA' | _ ||- y' : _])
+    [RP Ryy' Ree' | Γ ||- P[e .: y..] ≅ P[e' .: y' ..]])
+  (Rhrhr' : [RP Rxx' (reflCongRed RA RAA' Rxx' RIAxx) | _ ||- hr ≅ hr' : _])
   (Ryy' : [RA | _ ||- y ≅ y' : _])
   (RIAxy : [Γ ||-<l> tId A x y])
-  (RIAxy' : [Γ ||-<l> tId A' x' y'])
-  (Re : [RIAxy | _ ||- e : _]) 
-  (Re' : [RIAxy' | _ ||- e' : _]) 
   (Ree' : [RIAxy | _ ||- e ≅ e' : _])
-  (RIAxy0 : [Γ ||-Id<l> tId A x y])
-  (Pee' : IdPropEq RIAxy0 e e') :
-  [RP y e Ry _ Re | _ ||- tIdElim A x P hr y e ≅ tIdElim A' x' P' hr' y' e' : _].
+  (Pee' : IdPropEq (normRedId0 (invLRId RIAxy)) e e') :
+  [RP Ryy' Ree' | _ ||- tIdElim A x P hr y e ≅ tIdElim A' x' P' hr' y' e' : _].
 Proof.
-  pose proof (IdRedTy_inv RIAxy0) as [eA ex ey].
-  (* pose proof (IdRedTy_inv (invLRId RIAxy))) as [eA ex ey].
-  pose proof (IdRedTy_inv (invLRId RIAxy')) as [eA' ex' ey']. *)
-  pose proof (IdPropEq_whnf _ _ _ Pee') as [whe whe'].
-  assert (Rei : [LRId' RIAxy0 | _ ||- e : _]) by irrelevance.
-  assert (Rei' : [LRId' (invLRId RIAxy') | _ ||- e' : _]) by irrelevance.
-  pose proof (IdRedTm_whnf_prop Rei whe).
-  pose proof (IdRedTm_whnf_prop Rei' whe').
-  eapply LREqTermHelper.
-  1,2: unshelve eapply idElimPropRed; tea.
-  1: now eapply RPP'.
-  destruct Pee'; cbn in *.
-  + unshelve erewrite (idElimPropIrr X), (idElimPropIrr X0).
-    1,2: now eapply IdProp_refl_inv.
-    cbn; eapply LRTmEqRedConv; tea.
-    eapply RPeq; cycle 3; tea.
-    1,4: rewrite ex, ey; eapply transEqTerm; [|eapply LRTmEqSym]; irrelevance.
-    2: eapply reflLRTyEq.
-    eapply reflCongRed; tea.
-    1: irrelevance.
-    rewrite ex; irrelevance.
-  + unshelve erewrite (idElimPropIrr X), (idElimPropIrr X0); destruct r; unfold_id_outTy.
-    * econstructor; escape ; constructor; unfold_id_outTy.
-      1: rewrite <- ex, <- ey, <-eA; tea.
-      now eapply lrefl.
-    * econstructor; pose proof (IdRedTy_inv (invLRId RIAxy')) as [eA' ex' ey'].
-      escape; constructor; unfold_id_outTy.
-      all: rewrite <- ex', <- ey', <-eA'; tea.
-      eapply convneu_conv; [now eapply urefl|].
-      rewrite <- ex, <- ey, <-eA; now eapply convty_Id.
-    * cbn. escape; eapply neuTermEq.
-      - now eapply ty_IdElim.
-      - eapply ty_conv; [now eapply ty_IdElim|].
-        symmetry; eapply escapeEq; now eapply RPP'.
-        Unshelve. all: tea.
-      - eapply convneu_IdElim; tea.
-        now rewrite ex, ey, eA.
+  pose proof (RPP' _ _ _ _ Rxx' _ (reflCongRed RA RAA' Rxx' RIAxx)).
+  pose proof (RPP' _ _ _ _ Ryy' _ Ree').
+  destruct Pee'; cbn in *; escape.
+  - eapply redSubstTmEq; cycle 1.
+    + eapply redtm_idElimRefl; tea.
+      transitivity x'0; [|symmetry]; tea.
+    + eapply redtm_idElimRefl; tea.
+      1-4: eapply ty_conv; tea.
+      1: transitivity A; tea; now symmetry.
+      2: eapply convtm_conv; tea; transitivity x; tea; now symmetry.
+      eapply convtm_conv; tea.
+      transitivity y; tea.
+      transitivity x0; symmetry; tea.
+      transitivity x; tea. now symmetry.
+    + unshelve eapply escapeEq, RPP'; tea.
+    + eapply LRTmEqConv; tea.
+      irrelevanceRefl.
+      eapply RPeq; tea.
+      Unshelve.
+      * transitivity x0; [|symmetry]; irrelevance.
+      * tea.
+      * now eapply reflCongRed.
+  - eapply neuTermEq.
+    + now eapply ty_IdElim.
+    + eapply ty_conv; [|symmetry; tea].
+      eapply ty_IdElim; tea.
+      all: eapply ty_conv; tea.
+      now eapply convty_Id.
+    + eapply convneu_IdElim; tea.
+      destruct r; unfold_id_outTy; now cbn in *.
 Qed.
+
+
+
+
 
 Lemma idElimCongRed {Γ l A A' x x' P P' hr hr' y y' e e'}
   (RA : [Γ ||-<l> A])
   (RA' : [Γ ||-<l> A'])
   (RAA' : [RA | Γ ||- A ≅ A'])
-  (Rx : [RA | _ ||- x : _])
-  (Rx' : [RA' | _ ||- x' : _])
   (Rxx' : [RA | _ ||- x ≅ x' : _])
-  (RP0 : [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) ||-<l> P])
-  (RP0' : [Γ ,, A' ,, tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0) ||-<l> P'])
-  (RPP0 : [RP0 | _ ||- _ ≅ P'])
-  (RP : forall y e (Ry : [RA | Γ ||- y : _]) (RIAxy : [Γ ||-<l> tId A x y]),
-    [ RIAxy | _ ||- e : _] -> [Γ ||-<l> P[e .: y..]])
-  (RP' : forall y' e' (Ry' : [RA' | Γ ||- y' : _]) (RIAxy' : [Γ ||-<l> tId A' x' y']),
-    [ RIAxy' | _ ||- e' : _] -> [Γ ||-<l> P'[e' .: y'..]])
-  (RPP' : forall y y' e e' 
-    (Ry : [RA | Γ ||- y : _])
-    (Ry' : [RA' | Γ ||- y' : _])
+  (RIAxx : [Γ ||-<l> tId A x x])
+  (RP0 : [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P])
+  (RP0' : [Γ ,, A' ,, tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0) |- P'])
+  (RPP0 : [Γ ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P ≅ P'])
+  (RP : forall {y y' e e'} (Ryy' : [RA | Γ ||- y ≅ y' : _]) {RIAxy : [Γ ||-<l> tId A x y]},
+    [ RIAxy | _ ||- e ≅ e' : _] -> [Γ ||-<l> P[e .: y..]])
+  (RPP' : forall y y' e e'
     (Ryy' : [RA | _ ||- y ≅ y' : _])
     (RIAxy : [Γ ||-<l> tId A x y])
-    (RIAxy' : [Γ ||-<l> tId A' x' y'])
-    (Re : [ RIAxy | _ ||- e : _])
-    (Re' : [ RIAxy' | _ ||- e' : _])
     (Ree' : [ RIAxy | _ ||- e ≅ e' : _]),
-    [RP y e Ry _ Re | _ ||- P[e .: y..] ≅ P'[e' .: y'..]])
-  (RPeq : forall A' x' y y' e e' 
-    (RA' : [Γ ||-<l> A'])
+    [RP Ryy' Ree' | _ ||- P[e .: y..] ≅ P'[e' .: y'..]])
+  (RPeq : forall A' x' y y' e e'
     (RAA' : [RA | _ ||- _ ≅ A'])
-    (Rx' : [RA | _ ||- x' : _])
     (Rxx' : [RA | _ ||- x ≅ x' : _])
-    (Ry : [RA | Γ ||- y : _])
-    (Ry' : [RA' | _ ||- y' : _])
     (Ryy' : [RA | Γ ||- y ≅ y' : _])
     (RIAxy : [Γ ||-<l> tId A x y])
-    (RIAxy' : [Γ ||-<l> tId A x y'])
-    (Re : [ RIAxy | _ ||- e : _])
-    (Re' : [ RIAxy' | _ ||- e' : _])
     (Ree' : [ RIAxy | _ ||- e ≅ e' : _]),
-    [RP y e Ry RIAxy Re | Γ ||- P[e .: y..] ≅ P[e' .: y' ..]])
-  (RPeq' : forall A1 x1 y' y1 e' e1 
-    (RA1 : [Γ ||-<l> A1])
-    (RAA1 : [RA' | _ ||- _ ≅ A1])
-    (Rx1 : [RA' | _ ||- x1 : _])
-    (Rxx1 : [RA' | _ ||- x' ≅ x1 : _])
-    (Ry' : [RA' | Γ ||- y' : _])
-    (Ry1 : [RA1 | _ ||- y1 : _])
-    (Ryy1 : [RA' | Γ ||- y' ≅ y1 : _])
-    (RIAxy' : [Γ ||-<l> tId A' x' y'])
-    (RIAxy1 : [Γ ||-<l> tId A' x' y1])
-    (Re' : [ RIAxy' | _ ||- e' : _])
-    (Re1 : [ RIAxy1 | _ ||- e1 : _])
-    (Ree1 : [ RIAxy' | _ ||- e' ≅ e1 : _]),
-    [RP' y' e' Ry' RIAxy' Re' | Γ ||- P'[e' .: y'..] ≅ P'[e1 .: y1 ..]])
-  (Rhr : [RP x (tRefl A x) Rx (IdRed RA Rx Rx) (reflRed' RA Rx) | _ ||- hr : _])
-  (Rhr' : [RP' x' (tRefl A' x') Rx' (IdRed RA' Rx' Rx') (reflRed' RA' Rx') | _ ||- hr' : _])
-  (Rhrhr' : [RP x (tRefl A x) Rx (IdRed RA Rx Rx) (reflRed' RA Rx) | _ ||- hr ≅ hr' : _])
-  (Ry : [RA | _ ||- y : _])
-  (Ry' : [RA' | _ ||- y' : _])
+    [RP Ryy' Ree' | Γ ||- P[e .: y..] ≅ P[e' .: y' ..]])
+  (Rhrhr' : [RP Rxx' (reflCongRed RA RAA' Rxx' RIAxx) | _ ||- hr ≅ hr' : _])
   (Ryy' : [RA | _ ||- y ≅ y' : _])
   (RIAxy : [Γ ||-<l> tId A x y])
-  (RIAxy' : [Γ ||-<l> tId A' x' y'])
-  (Re : [RIAxy | _ ||- e : _]) 
-  (Re' : [RIAxy' | _ ||- e' : _]) 
-  (Ree' : [RIAxy | _ ||- e ≅ e' : _])  :
-  [RP y e Ry _ Re | _ ||- tIdElim A x P hr y e ≅ tIdElim A' x' P' hr' y' e' : _].
+  (Ree' : [RIAxy | _ ||- e ≅ e' : _]) :
+  [RP Ryy' Ree' | _ ||- tIdElim A x P hr y e ≅ tIdElim A' x' P' hr' y' e' : _].
 Proof.
-  pose proof (IdRedTy_inv (invLRId RIAxy)) as [eA ex ey].
-  assert (RIAxyeq : [RIAxy | _ ||- _ ≅ tId A' x' y']) by (escape; now eapply IdCongRed).
-  assert (Req : [LRId' (invLRId RIAxy) | _ ||- e ≅ e' : _]) by irrelevance.
-  cbn in Req; inversion Req; unfold_id_outTy.
-  pose proof redL as [? _]; pose proof redR as [? _].
-  rewrite <-eA,<-ex,<-ey in redL, redR.
-  pose proof (IdPropEq_whnf _ _ _ prop) as [whL whR].
-  pose proof (redTmFwdConv Re redL whL) as [RnfL RnfLeq].
-  unshelve epose proof (redTmFwdConv Re' _ whR) as [RnfR RnfReq].
-  1: eapply redtmwf_conv; tea; now escape.
-  eapply LREqTermHelper; cycle -1.
-  - eapply LRTmEqRedConv.
-    2: eapply idElimPropCongRed.
-    16: exact prop.
-    all: tea.
-    1: eapply RPeq; cycle 2; first [now eapply reflLRTmEq | now eapply LRTmEqSym| eapply reflLRTyEq| tea].
-    enough [LRId' (invLRId RIAxy) | _ ||- nfL ≅ nfR : _] by irrelevance.
-    exists nfL nfR; tea; eapply redtmwf_refl; unfold_id_outTy; tea.
-  - assert (Re1 : [LRId' (invLRId RIAxy) | _ ||- e : _]) by irrelevance.
-    rewrite (redtmwf_det whL (IdProp_whnf _ _ Re1.(IdRedTm.prop)) redL Re1.(IdRedTm.red)).
-    irrelevanceRefl; eapply idElimRed; tea.
-  - assert (Re1' : [LRId' (invLRId RIAxy') | _ ||- e' : _]) by irrelevance.
-    rewrite (redtmwf_det whR (IdProp_whnf _ _ Re1'.(IdRedTm.prop)) redR Re1'.(IdRedTm.red)).
-    irrelevanceRefl; eapply idElimRed; tea.
-    Unshelve. 
-    all: tea.
-    now eapply RP'.
-  - now eapply RPP'.
+  assert (nRee' : [normRedId RIAxy | Γ ||- e ≅ e' : _]) by irrelevance.
+  destruct nRee' as [nfL nfR ??? prop]; unfold_id_outTy; cbn in *.
+  pose proof (RPP' _ _ _ _ Rxx' _ (reflCongRed RA RAA' Rxx' RIAxx)).
+  pose proof (RPP' _ _ _ _ Ryy' _ Ree').
+  pose proof (IdPropEq_whnf _ _ _ prop) as [].
+  assert (RenfL : [RIAxy | _ ||- e ≅ nfL : _]).
+  1: symmetry; eapply redTmEqFwd; tea; now eapply lrefl.
+  assert (RnfLR : [RIAxy | _ ||- nfL ≅ nfR : _])
+  by (eapply redTmEqFwdBoth; cycle 1; tea).
+  assert (Ryy : [RA | _ ||- y ≅ y : _]) by now eapply lrefl.
+  pose proof (RAA := reflLRTyEq RA).
+  pose proof (RPeq _ _ _ _ _ _ RAA Rxx' Ryy _ RenfL).
+  escape.
+  assert [Γ |- tId A x y ≅ tId A' x' y'] by gen_typing.
+  eapply redSubstTmEq; cycle 1; tea.
+  1,2: eapply redtm_idElim; tea.
+  1: gen_typing.
+  1-3: now eapply ty_conv.
+  1: eapply redtm_conv; tea; gen_typing.
+  eapply LRTmEqConv. 1: now eapply LRTyEqSym.
+  now unshelve eapply idElimPropCongRed.
 Qed.
 
 End IdRed.

--- a/theories/LogicalRelation/Induction.v
+++ b/theories/LogicalRelation/Induction.v
@@ -27,16 +27,16 @@ Section Inductions.
 
 (** Reducibility at a lower level implies reducibility at a higher level, and their decoding are the
 same. Both need to be proven simultaneously, because of contravariance in the product case. *)
-  
+
   Fixpoint LR_embedding@{i j k l} {l l'} (l_ : l << l')
-    {Γ A rEq rTe rTeEq} (lr : LogRel@{i j k l} l Γ A rEq rTe rTeEq) {struct lr} 
-    : (LogRel@{i j k l} l' Γ A rEq rTe rTeEq) :=
+    {Γ A rEq rTeEq} (lr : LogRel@{i j k l} l Γ A rEq rTeEq) {struct lr}
+    : (LogRel@{i j k l} l' Γ A rEq rTeEq) :=
     let embedPolyAd {Γ A B} {PA : PolyRedPack Γ A B} (PAad : PolyRedPackAdequate _ PA) :=
         {|
           PolyRedPack.shpAd (Δ : context) (ρ : Δ ≤ _) (h : [  |- Δ]) :=
             LR_embedding l_ (PAad.(PolyRedPack.shpAd) ρ h) ;
-          PolyRedPack.posAd (Δ : context) (a : term) (ρ : Δ ≤ _) (h : [  |- Δ])
-              (ha : [PolyRedPack.shpRed PA ρ h | Δ ||- a : _]) :=
+          PolyRedPack.posAd (Δ : context) (a b : term) (ρ : Δ ≤ _) (h : [  |- Δ])
+              (ha : [PolyRedPack.shpRed PA ρ h | Δ ||- a ≅ b : _]) :=
             LR_embedding l_ (PAad.(PolyRedPack.posAd) ρ h ha)
         |}
     in
@@ -50,11 +50,11 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     | LRNat _ NA => LRNat _ NA
     | LREmpty _ NA => LREmpty _ NA
     | LRSig _ PA PAad => LRSig _ PA (embedPolyAd PAad)
-    | LRId _ IA IAad => 
-      let embedIdAd := 
+    | LRId _ IA IAad =>
+      let embedIdAd :=
         {| IdRedTyPack.tyAd := LR_embedding l_ IAad.(IdRedTyPack.tyAd) ;
           IdRedTyPack.tyKripkeAd (Δ : context) (ρ : Δ ≤ _) (wfΔ : [  |- Δ]) :=
-            LR_embedding l_ (IAad.(IdRedTyPack.tyKripkeAd) ρ wfΔ) |} 
+            LR_embedding l_ (IAad.(IdRedTyPack.tyKripkeAd) ρ wfΔ) |}
       in LRId _ IA embedIdAd
     end.
 
@@ -62,22 +62,22 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
 
   Notation PolyHyp P Γ ΠA HAad G :=
     ((forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ]), P (HAad.(PolyRedPack.shpAd) ρ h)) ->
-      (forall {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) 
-        (ha : [ ΠA.(PolyRedPack.shpRed) ρ h | Δ ||- a : _ ]),
+      (forall {Δ a b} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
+        (ha : [ ΠA.(PolyRedPack.shpRed) ρ h | Δ ||- a ≅ b: _ ]),
         P (HAad.(PolyRedPack.posAd) ρ h ha)) -> G).
 
 
   Theorem LR_rect@{i j k o}
     (l : TypeLevel)
     (rec : forall l', l' << l -> RedRel@{i j})
-    (P : forall {c t rEq rTe rTeEq},
-      LR@{i j k} rec c t rEq rTe rTeEq  -> Type@{o}) :
+    (P : forall {c t rEq rTeEq},
+      LR@{i j k} rec c t rEq rTeEq  -> Type@{o}) :
 
     (forall (Γ : context) A (h : [Γ ||-U<l> A]),
       P (LRU rec h)) ->
 
     (forall (Γ : context) (A : term) (neA : [Γ ||-ne A]),
-      P (LRne rec neA)) -> 
+      P (LRne rec neA)) ->
 
     (forall (Γ : context) (A : term) (ΠA : PiRedTy@{j} Γ A) (HAad : PiRedTyAdequate (LR rec) ΠA),
       PolyHyp P Γ ΠA HAad (P (LRPi rec ΠA HAad))) ->
@@ -89,18 +89,18 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     (forall (Γ : context) (A : term) (ΠA : SigRedTy@{j} Γ A) (HAad : SigRedTyAdequate (LR rec) ΠA),
       PolyHyp P Γ ΠA HAad (P (LRSig rec ΠA HAad))) ->
 
-    (forall Γ A (IA : IdRedTyPack@{j} Γ A) (IAad : IdRedTyAdequate (LR rec) IA), 
+    (forall Γ A (IA : IdRedTyPack@{j} Γ A) (IAad : IdRedTyAdequate (LR rec) IA),
       P IAad.(IdRedTyPack.tyAd) ->
       (forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), P (IAad.(IdRedTyPack.tyKripkeAd) ρ wfΔ)) ->
       P (LRId rec IA IAad)) ->
 
-    forall (Γ : context) (t : term) (rEq rTe : term -> Type@{j})
-      (rTeEq  : term -> term -> Type@{j}) (lr : LR@{i j k} rec Γ t rEq rTe rTeEq),
+    forall (Γ : context) (t : term) (rEq : term -> Type@{j})
+      (rTeEq  : term -> term -> Type@{j}) (lr : LR@{i j k} rec Γ t rEq rTeEq),
       P lr.
   Proof.
     cbn.
     intros HU Hne HPi HNat HEmpty HSig HId.
-    fix HRec 6.
+    fix HRec 5.
     destruct lr.
     - eapply HU.
     - eapply Hne.
@@ -114,17 +114,17 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
   Defined.
 
   Definition LR_rec@{i j k} := LR_rect@{i j k Set}.
-  
+
   Notation PolyHypLogRel P Γ ΠA G :=
     ((forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ]), P (ΠA.(PolyRed.shpRed) ρ h).(LRAd.adequate)) ->
-    (forall {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) 
-      (ha : [ Δ ||-< _ > a : ΠA.(ParamRedTy.dom)⟨ρ⟩ |  ΠA.(PolyRed.shpRed) ρ h ]),
+    (forall {Δ a b} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
+      (ha : [ Δ ||-< _ > a ≅ b : ΠA.(ParamRedTy.dom)⟨ρ⟩ |  ΠA.(PolyRed.shpRed) ρ h ]),
       P (ΠA.(PolyRed.posRed) ρ h ha).(LRAd.adequate)) -> G).
 
   (** Induction principle specialized to LogRel as the reducibility relation on lower levels *)
   Theorem LR_rect_LogRelRec@{i j k l o}
-    (P : forall {l Γ t rEq rTe rTeEq},
-    LogRel@{i j k l} l Γ t rEq rTe rTeEq -> Type@{o}) :
+    (P : forall {l Γ t rEq rTeEq},
+    LogRel@{i j k l} l Γ t rEq rTeEq -> Type@{o}) :
 
     (forall l (Γ : context) A (h : [Γ ||-U<l> A]),
       P (LRU (LogRelRec l) h)) ->
@@ -134,22 +134,22 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
 
     (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tProd Γ l A),
       PolyHypLogRel P Γ ΠA (P (LRPi' ΠA).(LRAd.adequate ))) ->
-    
+
     (forall l Γ A (NA : [Γ ||-Nat A]), P (LRNat (LogRelRec l) NA)) ->
 
     (forall l Γ A (NA : [Γ ||-Empty A]), P (LREmpty (LogRelRec l) NA)) ->
-    
+
     (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
       PolyHypLogRel P Γ ΠA (P (LRSig' ΠA).(LRAd.adequate ))) ->
-    
-    (forall l Γ A (IA :  [Γ ||-Id<l> A]), 
-      P (IA.(IdRedTy.tyRed).(LRAd.adequate)) -> 
+
+    (forall l Γ A (IA :  [Γ ||-Id<l> A]),
+      P (IA.(IdRedTy.tyRed).(LRAd.adequate)) ->
       (forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), P (IA.(IdRedTy.tyKripke) ρ wfΔ).(LRAd.adequate)) ->
-      
+
       P (LRId' IA).(LRAd.adequate)) ->
 
-    forall (l : TypeLevel) (Γ : context) (t : term) (rEq rTe : term -> Type@{k})
-      (rTeEq  : term -> term -> Type@{k}) (lr : LR@{j k l} (LogRelRec@{i j k} l) Γ t rEq rTe rTeEq),
+    forall (l : TypeLevel) (Γ : context) (t : term) (rEq : term -> Type@{k})
+      (rTeEq  : term -> term -> Type@{k}) (lr : LR@{j k l} (LogRelRec@{i j k} l) Γ t rEq rTeEq),
       P lr.
   Proof.
     intros ?? HPi ?? HSig HId **; eapply LR_rect@{j k l o}.
@@ -161,8 +161,8 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
 
   Notation PolyHypTyUr P Γ ΠA G :=
     ((forall {Δ} (ρ : Δ ≤ Γ) (h : [ |- Δ]), P (ΠA.(PolyRed.shpRed) ρ h)) ->
-    (forall {Δ a} (ρ : Δ ≤ Γ) (h : [ |- Δ ]) 
-      (ha : [ ΠA.(PolyRed.shpRed) ρ h | Δ ||- a : ΠA.(ParamRedTy.dom)⟨ρ⟩ ]),
+    (forall {Δ a b} (ρ : Δ ≤ Γ) (h : [ |- Δ ])
+      (ha : [ ΠA.(PolyRed.shpRed) ρ h | Δ ||- a ≅ b : ΠA.(ParamRedTy.dom)⟨ρ⟩ ]),
       P (ΠA.(PolyRed.posRed) ρ h ha)) -> G).
 
   Theorem LR_rect_TyUr@{i j k l o}
@@ -180,21 +180,21 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     (forall l Γ A (NA : [Γ ||-Nat A]), P (LRNat_ l NA)) ->
 
     (forall l Γ A (NA : [Γ ||-Empty A]), P (LREmpty_ l NA)) ->
-    
+
     (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
       PolyHypTyUr P Γ ΠA (P (LRSig' ΠA))) ->
-    
-    (forall l Γ A (IA :  [Γ ||-Id<l> A]), 
-      P (IA.(IdRedTy.tyRed)) -> 
+
+    (forall l Γ A (IA :  [Γ ||-Id<l> A]),
+      P (IA.(IdRedTy.tyRed)) ->
       (forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), P (IA.(IdRedTy.tyKripke) ρ wfΔ)) ->
-      
+
       P (LRId' IA)) ->
 
     forall (l : TypeLevel) (Γ : context) (A : term) (lr : [LogRel@{i j k l} l | Γ ||- A]),
       P lr.
   Proof.
     intros HU Hne HPi HNat HEmpty HSig HId l Γ A lr.
-    apply (LR_rect_LogRelRec@{i j k l o} (fun l Γ A _ _ _ lr => P l Γ A (LRbuild lr))).
+    apply (LR_rect_LogRelRec@{i j k l o} (fun l Γ A _ _ lr => P l Γ A (LRbuild lr))).
     all: auto.
   Defined.
 
@@ -211,11 +211,11 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     (forall Γ A (NA : [Γ ||-Nat A]), P (LRNat_ l NA)) ->
 
     (forall Γ A (NA : [Γ ||-Empty A]), P (LREmpty_ l NA)) ->
-    
+
     (forall (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
       PolyHypTyUr P Γ ΠA (P (LRSig' ΠA))) ->
-    
-    (forall Γ A (IA :  [Γ ||-Id<l> A]), 
+
+    (forall Γ A (IA :  [Γ ||-Id<l> A]),
       P (IA.(IdRedTy.tyRed)) ->
       (forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), P (IA.(IdRedTy.tyKripke) ρ wfΔ)) ->
       P (LRId' IA)) ->
@@ -228,10 +228,10 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     generalize l Γ A lr.
     eapply LR_rect_TyUr; intros [] *; constructor + auto.
     exfalso. pose (x := URedTy.lt h). inversion x.
-  Defined. 
+  Defined.
 
   (* Induction principle with inductive hypothesis for the universe at lower levels *)
-    
+
   Theorem LR_rect_TyUrGen@{i j k l o}
     (P : forall {l Γ A}, [LogRel@{i j k l} l | Γ ||- A] -> Type@{o}) :
 
@@ -247,12 +247,12 @@ same. Both need to be proven simultaneously, because of contravariance in the pr
     (forall l Γ A (NA : [Γ ||-Nat A]), P (LRNat_ l NA)) ->
 
     (forall l Γ A (NA : [Γ ||-Empty A]), P (LREmpty_ l NA)) ->
-    
+
     (forall (l : TypeLevel) (Γ : context) (A : term) (ΠA : ParamRedTy@{i j k l} tSig Γ l A),
       PolyHypTyUr P Γ ΠA (P (LRSig' ΠA))) ->
-    
+
     (forall l Γ A (IA :  [Γ ||-Id<l> A]),
-       P (IA.(IdRedTy.tyRed)) -> 
+       P (IA.(IdRedTy.tyRed)) ->
       (forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), P (IA.(IdRedTy.tyKripke) ρ wfΔ)) ->
       P (LRId' IA)) ->
 
@@ -269,12 +269,8 @@ End Inductions.
 (** ** Inversion principles *)
 
 Section Inversions.
-  Context `{ta : tag}
-    `{!WfContext ta} `{!WfType ta} `{!Typing ta}
-    `{!ConvType ta} `{!ConvTerm ta} `{!ConvNeuConv ta}
-    `{!RedType ta} `{!RedTerm ta} `{!RedTypeProperties}
-    `{!ConvNeuProperties}.
-  
+  Context `{GenericTypingProperties}.
+
   Definition invLRTy {Γ l A A'} (lr : [Γ ||-<l> A]) (r : [A ⤳* A']) (w : isType A') :=
     match w return Type with
     | UnivType => [Γ ||-U<l> A]
@@ -325,14 +321,14 @@ Section Inversions.
         eapply redty_red, redA.
     - intros ??? [redA] ???.
       enough (A' = tNat) as ->.
-      + dependent inversion w. 
+      + dependent inversion w.
         1: now econstructor.
         inv_whne.
       + eapply whred_det; tea.
         all: gen_typing.
     - intros ??? [redA] ???.
       enough (A' = tEmpty) as ->.
-      + dependent inversion w. 
+      + dependent inversion w.
         1: now econstructor.
         inv_whne.
       + eapply whred_det; tea.
@@ -372,7 +368,7 @@ Section Inversions.
     intros.
     now unshelve eapply  (invLR _ redIdAlg ProdType).
   Qed.
-  
+
   Lemma invLRΣ {Γ l dom cod} : [Γ ||-<l> tSig dom cod] -> [Γ ||-Σ<l> tSig dom cod].
   Proof.
     intros.
@@ -386,5 +382,41 @@ Section Inversions.
   Qed.
 
   (* invLRNat is useless *)
+
+  Lemma invLRConvU {Γ l A} : [Γ ||-U<l> A] -> [Γ |- A ≅ U].
+  Proof. intros []; gen_typing. Qed.
+
+  Lemma invLRConvNe {Γ A} (RA : [Γ ||-ne A]) : [Γ |- A ≅ RA.(neRedTy.ty)].
+  Proof.
+    destruct RA; cbn in *.
+    eapply convty_exp.
+    2: apply redtywf_refl; gen_typing.
+    1: gen_typing.
+    apply convty_term; apply convtm_convneu.
+    all: gen_typing.
+  Qed.
+
+  Lemma invLRConvPi {Γ l A} (RA : [Γ ||-Π<l> A]) :  [Γ |- A ≅ RA.(PiRedTy.outTy)].
+  Proof.
+    destruct RA as [?? []]. cbn in *.
+    eapply convty_exp; tea.
+    now apply redtywf_refl.
+  Qed.
+
+  Lemma invLRConvSig {Γ l A} (RA : [Γ ||-Σ<l> A]) :  [Γ |- A ≅ RA.(SigRedTy.outTy)].
+  Proof.
+    destruct RA as [?? []]. cbn in *.
+    eapply convty_exp; tea.
+    now apply redtywf_refl.
+  Qed.
+
+  Lemma invLRConvNat {Γ A} (RA : [Γ ||-Nat A]) : [Γ |- A ≅ tNat].
+  Proof. destruct RA; gen_typing. Qed.
+
+  Lemma invLRConvEmpty {Γ A} (RA : [Γ ||-Empty A]) : [Γ |- A ≅ tEmpty].
+  Proof. destruct RA; gen_typing. Qed.
+
+  Lemma invLRConvId {Γ l A} (RA: [Γ ||-Id<l> A]) : [Γ |- A ≅ RA.(IdRedTy.outTy)].
+  Proof. destruct RA; unfold IdRedTy.outTy; cbn; gen_typing. Qed.
 
 End Inversions.

--- a/theories/LogicalRelation/InstKripke.v
+++ b/theories/LogicalRelation/InstKripke.v
@@ -1,0 +1,130 @@
+(** * LogRel.LogicalRelation.InstKripke: combinators to instantiate Kripke-style quantifications *)
+From LogRel.AutoSubst Require Import core unscoped Ast Extra.
+From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening
+  GenericTyping LogicalRelation Validity.
+From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Neutral Weakening Irrelevance Application Reduction Transitivity NormalRed EqRedRight.
+
+Set Universe Polymorphism.
+Set Printing Primitive Projection Parameters.
+
+
+Lemma instKripkeEq `{GenericTypingProperties} {Γ A B l} (wfΓ : [|-Γ])
+  {h : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [Δ ||-<l> A⟨ρ⟩]}
+  (eq : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [h Δ ρ wfΔ | Δ ||- A⟨ρ⟩ ≅ B⟨ρ⟩])
+  : [instKripke wfΓ h | Γ ||- A ≅ B].
+Proof.
+  specialize (eq Γ wk_id wfΓ); rewrite wk_id_ren_on in eq.
+  irrelevance.
+Qed.
+
+Lemma instKripkeTmEq `{GenericTypingProperties} {Γ A t u l} (wfΓ : [|-Γ])
+  {h : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [Δ ||-<l> A⟨ρ⟩]}
+  (eq : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [h Δ ρ wfΔ | Δ ||- t⟨ρ⟩ ≅ u⟨ρ⟩ : _])
+  : [instKripke wfΓ h | Γ ||- t ≅ u : _].
+Proof.
+  specialize (eq Γ wk_id wfΓ); rewrite !wk_id_ren_on in eq.
+  irrelevance.
+Qed.
+
+Lemma instKripkeSubst `{GenericTypingProperties} {Γ A B l} (wfΓ : [|-Γ])
+  {hA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [Δ ||-<l> A⟨ρ⟩]}
+  (hB : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [Δ ||-<l> B[a .: ρ >> tRel]])
+  : [ Γ ,, A ||-<l> B].
+Proof.
+  pose proof (instKripke wfΓ hA).
+  escape. assert (wfΓA : [|- Γ ,, A]) by gen_typing.
+  unshelve epose proof (hinst := hB (Γ ,, A) (tRel 0) (tRel 0) (@wk1 Γ A) wfΓA _).
+  1: eapply var0; tea; now bsimpl.
+  now rewrite <- eq_id_subst_scons in hinst.
+Qed.
+
+Lemma instKripkeSubstEq `{GenericTypingProperties} {Γ A B B' l} (wfΓ : [|-Γ])
+  {hA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [Δ ||-<l> A⟨ρ⟩]}
+  {hB : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [Δ ||-<l> B[a .: ρ >> tRel]]}
+  (eq : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [hB Δ a b ρ wfΔ hab | Δ ||- B[a .: ρ >> tRel] ≅ B'[b .: ρ >> tRel]])
+  : [ instKripkeSubst wfΓ hB |  Γ ,, A ||- _ ≅ B'].
+Proof.
+  pose proof (instKripke wfΓ hA).
+  escape. assert (wfΓA : [|- Γ ,, A]) by gen_typing.
+  unshelve epose proof (hinst := eq (Γ ,, A) (tRel 0) (tRel 0) (@wk1 Γ A) wfΓA _).
+  1: eapply var0; tea; now bsimpl.
+  rewrite <- eq_id_subst_scons in hinst.
+  irrelevance; now rewrite <- eq_id_subst_scons.
+Qed.
+
+Lemma instKripkeSubstTmEq `{GenericTypingProperties} {Γ A B t u l} (wfΓ : [|-Γ])
+  {hA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [Δ ||-<l> A⟨ρ⟩]}
+  {hB : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [Δ ||-<l> B[a .: ρ >> tRel]]}
+  (eq : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [hB Δ a b ρ wfΔ hab | Δ ||- t[a .: ρ >> tRel] ≅ u[b .: ρ >> tRel] : _])
+  : [ instKripkeSubst wfΓ hB |  Γ ,, A ||- t ≅ u : _].
+Proof.
+  pose proof (instKripke wfΓ hA).
+  escape. assert (wfΓA : [|- Γ ,, A]) by gen_typing.
+  unshelve epose proof (hinst := eq (Γ ,, A) (tRel 0) (tRel 0) (@wk1 Γ A) wfΓA _).
+  1: eapply var0; tea; now bsimpl.
+  rewrite <- ! eq_id_subst_scons in hinst.
+  irrelevance; now rewrite <- eq_id_subst_scons.
+Qed.
+
+Lemma instKripkeSubstConv `{GenericTypingProperties} {Γ A A' B l} (wfΓ : [|-Γ])
+  {hA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [Δ ||-<l> A⟨ρ⟩]}
+  (eq : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [hA Δ ρ wfΔ | Δ ||- A⟨ρ⟩ ≅ A'⟨ρ⟩])
+  (hB : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [Δ ||-<l> B[a .: ρ >> tRel]])
+  : [ Γ ,, A' ||-<l> B].
+Proof.
+  pose proof (instKripkeEq wfΓ eq).
+  escape. assert (wfΓA' : [|- Γ ,, A']) by gen_typing.
+  unshelve epose proof (hinst := hB (Γ ,, A') (tRel 0) (tRel 0) (@wk1 Γ A') wfΓA' _).
+  1: now unshelve (eapply var0conv; tea; symmetry; erewrite <- wk1_ren_on; now eapply escapeEq, wkEq).
+  now rewrite <- eq_id_subst_scons in hinst.
+Qed.
+
+Lemma instKripkeSubstConvEq `{GenericTypingProperties} {Γ A A' B B' l} (wfΓ : [|-Γ])
+  {hA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [Δ ||-<l> A⟨ρ⟩]}
+  (eqA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [hA Δ ρ wfΔ | Δ ||- A⟨ρ⟩ ≅ A'⟨ρ⟩])
+  {hB : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [Δ ||-<l> B[a .: ρ >> tRel]]}
+  (eq : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [hB Δ a b ρ wfΔ hab | Δ ||- B[a .: ρ >> tRel] ≅ B'[b .: ρ >> tRel]])
+  : [ instKripkeSubstConv wfΓ eqA hB |  Γ ,, A' ||- _ ≅ B'].
+Proof.
+  pose proof (instKripkeEq wfΓ eqA).
+  escape. assert (wfΓA' : [|- Γ ,, A']) by gen_typing.
+  unshelve epose proof (hinst := eq (Γ ,, A') (tRel 0) (tRel 0) (@wk1 Γ A') wfΓA' _).
+  1: now unshelve (eapply var0conv; tea; symmetry; erewrite <- wk1_ren_on; now eapply escapeEq, wkEq).
+  rewrite <- eq_id_subst_scons in hinst.
+  irrelevance; now rewrite <- eq_id_subst_scons.
+Qed.
+
+Lemma instKripkeSubstConvTmEq `{GenericTypingProperties} {Γ A A' B t u l} (wfΓ : [|-Γ])
+  {hA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [Δ ||-<l> A⟨ρ⟩]}
+  (eqA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), [hA Δ ρ wfΔ | Δ ||- A⟨ρ⟩ ≅ A'⟨ρ⟩])
+  {hB : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [Δ ||-<l> B[a .: ρ >> tRel]]}
+  (eq : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ])
+    (hab : [hA Δ ρ wfΔ | Δ ||- a ≅ b : _]),
+    [hB Δ a b ρ wfΔ hab | Δ ||- t[a .: ρ >> tRel] ≅ u[b .: ρ >> tRel] : _])
+  : [ instKripkeSubstConv wfΓ eqA hB |  Γ ,, A' ||- t ≅ u : _].
+Proof.
+  pose proof (instKripkeEq wfΓ eqA).
+  escape. assert (wfΓA' : [|- Γ ,, A']) by gen_typing.
+  unshelve epose proof (hinst := eq (Γ ,, A') (tRel 0) (tRel 0) (@wk1 Γ A') wfΓA' _).
+  1: now unshelve (eapply var0conv; tea; symmetry; erewrite <- wk1_ren_on; now eapply escapeEq, wkEq).
+  rewrite <- ! eq_id_subst_scons in hinst.
+  irrelevance; now rewrite <- eq_id_subst_scons.
+Qed.

--- a/theories/LogicalRelation/InstKripke.v
+++ b/theories/LogicalRelation/InstKripke.v
@@ -1,7 +1,7 @@
 (** * LogRel.LogicalRelation.InstKripke: combinators to instantiate Kripke-style quantifications *)
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening
-  GenericTyping LogicalRelation Validity.
+  GenericTyping LogicalRelation.
 From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Neutral Weakening Irrelevance Application Reduction Transitivity NormalRed EqRedRight.
 
 Set Universe Polymorphism.

--- a/theories/LogicalRelation/Neutral.v
+++ b/theories/LogicalRelation/Neutral.v
@@ -375,6 +375,10 @@ Proof.
   intros; now eapply reflectness.
 Qed.
 
+Lemma neNfTermEq {Γ l A n n'} (RA : [Γ ||-<l> A]) : [Γ ||-NeNf n ≅ n' : A] -> [RA | Γ ||- n ≅ n' : A].
+Proof.  intros []; now eapply neuTermEq. Qed.
+
+
 Lemma var0conv {l Γ A A'} (RA : [Γ ,, A ||-<l> A']) :
   [Γ,, A |- A⟨↑⟩ ≅ A'] ->
   [Γ |- A] ->

--- a/theories/LogicalRelation/Neutral.v
+++ b/theories/LogicalRelation/Neutral.v
@@ -1,6 +1,8 @@
+(** * LogRel.Neutral: Reducibility of neutral types and terms. *)
+From Coq Require Import CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms UntypedReduction Weakening GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Reflexivity Irrelevance Escape.
+From LogRel.LogicalRelation Require Import Induction Reflexivity Escape Irrelevance Transitivity.
 
 Set Universe Polymorphism.
 
@@ -15,17 +17,12 @@ Defined.
 
 Lemma neU {l Γ A n} (h : [Γ ||-U<l> A]) :
   [Γ |- n : A] ->
-  [Γ |- n ~ n : A] ->
-  [LogRelRec l | Γ ||-U n : A | h].
+  [Γ |- n ~ n : A] -> URedTm (LogRelRec l) Γ n A h.
 Proof.
   assert [Γ |- A ≅ U] by (destruct h; gen_typing).
-  intros; exists n.
+  intros; unshelve eexists n.
   * eapply redtmwf_conv; tea; now eapply redtmwf_refl.
   * now eapply NeType, convneu_whne.
-  * apply convtm_convneu ; tea.
-    1: now constructor.
-    now eapply convneu_conv.
-  * eapply RedTyRecBwd, neu. 1,2: gen_typing.
 Defined.
 
 
@@ -45,6 +42,7 @@ Proof.
   all: cbn; assumption.
 Qed.
 
+(* TODO MOVE ME *)
 Lemma ty_app_ren {Γ Δ A f a dom cod} (ρ : Δ ≤ Γ) :
   [Γ |- f : A] -> [Γ |- A ≅ tProd dom cod] -> [Δ |- a : dom⟨ρ⟩] -> [Δ |- tApp f⟨ρ⟩ a : cod[a .: ρ >> tRel]].
 Proof.
@@ -55,6 +53,7 @@ Proof.
   gen_typing.
 Qed.
 
+(* TODO MOVE ME *)
 Lemma convneu_app_ren {Γ Δ A f g a b dom cod} (ρ : Δ ≤ Γ) :
   [Γ |- f ~ g : A] ->
   [Γ |- A ≅ tProd dom cod] ->
@@ -68,23 +67,22 @@ Proof.
   gen_typing.
 Qed.
 
-Record complete {l Γ A} (RA : [Γ ||-<l> A]) := {
-  reflect : forall n n',
+Definition reflect {l Γ A} (RA : [Γ ||-<l> A]) :=
+ forall n n',
     [Γ |- n : A] ->
     [Γ |- n' : A] ->
     [Γ |- n ~ n' : A] ->
-    [Γ ||-<l> n : A | RA] × [Γ ||-<l> n ≅ n' : A| RA];
-}.
+    [Γ ||-<l> n ≅ n' : A| RA].
 
-Lemma complete_reflect_simpl {l Γ A} (RA : [Γ ||-<l> A]) (c : complete RA) :
+Lemma reflect_diag {l Γ A} (RA : [Γ ||-<l> A]) (c : reflect RA) :
   forall n, [Γ |- n : A] -> [Γ |- n ~ n : A] -> [Γ ||-<l> n : A | RA].
 Proof.
 intros; eapply c.
 all: eassumption.
 Qed.
 
-Lemma complete_var0 {l Γ A A'} (RA : [Γ ,, A ||-<l> A']) :
-  complete RA ->
+Lemma reflect_var0 {l Γ A A'} (RA : [Γ ,, A ||-<l> A']) :
+  reflect RA ->
   [Γ ,, A |- A⟨↑⟩ ≅ A'] ->
   [Γ |- A] ->
   [Γ ,, A ||-<l> tRel 0 : A' | RA].
@@ -92,18 +90,17 @@ Proof.
   intros cRA conv HA.
   assert [Γ ,, A |- tRel 0 : A']
   by (eapply ty_conv; tea; escape; eapply (ty_var (wfc_wft EscRA) (in_here _ _))).
-  eapply complete_reflect_simpl; tea.
-  - eapply convneu_var; tea.
+  eapply reflect_diag; tea.
+  eapply convneu_var; tea.
 Qed.
 
 
-Lemma complete_U : forall l Γ A (RA : [Γ ||-U< l > A]), complete (LRU_ RA).
+Lemma reflect_U : forall l Γ A (RA : [Γ ||-U< l > A]), reflect (LRU_ RA).
 Proof.
-intros l Γ A h0; split.
-- intros ???? h; pose proof (lrefl h); pose proof (urefl h).
-  assert [Γ |- A ≅ U] by (destruct h0; gen_typing); split.
-  2: unshelve econstructor.
-  1-3: now apply neU.
+  intros l Γ A h0 ???? h; pose proof (lrefl h); pose proof (urefl h).
+  assert [Γ |- A ≅ U] by (destruct h0; gen_typing).
+  unshelve econstructor.
+  1-2: now apply neU.
   + eapply RedTyRecBwd, neu. 1,2: try gen_typing.
   + cbn. gen_typing.
   + eapply RedTyRecBwd; apply neu. 1,2: gen_typing.
@@ -111,168 +108,105 @@ intros l Γ A h0; split.
     all: eapply ty_ne_term, tm_ne_conv; tea; gen_typing.
 Qed.
 
-Lemma complete_ne : forall l Γ A (RA : [Γ ||-ne A]), complete (LRne_ l RA).
+Lemma reflect_ne : forall l Γ A (RA : [Γ ||-ne A]), reflect (LRne_ l RA).
 Proof.
-intros l Γ A h0; split.
-- destruct h0 as [B []]; intros ** ; assert ([Γ |- A ≅ B]) by gen_typing ; split.
-  + exists n; cbn.
-    * eapply redtmwf_refl ; gen_typing.
-    * eapply lrefl; eapply convneu_conv; eassumption.
-  + exists n n'; cbn.
-    1,2: eapply redtmwf_refl ; eapply ty_conv; gen_typing.
-    gen_typing.
+  intros l Γ A h0 ?????.
+  destruct h0 as [B []]; intros ** ; assert ([Γ |- A ≅ B]) by gen_typing.
+  exists n n'; cbn.
+  1,2: eapply redtmwf_refl ; eapply ty_conv; gen_typing.
+  gen_typing.
 Qed.
 
-Lemma complete_Pi : forall l Γ A (RA : [Γ ||-Π< l > A]),
+Lemma reflect_Pi : forall l Γ A (RA : [Γ ||-Π< l > A]),
   (forall (Δ : context) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ]),
-        complete (PolyRed.shpRed RA ρ h)) ->
-  (forall (Δ : context) (a : term) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ])
-          (ha : [PolyRed.shpRed RA ρ h | Δ ||- a : _]),
-        complete (PolyRed.posRed RA ρ h ha)) ->
-  complete (LRPi' RA).
+        reflect (PolyRed.shpRed RA ρ h)) ->
+  (forall (Δ : context) (a b : term) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ])
+          (ha : [PolyRed.shpRed RA ρ h | Δ ||- a ≅ b: _]),
+        reflect (PolyRed.posRed RA ρ h ha)) ->
+  reflect (LRPi' RA).
 Proof.
-intros l Γ A ΠA0 ihdom ihcod; split.
-- set (ΠA := ΠA0); destruct ΠA0 as [dom cod].
+  intros l Γ A ΠA0 ihdom ihcod.
+  set (ΠA := ΠA0); destruct ΠA0 as [dom cod].
   simpl in ihdom, ihcod.
   assert [Γ |- A ≅ tProd dom cod] by gen_typing.
-  assert [Γ |- A ≅ tProd dom cod] by gen_typing.
-  assert [Γ |- dom].
-  {
-    erewrite <- wk_id_ren_on.
-    eapply escape, polyRed.
-    gen_typing.
-  }
+  assert [Γ |- dom] by eapply PolyRed.shpTy, polyRed.
   assert [|- Γ ,, dom] as Hext by gen_typing.
-  assert [Γ,, dom |-[ ta ] tRel 0 : dom⟨@wk1 Γ dom⟩].
-  {
-    eapply ty_var ; tea.
-    rewrite wk1_ren_on.
-    econstructor.
-  }
+  assert [Γ,, dom |-[ ta ] tRel 0 : dom⟨@wk1 Γ dom⟩]
+    by (rewrite wk1_ren_on; now eapply ty_var0).
   assert [Γ,, dom |-[ ta ] tRel 0 ~ tRel 0 : dom⟨@wk1 Γ dom⟩]
     by now apply convneu_var.
   assert [PolyRed.shpRed polyRed (wk1 dom) Hext | Γ,, dom ||- tRel 0 : dom⟨wk1 dom⟩]
     by now eapply ihdom.
-  assert [Γ ,, dom |- cod].
-  {
-    replace cod with cod[tRel 0 .: @wk1 Γ dom >> tRel].
-    2: bsimpl; rewrite scons_eta'; now asimpl.
-    now eapply escape, polyRed.
-  }
+  assert [Γ ,, dom |- cod] by eapply PolyRed.posTy, polyRed.
+
   assert (forall n Δ a (ρ : Δ ≤ Γ),
       [|- Δ] -> [Γ |- n : A] -> [Δ |- a : dom⟨ρ⟩] -> [Δ |-[ ta ] tApp n⟨ρ⟩ a : cod[a .: ρ >> tRel]]) as Happ.
-    {
-      intros.
-      eapply typing_meta_conv.
-      1: eapply ty_app ; tea.
-      1: eapply typing_meta_conv.
-      1: eapply ty_wk.
-      - eassumption.
-      - eapply ty_conv ; tea.
-      - cbn ; reflexivity.
-      - now bsimpl. 
-    }
-    assert (forall n, [Γ |- n : A] -> [Γ,, dom |-[ ta ] tApp n⟨@wk1 Γ dom⟩ (tRel 0) : cod]).
-    {
-      intros.
-      eapply typing_meta_conv.
-      1: apply Happ ; tea.
-      bsimpl. rewrite scons_eta'. now bsimpl.
-    }
+  {
+    intros.
+    eapply typing_meta_conv.
+    1: eapply ty_app ; tea.
+    1: eapply typing_meta_conv.
+    1: eapply ty_wk.
+    - eassumption.
+    - eapply ty_conv ; tea.
+    - cbn ; reflexivity.
+    - now bsimpl.
+  }
+
   assert (forall n n',
     [Γ |- n : A] -> [Γ |- n' : A] ->
-    [Γ |- n ~ n : A] -> [Γ |- n' ~ n' : A] -> 
+    [Γ |- n ~ n : A] -> [Γ |- n' ~ n' : A] ->
     [Γ |- n ~ n' : A] ->
     [Γ |-[ ta ] n ≅ n' : tProd dom cod]).
   {
-    intros.
+    intros ?????? hnn'.
     eapply convtm_eta ; tea.
-    - now eapply ty_conv.
-    - constructor.
-      now eapply convneu_conv.
-    - now eapply ty_conv.
-    - econstructor.
-      now eapply convneu_conv.
-    - eapply convneu_app_ren in H21 ; tea ; cycle -1.
-      2: eapply ihcod in H21 as [_ hred].
-      + now eapply escapeEqTerm, reflLRTmEq.
-      + erewrite <- wk1_ren_on.
-        eapply convtm_meta_conv.
-        1: now escape.
-        1: bsimpl; rewrite scons_eta' ; now bsimpl.
-        now bsimpl.
-      + eapply typing_meta_conv ; eauto.
-        bsimpl. rewrite scons_eta'. now bsimpl.
-      + eapply typing_meta_conv ; eauto.
-        bsimpl. rewrite scons_eta'. now bsimpl.
+    1-4: first [now eapply ty_conv| constructor; now eapply convneu_conv].
+    eapply convneu_app_ren in hnn' ; tea ; cycle -1.
+    1: now eapply escapeEqTerm.
+    eapply ihcod in hnn' as hred.
+    + erewrite <- wk1_ren_on.
+      eapply convtm_meta_conv.
+      1: now escape.
+      1: bsimpl; rewrite scons_eta' ; now bsimpl.
+      now bsimpl.
+    + eapply typing_meta_conv ; eauto.
+    + eapply typing_meta_conv ; eauto.
+    Unshelve. 3: eassumption.
   }
 
-  unshelve refine ( let funred : forall n, [Γ |- n : A] -> [Γ |- n ~ n : A] -> [Γ ||-Π n : A | ΠA] := _ in _).
+  unshelve refine ( let funred : forall n, [Γ |- n : A] -> [Γ |- n ~ n : A] -> PiRedTm ΠA n := _ in _).
   {
     intros. exists n; cbn.
     - eapply redtmwf_refl ; gen_typing.
     - constructor; now eapply convneu_conv.
-    - eauto.
-    - intros.
-      eapply ihcod ; last first.
-      + eapply convne_meta_conv.
-        1: eapply convneu_app.
-        * eapply convne_meta_conv.
-          1: eapply convneu_wk.
-          2: eapply convneu_conv ; tea.
-          all: cbn ; easy.
-        * now eapply escapeEqTerm, reflLRTmEq.
-        * now bsimpl.
-        * reflexivity. 
-      + eapply Happ ; tea.
-        now escape.
-      + eapply Happ ; tea.
-        now escape.
-    - intros.
-      eapply ihcod ; last first.
-      + eapply convne_meta_conv.
-        1: eapply convneu_app.
-        * eapply convne_meta_conv.
-          1: eapply convneu_wk.
-          2: eapply convneu_conv ; tea.
-          all: cbn ; easy.
-        * now escape.
-        * now bsimpl.
-        * reflexivity. 
-      + eapply ty_conv.
-        1: eapply Happ ; tea ; now escape.
-        symmetry.
-        eapply escapeEq, PolyRed.posExt ; tea.
-      + eapply Happ ; tea.
-        now escape.
   }
 
   intros ???? h.
   pose proof (lrefl h); pose proof (urefl h).
-  split. 1: now apply funred.
   unshelve econstructor.
   1,2: now apply funred.
   all: cbn; clear funred.
   * eauto.
   * intros. apply ihcod; cbn.
-    + apply escapeTerm in ha; now eapply ty_app_ren.
-    + apply escapeTerm in ha; now eapply ty_app_ren.
+    + apply escapeTerm in hab; now eapply ty_app_ren.
+    + pose proof (escapeEq _ (ΠA.(PolyRed.posExt) _ _ hab)).
+      apply LRTmEqSym, escapeTerm in hab.
+      eapply ty_conv; [| now symmetry].
+      now eapply ty_app_ren.
     + eapply convneu_app_ren. 1,2: eassumption.
-    eapply escapeEqTerm; eapply reflLRTmEq; eassumption.
-
-  Unshelve.
-  all: eauto.
+      now eapply escapeEqTerm.
 Qed.
 
 Arguments ParamRedTy.outTy /.
 
-Lemma complete_Sig : forall l Γ A (RA : [Γ ||-Σ< l > A]),
+Lemma reflect_Sig : forall l Γ A (RA : [Γ ||-Σ< l > A]),
   (forall (Δ : context) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ]),
-        complete (PolyRed.shpRed RA ρ h)) ->
-  (forall (Δ : context) (a : term) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ])
-          (ha : [PolyRed.shpRed RA ρ h | Δ ||- a : _]),
-        complete (PolyRed.posRed RA ρ h ha)) ->
-  complete (LRSig' RA).
+        reflect (PolyRed.shpRed RA ρ h)) ->
+  (forall (Δ : context) (a b : term) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ])
+          (ha : [PolyRed.shpRed RA ρ h | Δ ||- a ≅ b : _]),
+        reflect (PolyRed.posRed RA ρ h ha)) ->
+  reflect (LRSig' RA).
 Proof.
   intros l Γ A ΣA0 ihdom ihcod.
   set (ΣA := ΣA0); destruct ΣA0 as [dom cod] ; cbn in *.
@@ -281,39 +215,17 @@ Proof.
     by (destruct ΣA; cbn in *; gen_typing).
   assert [Γ |- ΣA.(outTy)]
     by (destruct ΣA; cbn in *; gen_typing).
-  assert [Γ |- dom].
-  {
-    erewrite <- wk_id_ren_on.
-    eapply escape, polyRed.
-    gen_typing.
-  } 
+  assert [Γ |- dom] by now eapply PolyRed.shpTy.
   assert [|- Γ ,, dom] as Hext by gen_typing.
-  assert [Γ,, dom |-[ ta ] tRel 0 : dom⟨@wk1 Γ dom⟩].
-  {
-    eapply ty_var ; tea.
-    rewrite wk1_ren_on.
-    econstructor.
-  }
+  assert [Γ,, dom |-[ ta ] tRel 0 : dom⟨@wk1 Γ dom⟩]
+    by (rewrite wk1_ren_on; now eapply ty_var0).
   assert [Γ,, dom |-[ ta ] tRel 0 ~ tRel 0 : dom⟨@wk1 Γ dom⟩]
     by now apply convneu_var.
   assert [PolyRed.shpRed polyRed (wk1 dom) Hext | Γ,, dom ||- tRel 0 : dom⟨wk1 dom⟩]
     by now eapply ihdom.
-  assert [Γ ,, dom |- cod].
-  {
-    replace cod with cod[tRel 0 .: @wk1 Γ dom >> tRel].
-    2: bsimpl; rewrite scons_eta'; now asimpl.
-    now eapply escape, polyRed.
-  }
-  assert (hfst : forall n Δ (ρ : Δ ≤ Γ) (h : [ |- Δ]), [Γ |- n : A] -> [Γ |- n ~ n : A] ->
-    [PolyRedPack.shpRed ΣA ρ h | Δ ||- tFst n⟨ρ⟩ : _]).
-    1:{
-      intros; eapply complete_reflect_simpl.
-      * eapply ihdom.
-      * rewrite wk_fst; eapply ty_wk; tea.
-        eapply ty_fst; now eapply ty_conv.
-      * rewrite wk_fst; eapply convneu_wk; tea.
-        eapply convneu_fst; now eapply convneu_conv.
-    }
+  assert [Γ ,, dom |- cod]
+    by now eapply PolyRed.posTy.
+
   assert (hconv_fst : forall n n' Δ (ρ : Δ ≤ Γ) (h : [ |- Δ]), [Γ |- n : A] -> [Γ |- n' : A] -> [Γ |- n ~ n' : A] ->
     [PolyRedPack.shpRed ΣA ρ h | Δ ||- tFst n⟨ρ⟩ ≅ tFst n'⟨ρ⟩ : _]).
     1:{
@@ -322,165 +234,128 @@ Proof.
       * rewrite wk_fst; eapply ty_wk; tea.
         eapply ty_fst; now eapply ty_conv.
       * rewrite wk_fst ; eapply ty_wk ; tea.
-        eapply ty_fst ; now eapply ty_conv. 
+        eapply ty_fst ; now eapply ty_conv.
       * repeat rewrite wk_fst; eapply convneu_wk; tea.
         eapply convneu_fst; now eapply convneu_conv.
     }
+
   assert (hconv : forall n n',
   [Γ |- n : A] -> [Γ |- n' : A] ->
   [Γ |- n ~ n : A] -> [Γ |- n' ~ n' : A] ->
   [Γ |- n ~ n' : A] -> [Γ |-[ ta ] n ≅ n' : tSig dom cod]).
   {
-    intros.
+    intros n n' hn hn' hnn hn'n' hnn'.
+    assert (wfΓ : [|- Γ]) by gen_typing.
+    pose proof (hfst := hconv_fst n n' Γ wk_id wfΓ hn hn' hnn').
     eapply convtm_eta_sig ; cbn in * ; tea.
-    - now eapply ty_conv.
-    - econstructor.
-      now eapply convneu_conv.
-    - now eapply ty_conv.
-    - econstructor.
-      now eapply convneu_conv.
-    - eapply convtm_meta_conv.
-      1: eapply escapeEqTerm, ihdom.
-      4: now rewrite wk_id_ren_on.
-      4: reflexivity.
-      all: rewrite wk_id_ren_on.
-      + now eapply ty_fst, ty_conv.
-      + now eapply ty_fst, ty_conv.
-      + eapply convneu_fst, convneu_conv ; tea.
-      Unshelve.
-      gen_typing.
-    - eapply convtm_meta_conv.
-      1: eapply escapeEqTerm, (ihcod _ (tFst n) wk_id).
-      5: reflexivity.
-      Unshelve.
-      + eapply typing_meta_conv.
-        1: gen_typing.
-        now bsimpl.
-      + eapply ty_conv.
-        1: gen_typing.
-        symmetry.
-        replace (cod[(tFst n')..]) with (cod[(tFst n') .: (@wk_id Γ) >> tRel]) by (now bsimpl).
-        eapply escapeEq, polyRed.(PolyRed.posExt) ; tea.
-        Unshelve.
-        * now erewrite <- wk_id_ren_on.
-        * now erewrite <- (wk_id_ren_on _ n), <- (wk_id_ren_on _ n').
-        * gen_typing.
-        * now erewrite <- wk_id_ren_on.
-      + eapply convne_meta_conv.
-        1:now eapply convneu_snd, convneu_conv.
-        1: now bsimpl.
-        easy.
-      + now bsimpl.
-      + gen_typing.
-      + now erewrite <- wk_id_ren_on.
-      }
-  split.
+    1-4: first [now eapply ty_conv| constructor; now eapply convneu_conv].
+    1: generalize (escapeEqTerm _ hfst); now rewrite !wk_id_ren_on.
+
+    eapply convtm_meta_conv.
+    1: unshelve eapply escapeEqTerm, (ihcod _ (tFst n)⟨wk_id⟩ (tFst n)⟨wk_id⟩ wk_id); tea.
+    6: reflexivity.
+    + now eapply lrefl.
+    + eapply typing_meta_conv.
+      1: gen_typing.
+      now bsimpl.
+    + eapply ty_conv.
+      1: gen_typing.
+      symmetry.
+      replace (cod[(tFst n')..]) with (cod[(tFst n') .: (@wk_id Γ) >> tRel]) by (now bsimpl).
+      unshelve eapply escapeEq, polyRed.(PolyRed.posExt) ; tea.
+      now erewrite <- (wk_id_ren_on _ n').
+    + eapply convne_meta_conv.
+      1:now eapply convneu_snd, convneu_conv.
+      1: now bsimpl.
+      easy.
+    + now bsimpl.
+  }
+
   unshelve refine ( let funred : forall n,
     [Γ |- n : A] ->
-    [Γ |- n ~ n : A] -> [Γ ||-Σ n : A | ΣA] := _ in _).
+    [Γ |- n ~ n : A] -> SigRedTm ΣA n  := _ in _).
   {
     intros n **.
     cbn in *.
-    unshelve eexists n _.
-    - intros. now eapply hfst. 
+    unshelve eexists n.
     - eapply redtmwf_refl; now eapply ty_conv.
     - constructor ; cbn ; now eapply convneu_conv.
-    - eauto.
-    - intros.
-      cbn.
-      eapply complete_reflect_simpl.
-      * eapply ihcod.
-      * rewrite wk_snd.
-        eapply typing_meta_conv.
-        1: eapply ty_wk ; tea.
-        1: now eapply ty_snd, ty_conv.
-        now bsimpl.
-      * eapply convne_meta_conv.
-        3: reflexivity.
-        1: rewrite wk_snd.
-        1: eapply convneu_wk ; tea.
-        1: now eapply convneu_snd, convneu_conv.
-        now bsimpl.
   }
 
   intros ???? h.
-  pose proof (lrefl h); pose proof (urefl h).  
-  unshelve refine (let Rn :[Γ ||-Σ n : A | ΣA] := _ in _).
-    1: eapply funred; tea; now eapply lrefl.
-    unshelve refine (let Rn' :[Γ ||-Σ n' : A | ΣA] := _ in _).
-    1: eapply funred; tea; now eapply urefl.
-    assert (forall (Δ : context) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ]),
-      [Δ |- cod[tFst n⟨ρ⟩ .: ρ >> tRel] ≅ cod[tFst n'⟨ρ⟩ .: ρ >> tRel]]).
-    {
-      intros; eapply escapeEq; unshelve eapply (PolyRed.posExt ΣA); tea.
-      + eapply Rn.
-      + eapply Rn'.
-      + now eapply hconv_fst.
-    }
-    split; tea; eexists Rn Rn'.
-    + cbn.
-      eapply hconv ; tea.
-    + cbn. intros. now eapply hconv_fst.
-    + intros; cbn; eapply ihcod.
-      all: rewrite wk_fst; rewrite !wk_snd.
-      2: eapply ty_conv; [|now symmetry]; rewrite wk_fst.
-      all: rewrite <- subst_ren_subst_mixed.
-      * eapply ty_wk; tea; eapply ty_snd; now eapply ty_conv.
-      * eapply ty_wk; tea; eapply ty_snd; now eapply ty_conv.
-      * eapply convneu_wk; tea; eapply convneu_snd; now eapply convneu_conv.
+  pose proof (lrefl h); pose proof (urefl h).
+  unshelve refine (let Rn : SigRedTm ΣA n := _ in _).
+  1: now eapply funred.
+  unshelve refine (let Rn' : SigRedTm ΣA n' := _ in _).
+  1: now eapply funred.
+  assert (forall (Δ : context) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ]),
+    [Δ |- cod[tFst n⟨ρ⟩ .: ρ >> tRel] ≅ cod[tFst n'⟨ρ⟩ .: ρ >> tRel]]).
+  {
+    intros; eapply escapeEq; unshelve eapply (PolyRed.posExt ΣA); tea.
+    now eapply hconv_fst.
+  }
+  unshelve eexists Rn Rn' _.
+  + cbn. intros. now eapply hconv_fst.
+  + cbn.  eapply hconv ; tea.
+  + intros; cbn. eapply ihcod.
+    all: rewrite wk_fst; rewrite !wk_snd.
+    2: eapply ty_conv; [|now symmetry]; rewrite wk_fst.
+    all: rewrite <- subst_ren_subst_mixed.
+    * eapply ty_wk; tea; eapply ty_snd; now eapply ty_conv.
+    * eapply ty_wk; tea; eapply ty_snd; now eapply ty_conv.
+    * eapply convneu_wk; tea; eapply convneu_snd; now eapply convneu_conv.
 Qed.
 
-Lemma complete_Nat {l Γ A} (NA : [Γ ||-Nat A]) : complete (LRNat_ l NA).
+Lemma reflect_Nat {l Γ A} (NA : [Γ ||-Nat A]) : reflect (LRNat_ l NA).
 Proof.
-  split.
-  - intros. 
-    assert [Γ |- A ≅ tNat] by (destruct NA; gen_typing). 
-    assert [Γ |- n : tNat] by now eapply ty_conv.
-    split; econstructor.
-    1,4,5: eapply redtmwf_refl; tea; now eapply ty_conv.
-    2,4: do 2 constructor; tea.
-    1,4: eapply convtm_convneu ; [now constructor|..].
-    all: eapply convneu_conv; [|eassumption].
-    all: first [assumption|now eapply lrefl].
+  red; intros.
+  assert [Γ |- A ≅ tNat] by (destruct NA; gen_typing).
+  assert [Γ |- n : tNat] by now eapply ty_conv.
+  econstructor.
+  1,2: eapply redtmwf_refl; tea; now eapply ty_conv.
+  2: do 2 constructor; tea.
+  1: eapply convtm_convneu ; [now constructor|..].
+  1,3: eapply convneu_conv; [|eassumption]; tea.
+  eapply ty_conv; eassumption.
 Qed.
 
-Lemma complete_Empty {l Γ A} (NA : [Γ ||-Empty A]) : complete (LREmpty_ l NA).
+Lemma reflect_Empty {l Γ A} (NA : [Γ ||-Empty A]) : reflect (LREmpty_ l NA).
 Proof.
-  split.
-  - intros. 
-    assert [Γ |- A ≅ tEmpty] by (destruct NA; gen_typing). 
-    assert [Γ |- n : tEmpty] by now eapply ty_conv.
-    split; econstructor.
-    1,4,5: eapply redtmwf_refl; tea; now eapply ty_conv.
-    2,4: do 2 constructor; tea.
-    1,4: eapply convtm_convneu ; [now constructor|..].
-    all: eapply convneu_conv; [|eassumption].
-    all: try first [assumption|now eapply lrefl].
+  red; intros.
+  assert [Γ |- A ≅ tEmpty] by (destruct NA; gen_typing).
+  assert [Γ |- n : tEmpty] by now eapply ty_conv.
+  assert [Γ |- n' : tEmpty] by now eapply ty_conv.
+  econstructor.
+  1,2: eapply redtmwf_refl; tea; now eapply ty_conv.
+  2: do 2 constructor; tea.
+  1: eapply convtm_convneu ; [now constructor|..].
+  all: now eapply convneu_conv.
 Qed.
 
-Lemma complete_Id {l Γ A} (IA : [Γ ||-Id<l> A]) :
-  complete (LRId' IA).
+Lemma reflect_Id {l Γ A} (IA : [Γ ||-Id<l> A]) :
+  reflect (LRId' IA).
 Proof.
-  split; intros.
+  red; intros.
   assert [Γ |- A ≅ IA.(IdRedTy.outTy)] by (destruct IA; unfold IdRedTy.outTy; cbn; gen_typing).
   assert [Γ |- n : IA.(IdRedTy.outTy)] by now eapply ty_conv.
-  split; econstructor.
-  1,4,5: eapply redtmwf_refl; tea; now eapply ty_conv.
-  2,4: do 2 constructor; tea.
-  1,4: eapply convtm_convneu ; [now constructor|..].
-  all: eapply convneu_conv; tea; now eapply lrefl.
+  assert [Γ |- n' : IA.(IdRedTy.outTy)] by now eapply ty_conv.
+  econstructor.
+  1,2: eapply redtmwf_refl; tea; now eapply ty_conv.
+  2: do 2 constructor; tea.
+  1: eapply convtm_convneu ; [now constructor|..].
+  all: now eapply convneu_conv.
 Qed.
 
-Lemma completeness {l Γ A} (RA : [Γ ||-<l> A]) : complete RA.
+Lemma reflectness {l Γ A} (RA : [Γ ||-<l> A]) : reflect RA.
 Proof.
 revert l Γ A RA; eapply LR_rect_TyUr; cbn; intros.
-- now apply complete_U.
-- now apply complete_ne.
-- now apply complete_Pi.
-- now apply complete_Nat.
-- now apply complete_Empty.
-- now apply complete_Sig.
-- now apply complete_Id.
+- now apply reflect_U.
+- now apply reflect_ne.
+- now apply reflect_Pi.
+- now apply reflect_Nat.
+- now apply reflect_Empty.
+- now apply reflect_Sig.
+- now apply reflect_Id.
 Qed.
 
 Lemma neuTerm {l Γ A} (RA : [Γ ||-<l> A]) {n} :
@@ -488,7 +363,7 @@ Lemma neuTerm {l Γ A} (RA : [Γ ||-<l> A]) {n} :
   [Γ |- n ~ n : A] ->
   [Γ ||-<l> n : A | RA].
 Proof.
-  intros.  now eapply completeness.
+  intros.  now eapply reflectness.
 Qed.
 
 Lemma neuTermEq {l Γ A} (RA : [Γ ||-<l> A]) {n n'} :
@@ -497,7 +372,7 @@ Lemma neuTermEq {l Γ A} (RA : [Γ ||-<l> A]) {n n'} :
   [Γ |- n ~ n' : A] ->
   [Γ ||-<l> n ≅ n' : A| RA].
 Proof.
-  intros; now eapply completeness.
+  intros; now eapply reflectness.
 Qed.
 
 Lemma var0conv {l Γ A A'} (RA : [Γ ,, A ||-<l> A']) :
@@ -505,7 +380,7 @@ Lemma var0conv {l Γ A A'} (RA : [Γ ,, A ||-<l> A']) :
   [Γ |- A] ->
   [Γ ,, A ||-<l> tRel 0 : A' | RA].
 Proof.
-  apply complete_var0 ; now eapply completeness.
+  apply reflect_var0 ; now eapply reflectness.
 Qed.
 
 Lemma var0 {l Γ A A'} (RA : [Γ ,, A ||-<l> A']) :
@@ -521,3 +396,5 @@ Proof.
 Qed.
 
 End Neutral.
+
+

--- a/theories/LogicalRelation/NormalRed.v
+++ b/theories/LogicalRelation/NormalRed.v
@@ -48,6 +48,19 @@ Solve All Obligations with
 Definition normRedΠ {Γ F G l} (h : [Γ ||-<l> tProd F G]) : [Γ ||-<l> tProd F G] :=
   LRPi' (normRedΠ0 (invLRΠ h)).
 
+#[program]
+Definition normEqRedΠ {Γ F F' G G' l} (h : [Γ ||-<l> tProd F G])
+  (heq : [Γ ||-<l> _ ≅ tProd F' G' | h]) : [Γ ||-<l> _ ≅ tProd F' G' | normRedΠ h] :=
+  {|
+    PiRedTyEq.dom := F';
+    PiRedTyEq.cod := G';
+  |}.
+Solve All Obligations with
+  intros; assert[Γ ||-<l> _ ≅ tProd F' G' | normRedΠ h] as [?? red] by irrelevance;
+  pose proof (e := redtywf_whnf red whnf_tProd);
+  symmetry in e; injection e; clear e;
+  destruct h ; intros; cbn in *; subst; eassumption.
+
 Definition normRedΣ {Γ F G l} (h : [Γ ||-<l> tSig F G]) : [Γ ||-<l> tSig F G] :=
   LRSig' (normRedΣ0 (invLRΣ h)).
 
@@ -160,9 +173,9 @@ Ltac normRedΠ id :=
   set (G := _);
   let g := eval unfold G in G in
   match g with
-  | [ LRAd.pack ?R | _ ||- ?t : _] =>
+  | [ LRAd.pack ?R | _ ||- ?t ≅ ?u : _] =>
     pose (id := normRedΠ0 (invLRΠ R)); subst G;
-    enough [_ ||-<_> t : _ | LRPi' id] by irrelevance
+    enough [_ ||-<_> t ≅ u : _ | LRPi' id] by irrelevance
   end.
 
 (* Normalizes a term reducible at a Π type *)

--- a/theories/LogicalRelation/NormalRed.v
+++ b/theories/LogicalRelation/NormalRed.v
@@ -2,13 +2,13 @@
 From Coq Require Import CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms UntypedReduction Weakening GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity Reduction.
+From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity Reduction EqRedRight.
 
 Set Universe Polymorphism.
 
 Ltac redSubst :=
   match goal with
-  | [H : [_ |- ?X :⤳*: ?Y] |- _] => 
+  | [H : [_ |- ?X :⤳*: ?Y] |- _] =>
     assert (X = Y)by (eapply redtywf_whnf ; gen_typing); subst; clear H
   end.
 
@@ -31,18 +31,18 @@ Program Definition normRedΠ0 {Γ F G l} (h : [Γ ||-Π<l> tProd F G])
   : [Γ ||-Π<l> tProd F G] :=
   {| PiRedTyPack.dom := F ;
      PiRedTyPack.cod := G |}.
-Solve All Obligations with 
+Solve All Obligations with
   intros; pose proof (e := redtywf_whnf (PiRedTyPack.red h) whnf_tProd);
-  symmetry in e; injection e; clear e; 
+  symmetry in e; injection e; clear e;
   destruct h ; intros; cbn in *; subst; eassumption.
 
 Program Definition normRedΣ0 {Γ F G l} (h : [Γ ||-Σ<l> tSig F G])
   : [Γ ||-Σ<l> tSig F G] :=
   {| PiRedTyPack.dom := F ;
      PiRedTyPack.cod := G |}.
-Solve All Obligations with 
+Solve All Obligations with
   intros; pose proof (e := redtywf_whnf (PiRedTyPack.red h) whnf_tSig);
-  symmetry in e; injection e; clear e; 
+  symmetry in e; injection e; clear e;
   destruct h ; intros; cbn in *; subst; eassumption.
 
 Definition normRedΠ {Γ F G l} (h : [Γ ||-<l> tProd F G]) : [Γ ||-<l> tProd F G] :=
@@ -52,7 +52,7 @@ Definition normRedΣ {Γ F G l} (h : [Γ ||-<l> tSig F G]) : [Γ ||-<l> tSig F G
   LRSig' (normRedΣ0 (invLRΣ h)).
 
 #[program]
-Definition normEqRedΣ {Γ F F' G G' l} (h : [Γ ||-<l> tSig F G]) 
+Definition normEqRedΣ {Γ F F' G G' l} (h : [Γ ||-<l> tSig F G])
   (heq : [Γ ||-<l> _ ≅ tSig F' G' | h]) : [Γ ||-<l> _ ≅ tSig F' G' | normRedΣ h] :=
   {|
     PiRedTyEq.dom := F';
@@ -61,29 +61,49 @@ Definition normEqRedΣ {Γ F F' G G' l} (h : [Γ ||-<l> tSig F G])
 Solve All Obligations with
   intros; assert[Γ ||-<l> _ ≅ tSig F' G' | normRedΣ h] as [?? red] by irrelevance;
   pose proof (e := redtywf_whnf red whnf_tSig);
-  symmetry in e; injection e; clear e; 
+  symmetry in e; injection e; clear e;
   destruct h ; intros; cbn in *; subst; eassumption.
 
 #[program]
-Definition normLambda {Γ F F' G t l RΠ} 
-  (Rlam : [Γ ||-<l> tLambda F' t : tProd F G | normRedΠ RΠ ]) :
-  [Γ ||-<l> tLambda F' t : tProd F G | normRedΠ RΠ ] :=
-  {| PiRedTm.nf := tLambda F' t |}.
+Definition normRedId0 {Γ A x y l} (h : [Γ ||-Id<l> tId A x y])
+  : [Γ ||-Id<l> tId A x y] :=
+  mkIdRedTy A x y _ _ _ _.
 Solve All Obligations with
-  intros;
-  pose proof (e := redtmwf_whnf (PiRedTm.red Rlam) whnf_tLambda);
-  destruct Rlam as [???? app eqq]; cbn in *; subst;
-  first [eapply app | now eapply eqq| eassumption].
+  intros; pose proof (e := redtywf_whnf (IdRedTy.red h) whnf_tId);
+  symmetry in e; injection e; clear e;
+  destruct h ; intros; cbn in *; subst;
+  first [eassumption | irrelevance].
+
+Definition normRedId {Γ A x y l} (h : [Γ ||-<l> tId A x y]) : [Γ ||-<l> tId A x y] :=
+  LRId' (normRedId0 (invLRId h)).
 
 #[program]
-Definition normPair {Γ F F' G G' f g l RΣ} 
-  (Rp : [Γ ||-<l> tPair F' G' f g : tSig F G | normRedΣ RΣ ]) :
-  [Γ ||-<l> tPair F' G' f g : tSig F G | normRedΣ RΣ ] :=
-  {| SigRedTm.nf := tPair F' G' f g |}.
+Definition normLambda {Γ F Fl Fr G tl tr l RΠ}
+  (Rlam : [Γ ||-<l> tLambda Fl tl ≅ tLambda Fr tr : tProd F G | normRedΠ RΠ ]) :
+  [Γ ||-<l> tLambda Fl tl ≅ tLambda Fr tr : tProd F G | normRedΠ RΠ ] :=
+  {|
+    PiRedTmEq.redL := {| PiRedTmEq.nf := tLambda Fl tl |} ;
+    PiRedTmEq.redR := {| PiRedTmEq.nf := tLambda Fr tr |}
+  |}.
 Solve All Obligations with
   intros;
-  pose proof (e := redtmwf_whnf (SigRedTm.red Rp) whnf_tPair);
-  destruct Rp as [???? fstRed sndRed]; cbn in *; subst;
+  pose proof (eL := redtmwf_whnf (PiRedTmEq.red Rlam.(PiRedTmEq.redL)) whnf_tLambda);
+  pose proof (eR := redtmwf_whnf (PiRedTmEq.red Rlam.(PiRedTmEq.redR)) whnf_tLambda);
+  destruct Rlam as [[] [] app eqq]; cbn in *; subst;
+  first [eapply app | now eapply eqq| eassumption].
+
+
+#[program]
+Definition normPair {Γ F Fl Fr G Gl Gr fl fr gl gr l RΣ}
+  (Rp : [Γ ||-<l> tPair Fl Gl fl gl ≅ tPair Fr Gr fr gr : tSig F G | normRedΣ RΣ ]) :
+  [Γ ||-<l> tPair Fl Gl fl gl ≅ tPair Fr Gr fr gr : tSig F G | normRedΣ RΣ ] :=
+  {| SigRedTmEq.redL := {| SigRedTmEq.nf := tPair Fl Gl fl gl |} ;
+     SigRedTmEq.redR := {| SigRedTmEq.nf := tPair Fr Gr fr gr |} |}.
+Solve All Obligations with
+  intros;
+  pose proof (eL := redtmwf_whnf (SigRedTmEq.red (SigRedTmEq.redL Rp)) whnf_tPair);
+  pose proof (eR := redtmwf_whnf (SigRedTmEq.red (SigRedTmEq.redR Rp)) whnf_tPair);
+  destruct Rp as [[] [] ? fstRed sndRed]; cbn in *; subst;
   first [eapply fstRed | irrelevanceRefl; now unshelve eapply sndRed| eassumption].
 
 Definition invLRcan {Γ l A} (lr : [Γ ||-<l> A]) (w : isType A) : [Γ ||-<l> A] :=
@@ -96,7 +116,6 @@ Definition invLRcan {Γ l A} (lr : [Γ ||-<l> A]) (w : isType A) : [Γ ||-<l> A]
   | IdType => fun _ x => LRId' x
   | NeType wh => fun _ x => LRne_ _ (normRedNe0 x wh)
   end lr (invLR lr (reflexivity A) w).
-  
 
 End Normalization.
 
@@ -107,10 +126,10 @@ End Normalization.
 Ltac normRedΠin X :=
   let g := type of X in
   match g with
-  | [ LRAd.pack ?R | _ ||- ?t : _] =>
+  (* | [ LRAd.pack ?R | _ ||- ?t : _] =>
     let X' := fresh X in
     rename X into X' ;
-    assert (X : [_ ||-<_> t : _ | LRPi' (normRedΠ0 (invLRΠ R))]) by irrelevance; clear X'
+    assert (X : [_ ||-<_> t : _ | LRPi' (normRedΠ0 (invLRΠ R))]) by irrelevance; clear X' *)
   | [ LRAd.pack ?R | _ ||- _ ≅ ?B] =>
     let X' := fresh X in
     rename X into X' ;
@@ -123,12 +142,12 @@ Ltac normRedΠin X :=
 
 Goal forall `{GenericTypingProperties} Γ A B l R f X
   (RABX : [Γ ||-<l> arr A B ≅ X | R])
-  (Rf : [Γ ||-<l> f : arr A B | R])
+  (* (Rf : [Γ ||-<l> f : arr A B | R]) *)
   (Rff : [Γ ||-<l> f ≅ f : arr A B | R])
 , True.
 Proof.
   intros.
-  normRedΠin Rf.
+  (* normRedΠin Rf. *)
   normRedΠin Rff.
   normRedΠin RABX.
   constructor.
@@ -151,10 +170,10 @@ Ltac normRedΠ id :=
 Ltac normRedΣin X :=
   let g := type of X in
   match g with
-  | [ LRAd.pack ?R | _ ||- ?t : _] =>
+  (* | [ LRAd.pack ?R | _ ||- ?t : _] =>
     let X' := fresh X in
     rename X into X' ;
-    assert (X : [_ ||-<_> t : _ | LRSig' (normRedΣ0 (invLRΣ R))]) by irrelevance; clear X'
+    assert (X : [_ ||-<_> t : _ | LRSig' (normRedΣ0 (invLRΣ R))]) by irrelevance; clear X' *)
   | [ LRAd.pack ?R | _ ||- _ ≅ ?B] =>
     let X' := fresh X in
     rename X into X' ;

--- a/theories/LogicalRelation/Poly.v
+++ b/theories/LogicalRelation/Poly.v
@@ -1,0 +1,2 @@
+
+(** * LogRel.LogicalRelation.Poly: derived properties of reducible polynomials.*)

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -1,7 +1,7 @@
-(* From Coq.Classes Require Import CRelationClasses. *)
+From Coq.Classes Require Import CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Notations Utils BasicAst Context NormalForms UntypedReduction Weakening GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Reflexivity Universe Escape Irrelevance.
+From LogRel.LogicalRelation Require Import Induction Reflexivity Universe Escape Irrelevance Transitivity.
 
 Set Universe Polymorphism.
 
@@ -57,116 +57,135 @@ Proof.
   intros ? []; now eapply redSubst.
 Qed.
 
-Lemma redSubstTerm {Γ A t u l} (RA : [Γ ||-<l> A]) :
-  [Γ ||-<l> u : A | RA] ->
-  [Γ |- t ⤳* u : A ] ->
-  [Γ ||-<l> t : A | RA] × [Γ ||-<l> t ≅ u : A | RA].
+
+Lemma redURedTm {Γ l A t u} {h : [Γ ||-U<l> A]} :
+  [Γ |- t ⤳* u : A] ->
+  URedTm (LogRelRec l) Γ u A h ->
+  URedTm (LogRelRec l) Γ t A h.
 Proof.
-  revert t u; pattern l, Γ, A, RA; apply LR_rect_TyUr; clear l Γ A RA; intros l Γ.
-  - intros ? h ?? ru' redtu; pose (ru := ru'); destruct ru' as [T].
-    assert [Γ |- A ≅ U] by (destruct h; gen_typing).
-    assert [Γ |- t : U] by (eapply ty_conv; [gen_typing| now escape]).
-    assert (redtu' : [Γ |-[ ta ] t ⤳* u]) by gen_typing.
-    destruct (redSubst (A:=t) (RedTyRecFwd h rel) redtu') as [rTyt0].
-    pose proof (rTyt := RedTyRecBwd h rTyt0).
-    unshelve refine (let rt : [LRU_ h | Γ ||- t : A]:= _ in _).
-    + exists T; tea; constructor; destruct red; tea.
-      etransitivity; tea; eapply redtm_conv; tea; now escape.
-    + split; tea; exists rt ru rTyt; tea.
-      apply TyEqRecFwd; irrelevance.
-  - intros ???? ru' ?; pose (ru := ru'); destruct ru' as [n].
-    assert [Γ |- A ≅ neRedTy.ty neA]. 1:{
-      destruct neA; cbn in *.
-      eapply convty_exp.
-       2: apply redtywf_refl; gen_typing.
-       1: gen_typing.
-       apply convty_term; apply convtm_convneu.
-       all: gen_typing.
-    }
-    assert [Γ |-[ ta ] t ⤳* u : neRedTy.ty neA] by (eapply redtm_conv; tea). 
-    assert [Γ |-[ ta ] t : neRedTy.ty neA] by (eapply ty_conv; tea; gen_typing). 
-    unshelve refine (let rt : [LRne_ l neA | Γ ||- t : A] := _ in _).
-    + exists n; tea; destruct red; constructor; tea; now etransitivity.
-    + split; tea; exists n n; tea; destruct red; constructor; tea; now etransitivity. 
-  - intros ? ΠA ihdom ihcod ?? ru' ?; pose (ru := ru'); destruct ru' as [f].
-    assert [Γ |- A ≅ ΠA.(outTy)]. 1:{
-      destruct ΠA as [?? []]. cbn in *.
-      eapply convty_exp; tea.
-      now apply redtywf_refl.
-    }
-    assert [Γ |-[ ta ] t ⤳* u : ΠA.(outTy)] by now eapply redtm_conv. 
-    assert [Γ |-[ ta ] t : ΠA.(outTy)] by (eapply ty_conv; gen_typing).
-    unshelve refine (let rt : [LRPi' ΠA | Γ ||- t : A] := _ in _).
-    1: exists f; tea; constructor; destruct red; tea; etransitivity; tea.
-    split; tea; exists rt ru; tea.
-    intros; cbn. apply eq; tea.
-    now apply reflLRTmEq.
-  - intros ? NA t ? Ru red; inversion Ru; subst.
-    assert [Γ |- A ≅ tNat] by (destruct NA; gen_typing).
-    assert [Γ |- t :⤳*: nf : tNat]. 1:{
+  intros redtu ru; pose proof (invLRConvU h).
+  assert [Γ |- t : U] by (eapply ty_conv; [gen_typing| now escape]).
+  destruct ru as [nf]; exists nf; tea.
+  etransitivity; tea; gen_typing.
+Defined.
+
+Lemma redPiRedTm {Γ l A t u} {h : [Γ ||-Π<l> A]} :
+  [Γ |- t ⤳* u : A] ->
+  PiRedTm h u ->
+  PiRedTm h t.
+Proof.
+  intros redtu ru; pose proof (invLRConvPi h).
+  assert [Γ |-[ ta ] t ⤳* u : h.(outTy)] by now eapply redtm_conv.
+  destruct ru as [nf]; exists nf; tea.
+  constructor; destruct red; tea; now etransitivity.
+Defined.
+
+Lemma redSigRedTm {Γ l A t u} {h : [Γ ||-Σ<l> A]} :
+  [Γ |- t ⤳* u : A] ->
+  SigRedTm h u ->
+  SigRedTm h t.
+Proof.
+  intros redtu ru; pose proof (invLRConvSig h).
+  assert [Γ |-[ ta ] t ⤳* u : h.(outTy)] by now eapply redtm_conv.
+  destruct ru as [nf]; exists nf; tea.
+  constructor; destruct red; tea; now etransitivity.
+Defined.
+
+Lemma eqAppLRefl {Γ l A u v} (ΠA : [Γ ||-Π<l> A]):
+  (forall Δ a b, PiRedTmEq.appRed ΠA u v Δ a b) ->
+  (forall Δ a b, PiRedTmEq.appRed ΠA u u Δ a b).
+Proof.
+  cbn; intros eqApp; etransitivity.
+  1: eapply eqApp.
+  symmetry; eapply LRTmEqConv.
+  2: unshelve eapply eqApp; tea; now eapply urefl.
+  irrelevanceRefl; unshelve eapply (ΠA.(PolyRed.posExt) ρ h).
+  now symmetry.
+Qed.
+
+Lemma redSubstLeftTmEq {Γ A t u v l} (RA : [Γ ||-<l> A]) :
+  [Γ ||-<l> u ≅ v : A | RA] ->
+  [Γ |- t ⤳* u : A ] ->
+  [Γ ||-<l> t ≅ v : A | RA].
+Proof.
+  intros uv tu; transitivity u; [|assumption].
+  revert t u v uv tu; pattern l, Γ, A, RA; apply LR_rect_TyUr; clear l Γ A RA; intros l Γ.
+  - intros ? h ??? [ru] redtu ; pose proof (invLRConvU h).
+    assert (redtu' : [Γ |-[ ta ] t ⤳* u]) by (eapply redty_term; gen_typing).
+    destruct (redSubst (A:=t) (RedTyRecFwd h relL) redtu') as [rTyt0 ?].
+    unshelve eexists (redURedTm redtu ru) ru (RedTyRecBwd h rTyt0); tea.
+    1: now eapply lrefl.
+    apply TyEqRecFwd; irrelevance.
+  - intros ????? ru' ?; pose (ru := ru'); destruct ru' as [n].
+    assert [Γ |- A ≅ neRedTy.ty neA] by now eapply invLRConvNe.
+    assert [Γ |-[ ta ] t ⤳* u : neRedTy.ty neA] by (eapply redtm_conv; tea).
+    assert [Γ |-[ ta ] t : neRedTy.ty neA] by (eapply ty_conv; tea; gen_typing).
+    exists n n; tea.
+    2: now eapply lrefl.
+    etransitivity; tea; gen_typing.
+  - intros ? ΠA ihdom ihcod ??? ru redtu.
+    pose proof (lrefl ru); destruct ru as [ru].
+    exists (redPiRedTm redtu ru) ru ; tea.
+    1: cbn; now eapply lrefl.
+    now eapply eqAppLRefl.
+  - intros ? NA t u ? Ru red.
+    inversion Ru as [?? nfL ???? [? _]%reflNatRedTmEq]; subst.
+    pose proof (invLRConvNat NA).
+    assert [Γ |- t :⤳*: nfL : tNat]. 1:{
       constructor. 1: gen_typing.
       etransitivity. 2: gen_typing.
       now eapply redtm_conv.
     }
-    split; econstructor; tea.
-    now eapply reflNatRedTmEq.
-  - intros ? NA t ? Ru red; inversion Ru; subst.
-    assert [Γ |- A ≅ tEmpty] by (destruct NA; gen_typing).
-    assert [Γ |- t :⤳*: nf : tEmpty]. 1:{
-      constructor. 
-      1: eapply ty_conv; gen_typing.
+    econstructor; tea; now eapply lrefl.
+  - intros ? NA t u ? Ru red.
+    inversion Ru as [?? nfL ???? [? _]%(reflEmptyRedTmEq (NA:=NA))]; subst.
+    pose proof (invLRConvEmpty NA).
+    assert [Γ |- t :⤳*: nfL : tEmpty]. 1:{
+      constructor. 1: gen_typing.
       etransitivity. 2: gen_typing.
       now eapply redtm_conv.
     }
-    split; econstructor; tea.
-    now eapply reflEmptyRedTmEq.
-    Unshelve. 2: tea.
-  - intros ? PA ihdom ihcod ?? ru' ?; pose (ru := ru'); destruct ru' as [p].
-    assert [Γ |- A ≅ PA.(outTy)]. 1:{
-      destruct PA as [?? []]. cbn in *.
-      eapply convty_exp; tea.
-      now apply redtywf_refl.
-    }
-    assert [Γ |-[ ta ] t ⤳* u : PA.(outTy)] by now eapply redtm_conv. 
-    assert [Γ |-[ ta ] t : PA.(outTy)] by (eapply ty_conv; gen_typing).
-    unshelve refine (let rt : [LRSig' PA | Γ ||- t : A] := _ in _).
-    1: unshelve eexists p _; tea; constructor; destruct red; tea; etransitivity; tea.
-    split; tea; exists rt ru; tea; intros; cbn; now apply reflLRTmEq.
-  - intros ? IA ih _ t u [nf ?? prop] redt.
-    assert [Γ |- A ≅ IA.(IdRedTy.outTy)] by (destruct IA; unfold IdRedTy.outTy; cbn; gen_typing).
-    assert [Γ |-[ ta ] t ⤳* u : IA.(IdRedTy.outTy)] by now eapply redtm_conv. 
+    econstructor; tea; now eapply lrefl.
+  - intros ? PA ihdom ihcod ??? [ru] redtu.
+    unshelve eexists (redSigRedTm redtu ru) ru _.
+    all:cbn; intros; eapply lrefl; eauto.
+    irrelevanceRefl; unshelve eauto; tea.
+   - intros ? IA ih _ t u ? [nf ? redL ?? prop] redt.
+    assert [Γ |- A ≅ IA.(IdRedTy.outTy)] by now eapply invLRConvId.
+    assert [Γ |-[ ta ] t ⤳* u : IA.(IdRedTy.outTy)] by now eapply redtm_conv.
     assert [Γ |-[ ta ] t : IA.(IdRedTy.outTy)] by (eapply ty_conv; gen_typing).
     assert [Γ |-[ ta ] t :⤳*: nf : IA.(IdRedTy.outTy)].
-    1: constructor; [apply red|etransitivity; tea; apply red].
-    split; eexists; tea.
-    now eapply reflIdPropEq.
+    1: destruct redL; constructor; tea; now etransitivity.
+    eexists; tea; [now eapply lrefl|].
+    now eapply reflIdPropEq in prop as [].
 Qed.
 
-Lemma redSubstTerm' {Γ A t u l} (RA : [Γ ||-<l> A]) :
-  [Γ ||-<l> u : A | RA] ->
-  [Γ |- t ⤳* u : A ] ->
-  [Γ ||-<l> t : A | RA] ×  
-  [Γ ||-<l> u : A | RA] ×
-  [Γ ||-<l> t ≅ u : A | RA].
+Lemma redSubstTmEq {Γ A A' tl tr ul ur l} (RA : [Γ ||-<l> A]) :
+  [Γ ||-<l> ul ≅ ur : A | RA] ->
+  [Γ |- tl ⤳* ul : A ] ->
+  [Γ |- tr ⤳* ur : A' ] ->
+  [Γ |- A ≅ A'] ->
+  [Γ ||-<l> tl ≅ tr : A | RA].
 Proof.
-  intros. assert ([Γ ||-<l> t : A | RA] × [Γ ||-<l> t ≅ u : A | RA]) by now eapply redSubstTerm.
-  now repeat split.
+  intros.
+  assert [Γ |- tr ⤳* ur : A ].
+  1: eapply redtm_conv; tea; now symmetry.
+  eapply redSubstLeftTmEq; tea; symmetry.
+  eapply redSubstLeftTmEq; tea; now symmetry.
 Qed.
 
-
-Lemma redwfSubstTerm {Γ A t u l} (RA : [Γ ||-<l> A]) :
-  [Γ ||-<l> u : A | RA] ->
+Lemma redwfSubstTmEq {Γ A t u v l} (RA : [Γ ||-<l> A]) :
+  [Γ ||-<l> u ≅ v : A | RA] ->
   [Γ |- t :⤳*: u : A ] ->
-  [Γ ||-<l> t : A | RA] × [Γ ||-<l> t ≅ u : A | RA].
+  [Γ ||-<l> t ≅ v : A | RA].
 Proof.
-  intros ? []; now eapply redSubstTerm.
+  intros ? []; now eapply redSubstLeftTmEq.
 Qed.
-
 
 Lemma redFwd {Γ l A B} : [Γ ||-<l> A] -> [Γ |- A :⤳*: B] -> whnf B -> [Γ ||-<l> B].
 Proof.
   intros RA; revert B; pattern l, Γ, A, RA; apply LR_rect_TyUr; clear l Γ A RA.
-  - intros ??? [??? red] ? red' ?. 
+  - intros ??? [??? red] ? red' ?.
     eapply LRU_.  unshelve erewrite (redtywf_det _ _ red' red); tea.
     1: constructor. econstructor; tea. eapply redtywf_refl; gen_typing.
   - intros ??? [? red] ? red' ?.
@@ -176,7 +195,7 @@ Proof.
     econstructor; tea.
     eapply redtywf_refl; gen_typing.
   - intros ??? [?? red] ?? ? red' ?.
-    eapply LRPi'. 
+    eapply LRPi'.
     unshelve erewrite (redtywf_det _ _ red' red); tea.
     1: constructor.
     econstructor.
@@ -197,7 +216,7 @@ Proof.
     econstructor; tea.
     eapply redtywf_refl; gen_typing.
   - intros ??? [?? red] ?? ? red' ?.
-    eapply LRSig'. 
+    eapply LRSig'.
     unshelve erewrite (redtywf_det _ _ red' red); tea.
     1: constructor.
     econstructor.
@@ -217,59 +236,111 @@ Proof.
   split; tea; irrelevance.
 Qed.
 
-Lemma IdProp_whnf {Γ l A} (IA : [Γ ||-Id<l> A]) t : IdProp IA t -> whnf t.
-Proof. intros []; constructor; destruct r; now eapply convneu_whne. Qed.
-
-Lemma redTmFwd {Γ l A t u} {RA : [Γ ||-<l> A]} : 
-  [Γ ||-<l> t : A | RA] -> [Γ |- t :⤳*: u : A] -> whnf u -> [Γ ||-<l> u : A | RA].
+Lemma redFwdURedTm {Γ l A t u} {h : [Γ ||-U<l> A]} :
+  [Γ |- t :⤳*: u : A] ->
+  whnf u ->
+  URedTm (LogRelRec l) Γ t A h ->
+  URedTm (LogRelRec l) Γ u A h.
 Proof.
-  revert t u; pattern l,Γ,A,RA; apply LR_rect_TyUr; clear l Γ A RA.
-  - intros ?????? [? red] red' ?.
-    unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: now eapply isType_whnf.
-    econstructor; tea.
-    1: eapply redtmwf_refl; gen_typing.
-    eapply RedTyRecBwd. eapply redFwd. 
-    2,3: gen_typing.
-    now eapply RedTyRecFwd.
-  - intros ??? ??? [? red] red' ?.
+  intros redtu whu rt.
+  destruct rt as [nf rednf]; exists nf; tea.
+  unshelve erewrite (redtmwf_det _ _ redtu rednf); tea.
+  1: now eapply isType_whnf.
+  eapply redtmwf_refl; gen_typing.
+Defined.
+
+Lemma redFwdPiRedTm {Γ l A t u} {h : [Γ ||-Π<l> A]} :
+  [Γ |- t :⤳*: u : A] ->
+  whnf u ->
+  PiRedTm h t ->
+  PiRedTm h u.
+Proof.
+  intros redtu whu rt; pose proof (PiRedTmEq.whnf rt).
+  destruct rt as [nf rednf]; exists nf; tea.
+  unshelve erewrite (redtmwf_det _ _ redtu rednf); tea.
+  eapply redtmwf_refl; gen_typing.
+Defined.
+
+Lemma redFwdSigRedTm {Γ l A t u} {h : [Γ ||-Σ<l> A]} :
+  [Γ |- t :⤳*: u : A] ->
+  whnf u ->
+  SigRedTm h t ->
+  SigRedTm h u.
+Proof.
+  intros redtu whu rt; pose proof (SigRedTmEq.whnf rt).
+  destruct rt as [nf rednf]; exists nf; tea.
+  unshelve erewrite (redtmwf_det _ _ redtu rednf); tea.
+  eapply redtmwf_refl; gen_typing.
+Defined.
+
+
+Lemma IdProp_whnf {Γ l A} (IA : [Γ ||-Id<l> A]) t u : IdPropEq IA t u -> whnf t × whnf u.
+Proof.
+  intros []; split; constructor.
+  1: destruct r; now eapply convneu_whne.
+  destruct r as[?? conv]; symmetry in conv; now eapply convneu_whne.
+Qed.
+
+Lemma redTmEqFwd {Γ l A t u v} {RA : [Γ ||-<l> A]} :
+  [Γ ||-<l> t ≅ v : A | RA] -> [Γ |- t :⤳*: u : A] -> whnf u -> [Γ ||-<l> u ≅ v : A | RA].
+Proof.
+  intros tv tu wu; transitivity t; tea.
+  revert t u tv tu wu; pattern l,Γ,A,RA; apply LR_rect_TyUr; clear l Γ A RA.
+  - intros ?????? [red] red' ?.
+    pose proof (invLRConvU h).
+    assert [Γ |- t :⤳*: u] by (eapply redtywf_term; gen_typing).
+    assert (ru : [Γ ||-<h.(URedTy.level)> u]).
+    1:eapply redFwd; tea; now eapply RedTyRecFwd.
+    exists (redFwdURedTm red' wu red) red (RedTyRecBwd _ ru); cbn; tea.
+    1: now eapply lrefl.
+    eapply TyEqRecBwd.
+    eapply LRTyEqSym.
+    eapply redSubst in ru as []; [| now eapply tyr_wf_red ].
+    irrelevance.
+    Unshelve. 2: now eapply RedTyRecFwd.
+  - intros ??? ??? [?? red] red' ?.
     unshelve erewrite (redtmwf_det _ _ red' red); tea.
     1: constructor; now eapply convneu_whne.
     econstructor; tea.
     eapply redtmwf_refl; gen_typing.
-  - intros ???????? [? red] red' ?.
+    now eapply lrefl.
+  - intros ???????? [red] red' wu.
+    pose proof (PiRedTmEq.whnf red).
+    unshelve eexists (redFwdPiRedTm red' wu red) red.
+    1: now eapply lrefl.
+    now eapply eqAppLRefl.
+  - intros ?????? Rt red' ?; inversion Rt as [???? red ?? prop] ; subst.
     unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: eapply isFun_whnf; destruct isfun; constructor; tea; now eapply convneu_whne.
+    1: now eapply fst, NatPropEq_whnf.
     econstructor; tea.
     eapply redtmwf_refl; gen_typing.
-  - intros ?????? Rt red' ?; inversion Rt; subst.
+    1: now eapply lrefl.
+    now eapply reflNatRedTmEq in prop as [].
+  - intros ?????? Rt red' ?; inversion Rt as [???? red ?? prop]; subst.
     unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: now eapply NatProp_whnf.
+    1:now eapply fst, (EmptyPropEq_whnf (NA:=NA)).
     econstructor; tea.
     eapply redtmwf_refl; gen_typing.
-  - intros ?????? Rt red' ?; inversion Rt; subst.
+    1: now eapply lrefl.
+    now eapply (reflEmptyRedTmEq (NA:=NA)) in prop as [].
+  - intros ???????? [red] red' ?.
+    pose proof (SigRedTmEq.whnf red).
+    unshelve eexists (redFwdSigRedTm red' wu red) red _.
+    all:cbn; intros; eapply lrefl; eauto.
+    irrelevanceRefl; unshelve eauto; tea.
+  - intros ???????? [?? red ?? prop] red' ?.
     unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: now eapply EmptyProp_whnf.
+    1: now eapply fst, IdPropEq_whnf.
     econstructor; tea.
     eapply redtmwf_refl; gen_typing.
-    Unshelve. 2: tea.
-  - intros ???????? [? red] red' ?.
-    unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: eapply isPair_whnf; destruct ispair; constructor; tea; now eapply convneu_whne.
-    econstructor; tea.
-    eapply redtmwf_refl; gen_typing.
-  - intros ???????? [? red] red' ?.
-    unshelve erewrite (redtmwf_det _ _ red' red); tea.
-    1: now eapply IdProp_whnf.
-    econstructor; tea.
-    eapply redtmwf_refl; gen_typing.
+    1: now eapply lrefl.
+    now eapply fst, reflIdPropEq.
 Qed.
 
-Lemma redTmFwdConv {Γ l A t u} {RA : [Γ ||-<l> A]} : 
-  [Γ ||-<l> t : A | RA] -> [Γ |- t :⤳*: u : A] -> whnf u -> [Γ ||-<l> u : A | RA] × [Γ ||-<l> t ≅ u : A | RA].
+Lemma redTmEqFwdBoth {Γ l A t t' w w'} {RA : [Γ ||-<l> A]} :
+  [Γ ||-<l> t ≅ t' : A | RA] -> [Γ |- t :⤳*: w : A] -> [Γ |- t' :⤳*: w' : A] -> whnf w -> whnf w' -> [Γ ||-<l> w ≅ w' : A | RA].
 Proof.
-  intros Rt red wh. pose (Ru := redTmFwd Rt red wh).
-  destruct (redwfSubstTerm RA Ru red); now split.
+  intros; eapply redTmEqFwd; tea; symmetry; eapply redTmEqFwd; tea; now symmetry.
 Qed.
 
 End Reduction.

--- a/theories/LogicalRelation/Reduction.v
+++ b/theories/LogicalRelation/Reduction.v
@@ -337,6 +337,35 @@ Proof.
     now eapply fst, reflIdPropEq.
 Qed.
 
+
+Lemma redTmEqNf {Γ l A t u} {RA : [Γ ||-<l> A]} :
+  [Γ ||-<l> t ≅ u : A | RA] -> ∑ (v : term), [Γ |- t :⤳*: v : A] × whnf v.
+Proof.
+  revert t u; pattern l,Γ,A,RA; apply LR_rect_TyUr; clear l Γ A RA.
+  - intros ??? h ??  [[]]; eexists; split; tea.
+    2: now eapply isType_whnf.
+    eapply redtmwf_conv; tea.
+    destruct h; cbn in *; gen_typing.
+  - intros ??? h ?? []; eexists; split; tea.
+    1: eapply redtmwf_conv; tea; destruct h; timeout 2 gen_typing.
+    constructor; now eapply convneu_whne.
+  - intros ??? h ???? [Rt]; pose proof (PiRedTmEq.whnf Rt); destruct Rt; cbn in *.
+    eexists; split; tea.
+    eapply redtmwf_conv; tea; destruct h; cbn in *; timeout 2 gen_typing.
+  - intros ??? h ?? [??????? []%NatPropEq_whnf]; eexists; split.
+    1: eapply redtmwf_conv; tea; destruct h; cbn in *; eapply convty_exp; gen_typing.
+    assumption.
+  - intros ??? h ?? [??????? []%(EmptyPropEq_whnf (NA:=h))]; eexists; split.
+    1: eapply redtmwf_conv; tea; destruct h; cbn in *; eapply convty_exp; gen_typing.
+    assumption.
+  - intros ??? h ???? [Rt]; pose proof (SigRedTmEq.whnf Rt); destruct Rt.
+    eexists; split; tea; cbn in *.
+    eapply redtmwf_conv; tea; destruct h; cbn in *; eapply convty_exp; gen_typing.
+  - intros ??? h ???? [????? [? _]%IdPropEq_whnf]; eexists; split; tea; cbn in *.
+    eapply redtmwf_conv; tea; destruct h; cbn in *; tea; unfold_id_outTy; cbn.
+    eapply convty_exp; gen_typing.
+  Qed.
+
 Lemma redTmEqFwdBoth {Γ l A t t' w w'} {RA : [Γ ||-<l> A]} :
   [Γ ||-<l> t ≅ t' : A | RA] -> [Γ |- t :⤳*: w : A] -> [Γ |- t' :⤳*: w' : A] -> whnf w -> whnf w' -> [Γ ||-<l> w ≅ w' : A | RA].
 Proof.

--- a/theories/LogicalRelation/ShapeView.v
+++ b/theories/LogicalRelation/ShapeView.v
@@ -14,8 +14,8 @@ Section ShapeViews.
   in the same way. *)
 
   Definition ShapeView@{i j k l i' j' k' l'} Γ
-    A {lA eqTyA redTmA redTyA} B {lB eqTyB redTmB redTyB}
-    (lrA : LogRel@{i j k l} lA Γ A eqTyA redTmA redTyA) (lrB : LogRel@{i' j' k' l'} lB Γ B eqTyB redTmB redTyB) : Set :=
+    A {lA eqTyA redTyA} B {lB eqTyB redTyB}
+    (lrA : LogRel@{i j k l} lA Γ A eqTyA redTyA) (lrB : LogRel@{i' j' k' l'} lB Γ B eqTyB redTyB) : Set :=
     match lrA, lrB with
       | LRU _ _, LRU _ _ => True
       | LRne _ _, LRne _ _ => True
@@ -27,7 +27,7 @@ Section ShapeViews.
       | _, _ => False
     end.
 
-  Arguments ShapeView Γ A {lA eqTyA redTmA redTyA} B {lB eqTyB redTmB redTyB}
+  Arguments ShapeView Γ A {lA eqTyA redTyA} B {lB eqTyB redTyB}
   !lrA !lrB.
 
 (** ** The main property *)
@@ -37,32 +37,32 @@ if two reducible types are reducibly convertible, then they must be reducible in
 This lets us relate different reducibility proofs when we have multiple such proofs, typically
 when showing symmetry or transitivity of the logical relation. *)
 
-  Arguments ShapeView Γ A {lA eqTyA redTmA redTyA} B {lB eqTyB redTmB redTyB}
+  Arguments ShapeView Γ A {lA eqTyA redTyA} B {lB eqTyB redTyB}
   !lrA !lrB.
 
 
-  Lemma red_whnf@{i j k l} {Γ A lA eqTyA redTmA eqTmA}
-    (lrA : LogRel@{i j k l} lA Γ A eqTyA redTmA eqTmA) : 
+  Lemma red_whnf@{i j k l} {Γ A lA eqTyA eqTmA}
+    (lrA : LogRel@{i j k l} lA Γ A eqTyA eqTmA) :
     ∑ nf, [Γ |- A :⤳*: nf] × whnf nf.
   Proof.
-    pattern lA, Γ, A, eqTyA, redTmA, eqTmA, lrA; eapply LR_rect; intros ??[].
+    pattern lA, Γ, A, eqTyA, eqTmA, lrA; eapply LR_rect; intros ??[].
     all: eexists; split; tea; constructor; tea.
     now eapply convneu_whne.
   Defined.
 
-  Lemma eqTy_red_whnf@{i j k l} {Γ A lA eqTyA redTmA eqTmA B}
-    (lrA : LogRel@{i j k l} lA Γ A eqTyA redTmA eqTmA) : 
+  Lemma eqTy_red_whnf@{i j k l} {Γ A lA eqTyA eqTmA B}
+    (lrA : LogRel@{i j k l} lA Γ A eqTyA eqTmA) :
     eqTyA B -> ∑ nf, [Γ |- B :⤳*: nf] × whnf nf.
   Proof.
-    pattern lA, Γ, A, eqTyA, redTmA, eqTmA, lrA.
+    pattern lA, Γ, A, eqTyA, eqTmA, lrA.
     eapply LR_rect_LogRelRec@{i j k l k}; intros ??? [].
     3,6,7: intros ??.
     all: intros []; eexists; split; tea; constructor; tea.
     eapply convneu_whne; now symmetry.
   Defined.
 
-  Lemma ShapeViewConv@{i j k l i' j' k' l'} {Γ A lA eqTyA redTmA eqTmA B lB eqTyB redTmB eqTmB}
-    (lrA : LogRel@{i j k l} lA Γ A eqTyA redTmA eqTmA) (lrB : LogRel@{i' j' k' l'} lB Γ B eqTyB redTmB eqTmB) :
+  Lemma ShapeViewConv@{i j k l i' j' k' l'} {Γ A lA eqTyA eqTmA B lB eqTyB eqTmB}
+    (lrA : LogRel@{i j k l} lA Γ A eqTyA eqTmA) (lrB : LogRel@{i' j' k' l'} lB Γ B eqTyB eqTmB) :
     eqTyA B ->
     ShapeView@{i j k l i' j' k' l'} Γ A B lrA lrB.
   Proof.
@@ -70,7 +70,7 @@ when showing symmetry or transitivity of the logical relation. *)
     pose (x := eqTy_red_whnf lrA eqAB).
     pose (y:= red_whnf lrB).
     pose proof (h := redtywf_det (snd x.π2) (snd y.π2) (fst x.π2) (fst y.π2)).
-    revert eqAB x y h. 
+    revert eqAB x y h.
     destruct lrA; destruct lrB; intros []; cbn; try easy; try discriminate.
     all: try now (intros e; destruct neA as [? ? ne]; subst; apply convneu_whne in ne; inversion ne).
     all: try now (intros e; subst; symmetry in eq; apply convneu_whne in eq; inversion eq).

--- a/theories/LogicalRelation/Universe.v
+++ b/theories/LogicalRelation/Universe.v
@@ -13,15 +13,15 @@ Section UniverseReducibility.
     intros ?%escape; econstructor; [easy| gen_typing|eapply redtywf_refl; gen_typing].
   Qed.
 
-  Lemma UnivEq'@{i j k l} {Γ A l} (rU : [ LogRel@{i j k l} l | Γ ||- U ]) (rA : [ LogRel@{i j k l} l | Γ ||- A : U | rU])
+  Lemma UnivEq'@{i j k l} {Γ A B l} (rU : [ LogRel@{i j k l} l | Γ ||- U ]) (rA : [ LogRel@{i j k l} l | Γ ||- A ≅ B : U | rU])
     : [ LogRel@{i j k l} zero | Γ ||- A].
   Proof.
-    assert [ LogRel@{i j k l} one | Γ ||- A : U | LRU_@{i j k l} (redUOne rU)]
-             as [ _ _ _ _ hA ] by irrelevance.
+    assert [ LogRel@{i j k l} one | Γ ||- A ≅ B : U | LRU_@{i j k l} (redUOne rU)]
+             as [ ? ?? hA ] by irrelevance.
     exact (LRCumulative hA).
   Qed.
 
-  Lemma UnivEq@{i j k l} {Γ A l} l' (rU : [ LogRel@{i j k l} l | Γ ||- U]) (rA : [ LogRel@{i j k l} l | Γ ||- A : U | rU])
+  Lemma UnivEq@{i j k l} {Γ A B l} l' (rU : [ LogRel@{i j k l} l | Γ ||- U]) (rA : [ LogRel@{i j k l} l | Γ ||- A ≅ B : U | rU])
     : [ LogRel@{i j k l} l' | Γ ||- A].
   Proof.
     destruct l'.
@@ -37,31 +37,5 @@ Section UniverseReducibility.
     assert [ LogRel@{i j k l} one | Γ ||- A ≅ B : U | LRU_@{i j k l} (redUOne rU) ] as [ _ _ _ hA _ hAB ] by irrelevance.
     eapply LRTyEqIrrelevantCum. exact hAB.
   Qed.
-
-
-  (* The lemmas below does not seem to be
-     at the right levels for fundamental lemma ! *)
-
-  Set Printing Universes.
-  Lemma univTmTy'@{h i j k l} {Γ l UU A} (h : [Γ ||-U<l> UU ]) :
-    [LogRel@{i j k l} l | Γ ||- A : UU | LRU_ h] -> [LogRel@{h i j k} (URedTy.level h) | Γ ||- A].
-  Proof.  intros []; now eapply RedTyRecFwd. Qed.
-
-  Lemma univTmTy@{h i j k l} {Γ l A} (RU : [Γ ||-<l> U]) :
-    [LogRel@{i j k l} l | Γ ||- A : U | RU] -> [LogRel@{h i j k} (URedTy.level (invLRU RU)) | Γ ||- A].
-  Proof.
-    intros h; apply univTmTy'.
-    irrelevance.
-  Qed.
-
-  Lemma univEqTmEqTy'@{h i j k l} {Γ l l' UU A B} (h : [Γ ||-U<l> UU]) (RA : [Γ ||-<l'> A]) :
-    [LogRel@{i j k l} l | Γ ||- A ≅ B : UU | LRU_ h] ->
-    [LogRel@{h i j k} l' | Γ ||- A ≅ B | RA].
-  Proof. intros [????? RA']. apply TyEqRecFwd in RA'. irrelevance. Qed.
-
-  Lemma univEqTmEqTy@{h i j k l} {Γ l l' A B} (RU : [Γ ||-<l> U]) (RA : [Γ ||-<l'> A]) :
-    [LogRel@{i j k l} l | Γ ||- A ≅ B : U | RU] ->
-    [LogRel@{h i j k} l' | Γ ||- A ≅ B | RA].
-  Proof. intros h; eapply (univEqTmEqTy' (invLRU RU)); irrelevance. Qed.
 
 End UniverseReducibility.

--- a/theories/LogicalRelation/Universe.v
+++ b/theories/LogicalRelation/Universe.v
@@ -8,9 +8,14 @@ Set Printing Universes.
 Section UniverseReducibility.
   Context `{GenericTypingProperties}.
 
+  Lemma redUOneCtx {Γ} : [|- Γ] -> [Γ ||-U<one> U].
+  Proof.
+    intros ; econstructor; [easy| gen_typing|eapply redtywf_refl; gen_typing].
+  Defined.
+
   Lemma redUOne {Γ l A} : [Γ ||-<l> A] -> [Γ ||-U<one> U].
   Proof.
-    intros ?%escape; econstructor; [easy| gen_typing|eapply redtywf_refl; gen_typing].
+    intros ?%escape; eapply redUOneCtx; gen_typing.
   Qed.
 
   Lemma UnivEq'@{i j k l} {Γ A B l} (rU : [ LogRel@{i j k l} l | Γ ||- U ]) (rA : [ LogRel@{i j k l} l | Γ ||- A ≅ B : U | rU])

--- a/theories/LogicalRelation/Weakening.v
+++ b/theories/LogicalRelation/Weakening.v
@@ -11,21 +11,21 @@ Section Weakenings.
   Lemma wkU {Γ Δ l A} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (h : [Γ ||-U<l> A]) : [Δ ||-U<l> A⟨ρ⟩].
   Proof. destruct h; econstructor; tea; change U with U⟨ρ⟩; gen_typing. Defined.
 
-  Lemma wkPoly {Γ l shp pos Δ}  (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) : 
-    PolyRed Γ l shp pos -> 
+  Lemma wkPoly {Γ l shp pos Δ}  (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) :
+    PolyRed Γ l shp pos ->
     PolyRed Δ l shp⟨ρ⟩ pos⟨wk_up shp ρ⟩.
   Proof.
     intros []; opector.
     - intros ? ρ' ?; replace (_⟨_⟩) with (shp⟨ρ' ∘w ρ⟩) by now bsimpl.
       now eapply shpRed.
-    - intros ? a ρ' **. 
+    - intros ? a b ρ' **.
       replace (pos⟨_⟩[a .: ρ' >> tRel]) with (pos[ a .: (ρ' ∘w ρ) >> tRel]) by now bsimpl.
       econstructor; unshelve eapply posRed; tea; irrelevance.
     - now eapply wft_wk.
     - eapply wft_wk; tea; eapply wfc_cons; tea; now eapply wft_wk.
     - intros ? a b ρ'  wfΔ' **.
       replace (_[b .: ρ' >> tRel]) with (pos[ b .: (ρ' ∘w ρ) >> tRel]) by (now bsimpl).
-      unshelve epose (posExt _ a b (ρ' ∘w ρ) wfΔ' _ _ _); irrelevance.
+      unshelve epose (posExt _ a b (ρ' ∘w ρ) wfΔ' _); irrelevance.
   Qed.
 
   Lemma wkΠ  {Γ Δ A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Π< l > A]) :
@@ -47,45 +47,38 @@ Section Weakenings.
   Defined.
 
   Lemma wkNat {Γ A Δ} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) : [Γ ||-Nat A] -> [Δ ||-Nat A⟨ρ⟩].
-  Proof. 
+  Proof.
     intros []; constructor.
     change tNat with tNat⟨ρ⟩.
-    gen_typing. 
+    gen_typing.
   Qed.
 
   Lemma wkEmpty {Γ A Δ} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) : [Γ ||-Empty A] -> [Δ ||-Empty A⟨ρ⟩].
-  Proof. 
+  Proof.
     intros []; constructor.
     change tEmpty with tEmpty⟨ρ⟩.
-    gen_typing. 
+    gen_typing.
   Qed.
 
   Lemma wkId@{i j k l} {Γ l A Δ} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) :
     IdRedTy@{i j k l} Γ l A -> IdRedTy@{i j k l} Δ l A⟨ρ⟩.
     (* [Γ ||-Id<l> A] -> [Δ ||-Id<l> A⟨ρ⟩]. *)
-  Proof. 
+  Proof.
     intros []; unshelve econstructor.
     6: erewrite wk_Id; now eapply redtywf_wk.
     3: rewrite wk_Id; gen_typing.
     - now apply tyKripke.
     - intros; rewrite wk_comp_ren_on; now apply tyKripke.
-    - unshelve eapply tyKripkeTm; [eapply wk_id| gen_typing| now rewrite wk_comp_runit| irrelevance].
-    - unshelve eapply tyKripkeTm; [eapply wk_id| gen_typing| now rewrite wk_comp_runit| irrelevance].
     (* could also employ reflexivity instead *)
     - unshelve eapply tyKripkeTmEq; [eapply wk_id| gen_typing| now rewrite wk_comp_runit|irrelevance].
     - unshelve eapply tyKripkeTmEq; [eapply wk_id| gen_typing| now rewrite wk_comp_runit|irrelevance].
-    - apply perLRTmEq.
-    - intros; irrelevance0.  
+    - apply LRTmEqPER.
+    - intros; irrelevance0.
       1: now rewrite wk_comp_ren_on.
       unshelve eapply tyKripkeEq; tea.
       3: irrelevance; now rewrite wk_comp_ren_on.
       bsimpl; setoid_rewrite H10; now bsimpl.
-    - intros; irrelevance0.  
-      1: now rewrite wk_comp_ren_on.
-      unshelve eapply tyKripkeTm; tea.
-      3: irrelevance; now rewrite wk_comp_ren_on.
-      bsimpl; setoid_rewrite H10; now bsimpl.
-    - intros; irrelevance0.  
+    - intros; irrelevance0.
       1: now rewrite wk_comp_ren_on.
       unshelve eapply tyKripkeTmEq; tea.
       3: irrelevance; now rewrite wk_comp_ren_on.
@@ -115,7 +108,7 @@ Section Weakenings.
   Lemma wkΠ_eq {Γ Δ A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Π< l > A]) :
     wk ρ wfΔ (LRPi' ΠA) = LRPi' (wkΠ ρ wfΔ ΠA).
   Proof. reflexivity. Qed.
-  
+
   #[local]
   Lemma wkΣ_eq {Γ Δ A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Σ< l > A]) :
     wk ρ wfΔ (LRSig' ΠA) = LRSig' (wkΣ ρ wfΔ ΠA).
@@ -123,13 +116,13 @@ Section Weakenings.
 
   Set Printing Primitive Projection Parameters.
 
-  Lemma wkPolyEq {Γ l shp shp' pos pos' Δ}  (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (PA : PolyRed Γ l shp pos) : 
+  Lemma wkPolyEq {Γ l shp shp' pos pos' Δ}  (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (PA : PolyRed Γ l shp pos) :
     PolyRedEq PA shp' pos' -> PolyRedEq (wkPoly ρ wfΔ PA) shp'⟨ρ⟩ pos'⟨wk_up shp' ρ⟩.
   Proof.
     intros []; opector.
     - intros ? ρ' wfΔ'; replace (_⟨_⟩) with (shp'⟨ρ' ∘w ρ⟩) by now bsimpl.
       pose (shpRed _ (ρ' ∘w ρ) wfΔ'); irrelevance.
-    - intros ?? ρ' wfΔ' ha.
+    - intros ??? ρ' wfΔ' ha.
       replace (_[_ .: ρ' >> tRel]) with (pos'[ a .: (ρ' ∘w ρ) >> tRel]) by now bsimpl.
       irrelevance0.
       2: unshelve eapply posRed; tea; irrelevance.
@@ -137,7 +130,7 @@ Section Weakenings.
   Qed.
 
 
-  Lemma wkEq@{i j k l} {Γ Δ A B l} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (lrA : [Γ ||-<l> A]) : 
+  Lemma wkEq@{i j k l} {Γ Δ A B l} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (lrA : [Γ ||-<l> A]) :
     [LogRel@{i j k l} l | Γ ||- A ≅ B | lrA] ->
     [LogRel@{i j k l} l | Δ ||- A⟨ρ⟩ ≅ B⟨ρ⟩ | wk ρ wfΔ lrA].
   Proof.
@@ -183,11 +176,12 @@ Section Weakenings.
     irrelevance0; [apply eq|].
     rewrite <- eq.
     now unshelve apply Hdom.
-  + intros Ξ a ρ' wfΞ *; cbn.
+  + intros Ξ a b ρ' wfΞ *; cbn.
     assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
-    unshelve eassert (Ht0 := Ht Ξ a (ρ' ∘w ρ) wfΞ _).
+    unshelve eassert (Ht0 := Ht Ξ a b (ρ' ∘w ρ) wfΞ _).
     { cbn in ha; irrelevance0; [symmetry; apply eq|tea]. }
     replace (t'⟨upRen_term_term ρ⟩[a .: ρ' >> tRel]) with (t'[a .: (ρ' ∘w ρ) >> tRel]) by now bsimpl.
+    replace (t'⟨upRen_term_term ρ⟩[b .: ρ' >> tRel]) with (t'[b .: (ρ' ∘w ρ) >> tRel]) by now bsimpl.
     irrelevance0; [|apply Ht0].
     now bsimpl.
   + change [Δ |- f⟨ρ⟩ ~ f⟨ρ⟩ : (tProd (PiRedTy.dom ΠA) (PiRedTy.cod ΠA))⟨ρ⟩].
@@ -195,34 +189,16 @@ Section Weakenings.
   Qed.
 
   (* TODO: use program or equivalent to have only the first field non-opaque *)
-  Lemma wkΠTerm {Γ Δ u A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Π< l > A]) 
-    (ΠA' := wkΠ ρ wfΔ ΠA) : 
-    [Γ||-Π u : A | ΠA] -> 
-    [Δ ||-Π u⟨ρ⟩ : A⟨ρ⟩ | ΠA' ].
+  Lemma wkΠTerm {Γ Δ u A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Π< l > A])
+    (ΠA' := wkΠ ρ wfΔ ΠA) : PiRedTm ΠA u -> PiRedTm ΠA' u⟨ρ⟩.
   Proof.
     intros [t].
     exists (t⟨ρ⟩); try change (tProd _ _) with (ΠA.(outTy)⟨ρ⟩).
     + now eapply redtmwf_wk.
     + now apply isLRFun_ren.
-    + now apply convtm_wk.
-    + intros ? a ρ' ??.
-      replace ((t ⟨ρ⟩)⟨ ρ' ⟩) with (t⟨ρ' ∘w ρ⟩) by now bsimpl.
-      irrelevance0.
-      2: unshelve apply app; [eassumption|]; subst ΠA'; irrelevance. 
-      subst ΠA'; bsimpl; try rewrite scons_comp'; reflexivity.
-    + intros ??? ρ' ?????.
-      replace ((t ⟨ρ⟩)⟨ ρ' ⟩) with (t⟨ρ' ∘w ρ⟩) by now bsimpl.
-      irrelevance0.
-      2: unshelve apply eq; [eassumption|..]; subst ΠA'; irrelevance.
-      subst ΠA'; bsimpl; try rewrite scons_comp'; reflexivity.
   Defined.
 
-  Lemma wkNeNf {Γ Δ k A} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) : 
-    [Γ ||-NeNf k : A] -> [Δ ||-NeNf k⟨ρ⟩ : A⟨ρ⟩].
-  Proof.
-    intros []; constructor. all: gen_typing.
-  Qed.  
-  
+
   Lemma isLRPair_ren : forall Γ Δ t A l (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΣA : [Γ ||-Σ< l > A]),
     isLRPair ΣA t -> isLRPair (wkΣ ρ wfΔ ΣA) t⟨ρ⟩.
   Proof.
@@ -236,46 +212,37 @@ Section Weakenings.
     irrelevance0; [apply eq|].
     rewrite <- eq.
     now unshelve apply Hdom.
-  + intros Ξ a' ρ' wfΞ ha'; cbn.
+  + intros Ξ a' b' ρ' wfΞ ha'; cbn.
     assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
-    unshelve eassert (Hcod0 := Hcod Ξ a' (ρ' ∘w ρ) wfΞ _).
+    unshelve eassert (Hcod0 := Hcod Ξ a' b' (ρ' ∘w ρ) wfΞ _).
     { cbn in ha'; irrelevance0; [symmetry; apply eq|tea]. }
-    replace (B'⟨upRen_term_term ρ⟩[a' .: ρ' >> tRel]) with B'[a' .: (ρ' ∘w ρ) >> tRel] by now bsimpl.
+    replace (B'⟨upRen_term_term ρ⟩[b' .: ρ' >> tRel]) with B'[b' .: (ρ' ∘w ρ) >> tRel] by now bsimpl.
     irrelevance0; [|apply Hcod0].
     now bsimpl.
   + refold; intros Ξ ρ' wfΞ.
     assert (eq : forall t, t⟨ρ' ∘w ρ⟩ = t⟨ρ⟩⟨ρ'⟩) by now bsimpl.
-    rewrite <- eq.
-    irrelevance0; [|now unshelve apply Hsnd].
+    irrelevance0.
+    2:rewrite <- eq; now unshelve apply Hsnd.
     now bsimpl.
   + change [Δ |- p⟨ρ⟩ ~ p⟨ρ⟩ : (tSig (SigRedTy.dom ΣA) (SigRedTy.cod ΣA))⟨ρ⟩].
     now eapply convneu_wk.
   Qed.
 
-  Lemma wkΣTerm {Γ Δ u A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Σ< l > A]) 
-    (ΠA' := wkΣ ρ wfΔ ΠA) : 
-    [Γ||-Σ u : A | ΠA] -> 
-    [Δ ||-Σ u⟨ρ⟩ : A⟨ρ⟩ | ΠA' ].
+  Lemma wkΣTerm {Γ Δ u A l} (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (ΠA : [Γ ||-Σ< l > A])
+    (ΠA' := wkΣ ρ wfΔ ΠA) : SigRedTm ΠA u -> SigRedTm ΠA' u⟨ρ⟩.
   Proof.
-    intros [t]. 
-    unshelve eexists (t⟨ρ⟩) _; try (cbn; rewrite wk_sig).
-    + intros ? ρ' wfΔ'; rewrite wk_comp_ren_on; irrelevance0.
-      2: now unshelve eapply fstRed.
-      cbn; symmetry; apply wk_comp_ren_on.
+    intros [t].
+    unshelve eexists (t⟨ρ⟩); try (cbn; rewrite wk_sig).
     + now eapply redtmwf_wk.
     + apply isLRPair_ren; assumption.
-    + eapply convtm_wk; eassumption.
-    + intros ? ρ' ?;  irrelevance0.
-      2: rewrite wk_comp_ren_on; now unshelve eapply sndRed.
-      rewrite <- wk_comp_ren_on; cbn; now rewrite <- wk_up_ren_subst.
   Defined.
 
-  Lemma wkTerm {Γ Δ t A l} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (lrA : [Γ ||-<l> A]) : 
+  (* Lemma wkTerm {Γ Δ t A l} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (lrA : [Γ ||-<l> A]) :
     [Γ ||-<l> t : A | lrA] -> [Δ ||-<l> t⟨ρ⟩ : A⟨ρ⟩ | wk ρ wfΔ lrA].
   Proof.
     revert t Δ ρ wfΔ. pattern l, Γ, A, lrA.
     eapply LR_rect_TyUr; clear l Γ A lrA.
-    - intros ?????? ρ ? [te]; exists te⟨ρ⟩;  try change U with U⟨ρ⟩.
+    - intros ?????? ρ ? [te]; unshelve eexists te⟨ρ⟩ _ _;  try change U with U⟨ρ⟩.
       + gen_typing.
       + apply isType_ren; assumption.
       + now apply convtm_wk.
@@ -283,14 +250,14 @@ Section Weakenings.
     - intros ?????? ρ ? [te]. exists te⟨ρ⟩; cbn.
       + now eapply redtmwf_wk.
       + apply convneu_wk; assumption.
-    - intros; now apply wkΠTerm. 
+    - intros; now apply wkΠTerm.
     - intros??? NA t ? ρ wfΔ; revert t; pose (NA' := wkNat ρ wfΔ NA).
       set (G := _); enough (h : G × (forall t, NatProp NA t -> NatProp NA' t⟨ρ⟩)) by apply h.
       subst G; apply NatRedInduction.
       + intros; econstructor; tea; change tNat with tNat⟨ρ⟩; gen_typing.
       + constructor.
       + now constructor.
-      + intros; constructor. 
+      + intros; constructor.
         change tNat with tNat⟨ρ⟩.
         now eapply wkNeNf.
     - intros??? NA t ? ρ wfΔ; revert t; pose (NA' := wkEmpty ρ wfΔ NA).
@@ -306,7 +273,7 @@ Section Weakenings.
       + destruct prop. econstructor.
         change tEmpty with tEmpty⟨ρ⟩.
         now eapply wkNeNf.
-    - intros; now apply wkΣTerm. 
+    - intros; now apply wkΣTerm.
     - intros * _ _ * [??? prop]; econstructor; unfold_id_outTy; cbn; rewrite ?wk_Id.
       1: now eapply redtmwf_wk.
       1: now eapply convtm_wk.
@@ -318,26 +285,23 @@ Section Weakenings.
       2,3: eapply IA.(IdRedTy.tyKripkeTmEq); [now rewrite wk_comp_runit| irrelevance].
       eapply IA.(IdRedTy.tyKripkeEq); [now rewrite wk_comp_runit| irrelevance].
       Unshelve. all: tea.
-  Qed.
+  Qed. *)
 
   Lemma wkUTerm {Γ Δ l A t} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (h : [Γ ||-U<l> A]) :
-    [LogRelRec l| Γ ||-U t : A | h ] -> [LogRelRec l | Δ||-U t⟨ρ⟩ : A⟨ρ⟩ | wkU ρ wfΔ h].
+    URedTm (LogRelRec l) Γ t A h -> URedTm (LogRelRec l) Δ t⟨ρ⟩ A⟨ρ⟩ (wkU ρ wfΔ h).
   Proof.
     intros [te]. exists te⟨ρ⟩; change U with U⟨ρ⟩.
     - gen_typing.
     - apply isType_ren; assumption.
-    - now apply convtm_wk.
-    - destruct l; [destruct (elim (URedTy.lt h))|cbn].
-      eapply (wk (l:=zero)); eassumption.
   Defined.
 
-  Lemma wkNeNfEq {Γ Δ k k' A} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) : 
+  Lemma wkNeNfEq {Γ Δ k k' A} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) :
     [Γ ||-NeNf k ≅ k' : A] -> [Δ ||-NeNf k⟨ρ⟩ ≅ k'⟨ρ⟩ : A⟨ρ⟩].
   Proof.
-    intros []; constructor. gen_typing.
-  Qed.  
+    intros []; constructor; gen_typing.
+  Qed.
 
-  Lemma wkTermEq {Γ Δ t u A l} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (lrA : [Γ ||-<l> A]) : 
+  Lemma wkTermEq {Γ Δ t u A l} (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]) (lrA : [Γ ||-<l> A]) :
     [Γ ||-<l> t ≅ u : A | lrA] -> [Δ ||-<l> t⟨ρ⟩ ≅ u⟨ρ⟩: A⟨ρ⟩ | wk ρ wfΔ lrA].
   Proof.
     revert t u Δ ρ wfΔ. pattern l, Γ, A, lrA.
@@ -347,7 +311,7 @@ Section Weakenings.
       + exact (wkUTerm ρ wfΔ h rL).
       + exact (wkUTerm ρ wfΔ h rR).
       + apply RedTyRecBwd; apply wk; [assumption|]; now apply (RedTyRecFwd h).
-      + cbn. change U with U⟨ρ⟩. 
+      + cbn. change U with U⟨ρ⟩.
         now eapply convtm_wk.
       + apply RedTyRecBwd; apply wk; [assumption|]; now apply (RedTyRecFwd h).
       + apply TyEqRecBwd. eapply wkEq. now apply TyEqRecFwd.
@@ -355,7 +319,7 @@ Section Weakenings.
       exists (tL⟨ρ⟩) (tR⟨ρ⟩); cbn.
       1,2: now eapply redtmwf_wk.
       now eapply convneu_wk.
-    - intros * ?? * []; rewrite wkΠ_eq. 
+    - intros * ?? * []; rewrite wkΠ_eq.
       unshelve econstructor; cbn; try rewrite wk_prod.
       1,2: now eapply wkΠTerm.
       + now eapply convtm_wk.
@@ -369,7 +333,7 @@ Section Weakenings.
       + intros; econstructor; tea; change tNat with tNat⟨ρ⟩; gen_typing.
       + constructor.
       + now constructor.
-      + intros; constructor. 
+      + intros; constructor.
         change tNat with tNat⟨ρ⟩.
         now eapply wkNeNfEq.
     - intros??? NA t u ? ρ wfΔ; revert t u; pose (NA' := wkEmpty ρ wfΔ NA).
@@ -385,13 +349,13 @@ Section Weakenings.
       + destruct prop. econstructor.
         change tEmpty with tEmpty⟨ρ⟩.
         now eapply wkNeNfEq.
-    - intros * ?? * []; rewrite wkΣ_eq. 
+    - intros * ?? * []; rewrite wkΣ_eq.
       unshelve econstructor; cbn; try rewrite wk_sig.
       1,2: now eapply wkΣTerm.
-      + now eapply convtm_wk.
       + intros; cbn; do 2 rewrite wk_comp_ren_on.
         irrelevance0. 2: now unshelve eapply eqFst.
         now rewrite wk_comp_ren_on.
+      + now eapply convtm_wk.
       + intros; cbn; irrelevance0.
         2: do 2 rewrite wk_comp_ren_on; now unshelve eapply eqSnd.
         rewrite wk_comp_ren_on; now rewrite <- wk_up_ren_subst.

--- a/theories/Normalisation.v
+++ b/theories/Normalisation.v
@@ -168,7 +168,7 @@ Section Normalisation.
     - constructor.
     - destruct H as [? ? ? H].
       apply escapeEq in H as []; now split.
-    - destruct H as [? ? ? ? H].
+    - destruct H as [? ?  H].
       apply escapeTmEq in H as []; now split.
   Qed.
 

--- a/theories/Substitution/Conversion.v
+++ b/theories/Substitution/Conversion.v
@@ -2,7 +2,7 @@ From Coq Require Import CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
 From LogRel.LogicalRelation Require Import Irrelevance Escape Reflexivity Weakening Neutral.
-From LogRel.Substitution Require Import  Irrelevance Properties.
+From LogRel.Substitution Require Import  Irrelevance Properties Reflexivity.
 
 Set Universe Polymorphism.
 
@@ -12,29 +12,7 @@ Context `{GenericTypingProperties}.
 Set Printing Primitive Projection Parameters.
 
 
-Lemma conv {Γ t A B l} (VΓ : [||-v Γ])
-  (VA : [Γ ||-v<l> A | VΓ])
-  (VB : [Γ ||-v<l> B | VΓ])
-  (VeqAB : [Γ ||-v<l> A ≅ B | VΓ | VA])
-  (Vt : [Γ ||-v<l> t : A | VΓ | VA]) :
-  [Γ ||-v<l> t : B | VΓ | VB].
-Proof.
-  constructor; intros; eapply LRTmEqConv.
-  2: now unshelve now eapply validTmExt.
-  now eapply validTyEqLeft.
-Qed.
-
-Lemma convsym {Γ t A B l} (VΓ : [||-v Γ])
-  (VA : [Γ ||-v<l> A | VΓ])
-  (VB : [Γ ||-v<l> B | VΓ])
-  (VeqAB : [Γ ||-v<l> A ≅ B | VΓ | VA])
-  (Vt : [Γ ||-v<l> t : B | VΓ | VB]) :
-  [Γ ||-v<l> t : A | VΓ | VA].
-Proof.
-  eapply conv; tea; now eapply symValidTyEq.
-Qed.
-
-Lemma convEq {Γ t u A B l} (VΓ : [||-v Γ])
+Lemma conv {Γ t u A B l} (VΓ : [||-v Γ])
   (VA : [Γ ||-v<l> A | VΓ])
   (VB : [Γ ||-v<l> B | VΓ])
   (VeqAB : [Γ ||-v<l> A ≅ B | VΓ | VA])
@@ -42,9 +20,28 @@ Lemma convEq {Γ t u A B l} (VΓ : [||-v Γ])
   [Γ ||-v<l> t ≅ u : B | VΓ | VB].
 Proof.
   constructor; intros; eapply LRTmEqConv.
-  1: (unshelve now eapply validTyEqLeft); cycle 2; tea.
-  now eapply validTmEq.
+  2: now unshelve now eapply validTmEq.
+  now eapply validTyEqLeft.
 Qed.
+
+Lemma convsym {Γ t u A B l} (VΓ : [||-v Γ])
+  (VA : [Γ ||-v<l> A | VΓ])
+  (VB : [Γ ||-v<l> B | VΓ])
+  (VeqAB : [Γ ||-v<l> A ≅ B | VΓ | VA])
+  (Vt : [Γ ||-v<l> t ≅ u : B | VΓ | VB]) :
+  [Γ ||-v<l> t ≅ u : A | VΓ | VA].
+Proof.
+  eapply conv; tea; now eapply symValidTyEq.
+Qed.
+
+#[deprecated(note="Use conv")]
+Lemma convEq {Γ t u A B l} (VΓ : [||-v Γ])
+  (VA : [Γ ||-v<l> A | VΓ])
+  (VB : [Γ ||-v<l> B | VΓ])
+  (VeqAB : [Γ ||-v<l> A ≅ B | VΓ | VA])
+  (Vt : [Γ ||-v<l> t ≅ u : A | VΓ | VA]) :
+  [Γ ||-v<l> t ≅ u : B | VΓ | VB].
+Proof. now eapply conv. Qed.
 
 
 Lemma convSubstEqCtx1 {Γ Δ A B l σ σ'}
@@ -53,7 +50,6 @@ Lemma convSubstEqCtx1 {Γ Δ A B l σ σ'}
   (VΓA : [||-v Γ ,, A])
   (VΓB : [||-v Γ ,, B])
   (VA : [_ ||-v<l> A | VΓ])
-  (VB : [_ ||-v<l> B | VΓ])
   (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
   (Vσσ': [_ ||-v σ ≅ σ' : _ | VΓA | wfΔ]) :
   [_ ||-v σ ≅ σ' : _ | VΓB | wfΔ].
@@ -67,7 +63,7 @@ Proof.
   1: epose (eqTail Vσσ'); irrValid.
   eapply LRTmEqConv.
   2: irrelevanceRefl; eapply eqHead.
-  eapply validTyEqLeft; [exact VB| exact VAB].
+  eapply validTyEqLeft; [eapply ureflValidTy |]; exact VAB.
   Unshelve. 6: tea.
     3: eapply irrelevanceSubstEq; now eapply eqTail.
     tea.
@@ -78,7 +74,6 @@ Lemma convCtx1 {Γ A B P l}
   (VΓA : [||-v Γ ,, A])
   (VΓB : [||-v Γ ,, B])
   (VA : [_ ||-v<l> A | VΓ])
-  (VB : [_ ||-v<l> B | VΓ])
   (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
   (VP : [_ ||-v<l> P | VΓA]) :
   [_ ||-v<l> P | VΓB].
@@ -88,7 +83,7 @@ Proof.
   - irrelevanceRefl; unshelve eapply validTyExt.
     3,4: tea.
     eapply convSubstEqCtx1; tea; now eapply symValidTyEq.
-    Unshelve. all: tea.
+    Unshelve. all: tea; now eapply ureflValidTy.
 Qed.
 
 Lemma convEqCtx1 {Γ A B P Q l}
@@ -96,7 +91,6 @@ Lemma convEqCtx1 {Γ A B P Q l}
   (VΓA : [||-v Γ ,, A])
   (VΓB : [||-v Γ ,, B])
   (VA : [_ ||-v<l> A | VΓ])
-  (VB : [_ ||-v<l> B | VΓ])
   (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
   (VP : [_ ||-v<l> P | VΓA])
   (VPB : [_ ||-v<l> P | VΓB])
@@ -106,7 +100,9 @@ Proof.
   constructor; intros; irrelevanceRefl.
   eapply validTyEq; tea.
   Unshelve. 1: tea.
-  unshelve eapply convSubstEqCtx1; cycle 5; tea; now eapply symValidTyEq.
+  unshelve eapply convSubstEqCtx1; cycle 5; tea.
+  1: now eapply symValidTyEq.
+  now eapply ureflValidTy.
 Qed.
 
 Lemma convTmEqCtx1 {Γ A B C t u l}
@@ -114,7 +110,6 @@ Lemma convTmEqCtx1 {Γ A B C t u l}
   (VΓA : [||-v Γ ,, A])
   (VΓB : [||-v Γ ,, B])
   (VA : [_ ||-v<l> A | VΓ])
-  (VB : [_ ||-v<l> B | VΓ])
   (VC : [_ ||-v<l> C | VΓA])
   (VC' : [_ ||-v<l> C | VΓB])
   (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
@@ -123,7 +118,8 @@ Lemma convTmEqCtx1 {Γ A B C t u l}
 Proof.
   constructor; intros; irrelevanceRefl.
   (unshelve now eapply validTmEq); tea.
-  now unshelve (eapply convSubstEqCtx1; tea; now eapply symValidTyEq).
+  unshelve (eapply convSubstEqCtx1; tea; now eapply symValidTyEq).
+  now eapply ureflValidTy.
 Qed.
 
 
@@ -138,7 +134,7 @@ Lemma convSubstEqCtx2 {Γ Δ A1 B1 A2 B2 l σ σ'}
   (VA2 : [_ ||-v<l> A2 | VΓA1])
   (VB2 : [_ ||-v<l> B2 | VΓA1])
   (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
-  (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VB1 VAB1 VB2)
+  (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VAB1 VB2)
   (VΓA12 := validSnoc VΓA1 VA2)
   (VΓB12 := validSnoc VΓB1 VB2')
   (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA12 | wfΔ]) :
@@ -162,14 +158,14 @@ Lemma convSubstEqCtx2' {Γ Δ A1 B1 A2 B2 l σ σ'}
   (VΓA12 : [||-v Γ ,, A1 ,, A2])
   (VΓB12 : [||-v Γ ,, B1 ,, B2])
   (VA1 : [_ ||-v<l> A1 | VΓ])
-  (VB1 : [_ ||-v<l> B1 | VΓ])
   (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
   (VA2 : [_ ||-v<l> A2 | VΓA1])
-  (VB2 : [_ ||-v<l> B2 | VΓA1])
   (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
   (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA12 | wfΔ]) :
   [_ ||-v σ ≅ σ' : _ | VΓB12 | wfΔ].
 Proof.
+  pose proof (ureflValidTy VAB1).
+  pose proof (ureflValidTy VAB).
   eapply irrelevanceSubstEq.
   eapply convSubstEqCtx2; irrValid.
   Unshelve. all: tea; irrValid.
@@ -185,7 +181,7 @@ Lemma convCtx2 {Γ A1 B1 A2 B2 P l}
   (VA2 : [_ ||-v<l> A2 | VΓA1])
   (VB2 : [_ ||-v<l> B2 | VΓA1])
   (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
-  (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VB1 VAB1 VB2)
+  (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VAB1 VB2)
   (VΓA12 := validSnoc VΓA1 VA2)
   (VΓB12 := validSnoc VΓB1 VB2')
   (VP : [_ ||-v<l> P | VΓA12]) :
@@ -205,19 +201,17 @@ Qed.
 Lemma convCtx2' {Γ A1 A2 B1 B2 P l}
   (VΓ : [||-v Γ])
   (VA1 : [_ ||-v<l> A1 | VΓ])
-  (VB1 : [_ ||-v<l> B1 | VΓ])
   (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
   (VΓA1 : [||-v Γ ,, A1])
-  (VΓB1 : [||-v Γ ,, B1])
   (VA2 : [_ ||-v<l> A2 | VΓA1])
-  (VB2 : [_ ||-v<l> B2 | VΓA1])
   (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
-  (VB2' : [_ ||-v<l> B2 | VΓB1])
   (VΓA12 : [||-v Γ ,, A1 ,, A2])
   (VΓB12 : [||-v Γ ,, B1,, B2])
   (VP : [_ ||-v<l> P | VΓA12]) :
   [_ ||-v<l> P | VΓB12].
 Proof.
+  pose proof (ureflValidTy VAB1).
+  pose proof (ureflValidTy VAB).
   eapply irrelevanceTy; eapply convCtx2; irrValid.
   Unshelve. all: tea; irrValid.
 Qed.

--- a/theories/Substitution/Conversion.v
+++ b/theories/Substitution/Conversion.v
@@ -119,7 +119,7 @@ Proof.
   constructor; intros; irrelevanceRefl.
   (unshelve now eapply validTmEq); tea.
   unshelve (eapply convSubstEqCtx1; tea; now eapply symValidTyEq).
-  now eapply ureflValidTy.
+  2: now eapply ureflValidTy.
 Qed.
 
 
@@ -217,4 +217,190 @@ Proof.
 Qed.
 
 
+
+
+Inductive validCtxEq : forall {Γ Γ'}, [||-v Γ] -> [||-v Γ'] -> Type :=
+  | validCtxNil : validCtxEq validEmpty validEmpty
+  | validCtxSnoc {l l' Γ Γ' A A'} (VΓ :[||-v Γ]) (VΓ' : [||-v Γ'])
+    (VA : [_ ||-v<l> A| VΓ])
+    (VA' : [_ ||-v<l'> A'| VΓ']) :
+    validCtxEq VΓ VΓ' -> [_ ||-v<l> A ≅ A'| VΓ| VA] -> validCtxEq (validSnoc VΓ VA) (validSnoc VΓ' VA').
+
+Import EqNotations.
+
+Definition transpValidCtxEq {Γ1 Γ1' Γ2 Γ2'}
+  {VΓ1 : [||-v Γ1]}
+  {VΓ1' : [||-v Γ1']}
+  {VΓ2 : [||-v Γ2]}
+  {VΓ2' : [||-v Γ2']}
+  (h1 : validCtxEq VΓ1 VΓ1')
+  (h2 : validCtxEq VΓ2 VΓ2')
+  (e : Γ1 = Γ2) (e' : Γ1' = Γ2')
+  (eV : rew [fun Δ => [||-v Δ]] e in VΓ1 = VΓ2)
+  (eV' : rew [fun Δ => [||-v Δ]] e' in VΓ1' = VΓ2') : Type.
+Proof. subst; cbn in *; exact (h1 = h2). Defined.
+
+
+Lemma invValidCtxEq {Γ Γ'} {VΓ : [||-v Γ]} {VΓ' : [||-v Γ']} (h : validCtxEq VΓ VΓ'):
+  match Γ as Γ return forall Γ' (VΓ : [||-v Γ]) (VΓ' : [||-v Γ']) (h : validCtxEq VΓ VΓ'), Type with
+  | nil => fun Γ' VΓ  VΓ' h =>
+    ∑ (eΓ' : Γ' = ε),
+      transpValidCtxEq h validCtxNil eq_refl eΓ' (invValidityEmpty _) (invValidityEmpty _)
+  | (A :: Γ)%list => fun ΓA' VΓA  VΓA' h =>
+    let '(l;VΓ; VA;eVΓA) := invValiditySnoc VΓA in
+    ∑ l' A' Γ' (eΓ' : ΓA' = (A' :: Γ')%list)
+      (VΓ' : [||-v Γ'])
+      (VA' : [_ ||-v<l'> A'| VΓ'])
+      (VΓΓ' : validCtxEq VΓ VΓ')
+      (VAA' : [_ ||-v<l> A ≅ A'| VΓ| VA])
+      (eVΓA' : rew [fun Δ => [||-v Δ]] eΓ' in VΓA' = validSnoc VΓ' VA'),
+      transpValidCtxEq h (validCtxSnoc VΓ VΓ' VA VA' VΓΓ' VAA') eq_refl eΓ' eVΓA eVΓA'
+  end Γ' VΓ  VΓ' h.
+Proof.
+  induction h.
+  + exists eq_refl; reflexivity.
+  + unshelve eexists _,_, _, eq_refl, _, _, _, _, eq_refl; tea.
+    reflexivity.
+Defined.
+
+
+Notation "[||-v Γ ≅ Γ' ]" := (∑ VΓ VΓ', @validCtxEq Γ Γ' VΓ VΓ').
+
+Lemma reflValidCtxEq {Γ} (VΓ : [||-v Γ]) : validCtxEq VΓ VΓ.
+Proof.
+  induction Γ, VΓ using validity_rect; constructor; tea.
+  now eapply reflValidTy.
+Qed.
+
+Lemma convSubsS [Γ Γ'] [VΓ : [||-v Γ]] [VΓ' : [||-v Γ']] : validCtxEq VΓ VΓ' ->
+  forall {Δ} (wfΔ : [|-Δ]) {σ σ'},
+  [_ ||-v σ ≅ σ' : _ | VΓ | wfΔ ] -> [_ ||-v σ ≅ σ' : _ | VΓ' | wfΔ ].
+Proof.
+  intros h; induction h.
+  1: constructor.
+  intros ???? Vσ.
+  exists (IHh _ _ _ _ (eqTail Vσ)).
+  eapply LRTmEqConv. 2: exact (eqHead Vσ).
+  instValid (lrefl (eqTail Vσ)); irrelevance.
+Qed.
+
+(* If needed there is a much easier proof using convSubstS and idSubstS *)
+(* Lemma convValidCtxEqIdSubst {Γ Γ'} (VΓ : [||-v Γ]) (VΓ' : [||-v Γ']) : validCtxEq VΓ VΓ' ->
+  [_ ||-v tRel : _ | VΓ | validWf VΓ'].
+Proof.
+  intros h; induction h; unshelve econstructor.
+  - eapply irrelevanceSubstEqExt.
+    3: eapply (wkSubstSEq _ _ _ (wk1 A') IHh).
+    all: intros a; cbn -[wk1]; now rewrite (wk1_ren a).
+  - eapply var0conv. 2: now eapply validTyWf.
+    replace A[↑ >> tRel] with A⟨↑⟩ by (bsimpl; now substify).
+    erewrite <-2!wk1_ren_on; symmetry; unshelve eapply escapeEq, wkEq; tea.
+    1: now eapply validWf, validSnoc.
+    1: generalize (validTy VA _ IHh); now rewrite subst_rel.
+    rewrite <-(subst_rel A'); irrelevance0; [apply subst_rel|].
+    eapply (validTyEq t _ IHh).
+Qed. *)
+
+Lemma convValidTy [Γ Γ'] [VΓ : [||-v Γ]] [VΓ' : [||-v Γ']] : validCtxEq VΓ VΓ' ->
+  forall [l A], [_ ||-v<l> A | VΓ'] -> [_ ||-v<l> A | VΓ].
+Proof.
+  intros h l A VA; unshelve econstructor; intros ???? Vσ.
+  all: instValid (convSubsS h wfΔ Vσ); tea ; irrelevance.
+Qed.
+
+Lemma convValidTyEq [Γ Γ'] [VΓ : [||-v Γ]] [VΓ' : [||-v Γ']] : validCtxEq VΓ VΓ' ->
+  forall [l A A'] (VAΓ : [_ ||-v<l> A | VΓ]) (VAΓ' : [_ ||-v<l> A | VΓ']),
+  [_ ||-v<l> A ≅ A' | VΓ' | VAΓ'] -> [_ ||-v<l> A ≅ A' | VΓ | VAΓ].
+Proof.
+  intros * h ** ; unshelve econstructor; intros ???? Vσ.
+  instValid (convSubsS h wfΔ Vσ); irrelevance.
+Qed.
+
+Lemma convValidTyEq' [Γ Γ'] [VΓ : [||-v Γ]] [VΓ' : [||-v Γ']] (h : validCtxEq VΓ VΓ') :
+  forall [l A A'] (VAΓ' : [_ ||-v<l> A | VΓ']),
+  [_ ||-v<l> A ≅ A' | VΓ' | VAΓ'] -> [_ ||-v<l> A ≅ A' | VΓ | convValidTy h VAΓ'].
+Proof. intros; now eapply convValidTyEq. Qed.
+
+Lemma convValidTmEq {Γ Γ'} (VΓ : [||-v Γ]) (VΓ' : [||-v Γ']) : validCtxEq VΓ VΓ' ->
+  forall l A t u (VAΓ : [_ ||-v<l> A | VΓ]) (VAΓ' : [_ ||-v<l> A | VΓ']),
+  [_ ||-v<l> t ≅ u : _ | VΓ' | VAΓ'] -> [_ ||-v<l> t ≅ u  : _ | VΓ | VAΓ].
+Proof.
+  intros * h ** ; unshelve econstructor; intros ???? Vσ.
+  instValid (convSubsS h wfΔ Vσ); irrelevance.
+Qed.
+
+Lemma convValidTmEq' [Γ Γ'] [VΓ : [||-v Γ]] [VΓ' : [||-v Γ']] (h : validCtxEq VΓ VΓ') :
+  forall [l A t u] (VAΓ' : [_ ||-v<l> A | VΓ']),
+  [_ ||-v<l> t ≅ u : _ | VΓ' | VAΓ'] -> [_ ||-v<l> t ≅ u  : _ | VΓ | convValidTy h VAΓ'].
+Proof. intros; now eapply convValidTmEq. Qed.
+
+Lemma symValidCtxEq [Γ Δ] [VΓ : [||-v Γ]] [VΔ : [||-v Δ]] : validCtxEq VΓ VΔ -> validCtxEq VΔ VΓ.
+Proof.
+  intros h; induction h; constructor; tea.
+  eapply symValidTyEq.
+  now unshelve now eapply convValidTyEq'.
+Qed.
+
+Lemma transValidCtxEq [Γ Δ Ξ] [VΓ : [||-v Γ]] [VΔ : [||-v Δ]] [VΞ : [||-v Ξ]] :
+  validCtxEq VΓ VΔ -> validCtxEq VΔ VΞ -> validCtxEq VΓ VΞ.
+Proof.
+  intros h; induction h in Ξ, VΞ |- *; intros h'; pose proof (h'' := invValidCtxEq h'); cbn in h''.
+  - destruct h'' as []; subst; rewrite (invValidityEmpty VΞ); constructor.
+  - destruct h'' as (l''&A''&Γ''&?&?&?&?&?&?&?); do 3 (subst; cbn in *); econstructor.
+    + now eapply IHh.
+    + eapply transValidTyEq; tea.
+      now eapply convValidTyEq.
+      Unshelve. now eapply convValidTy.
+Qed.
+
+Lemma irrValidCtxEq [Γ Δ] [VΓ1 VΓ2 : [||-v Γ]] [VΔ1 VΔ2 : [||-v Δ]] : validCtxEq VΓ1 VΔ1 -> validCtxEq VΓ2 VΔ2.
+Proof.
+  intros h; induction h.
+  - rewrite (invValidityEmpty VΓ2), (invValidityEmpty VΔ2); constructor.
+  - pose proof (invValiditySnoc VΓ2) as (l1&VΓ1&?&->).
+    pose proof (invValiditySnoc VΔ2) as (l2&VΓ1'&?&->).
+    econstructor. 1: now eapply IHh. irrValid.
+Qed.
+
+Lemma reflValidCtx {Γ} : [||-v Γ] -> [||-v Γ ≅ Γ].
+Proof.
+  intros VΓ; exists VΓ, VΓ; apply reflValidCtxEq.
+Defined.
+
+Lemma symValidCtx [Γ Δ] : [||-v Γ ≅ Δ] -> [||-v Δ ≅ Γ].
+Proof.
+  intros (?&?&?); eexists _, _; now eapply symValidCtxEq.
+Defined.
+
+Lemma transValidCtx [Γ Δ Ξ] : [||-v Γ ≅ Δ] -> [||-v Δ ≅ Ξ] -> [||-v Γ ≅ Ξ].
+Proof.
+  intros (VΓ&VΔ&?) (?&?& h); eexists VΓ, _; eapply transValidCtxEq; tea.
+  eapply irrValidCtxEq, h.
+  Unshelve. tea.
+Qed.
+
+Lemma validCtxSnoc' [l Γ Γ' A A'] (VΓΓ' :[||-v Γ ≅ Γ']) (VA : [_ ||-v<l> A| VΓΓ'.π1]) :
+  [_ ||-v<l> A ≅ A'| _ | VA] -> [||-v Γ,,A ≅ Γ',,A'].
+Proof.
+  intros VAA'; destruct VΓΓ' as (VΓ& VΓ'& VΓΓ').
+  unshelve eexists (validSnoc _ VA), (validSnoc (l:=l) VΓ' _).
+  1: eapply convValidTy; [now eapply symValidCtxEq| exact (ureflValidTy VAA')].
+  econstructor; cbn; tea.
+Defined.
+
+Lemma convVTy [Γ Γ' l A] (Veq : [||-v Γ ≅ Γ']) :
+  [_ ||-v<l> A | Veq.π1] -> [_ ||-v<l> A | Veq.π2.π1].
+Proof. apply convValidTy, symValidCtxEq, Veq.π2.π2. Qed.
+
+Lemma convVTyEq [Γ Γ' l A B] (Veq : [||-v Γ ≅ Γ']) (VA : [_ ||-v<l> A | Veq.π1]) :
+  [_ ||-v<l> A ≅ B | Veq.π1 | VA ] -> [_ ||-v<l> A ≅ B | Veq.π2.π1 | convVTy Veq VA].
+Proof. apply convValidTyEq, symValidCtxEq, Veq.π2.π2. Qed.
+
+Lemma convVTmEq [Γ Γ' l A t u] (Veq : [||-v Γ ≅ Γ']) (VA : [_ ||-v<l> A | Veq.π1]) :
+  [_ ||-v<l> t ≅ u : _ | Veq.π1 | VA ] -> [_ ||-v<l> t ≅ u : _ | Veq.π2.π1 | convVTy Veq VA].
+Proof. apply convValidTmEq, symValidCtxEq, Veq.π2.π2. Qed.
+
+
 End Conversion.
+
+Notation "[||-v Γ ≅ Γ' ]" := (∑ VΓ VΓ', validCtxEq (Γ:=Γ) (Γ':=Γ') VΓ VΓ').

--- a/theories/Substitution/Conversion.v
+++ b/theories/Substitution/Conversion.v
@@ -1,7 +1,8 @@
+From Coq Require Import CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
 From LogRel.LogicalRelation Require Import Irrelevance Escape Reflexivity Weakening Neutral.
-From LogRel.Substitution Require Import Properties Irrelevance.
+From LogRel.Substitution Require Import  Irrelevance Properties.
 
 Set Universe Polymorphism.
 
@@ -10,6 +11,7 @@ Context `{GenericTypingProperties}.
 
 Set Printing Primitive Projection Parameters.
 
+
 Lemma conv {Γ t A B l} (VΓ : [||-v Γ])
   (VA : [Γ ||-v<l> A | VΓ])
   (VB : [Γ ||-v<l> B | VΓ])
@@ -17,10 +19,9 @@ Lemma conv {Γ t A B l} (VΓ : [||-v Γ])
   (Vt : [Γ ||-v<l> t : A | VΓ | VA]) :
   [Γ ||-v<l> t : B | VΓ | VB].
 Proof.
-  constructor; intros; [eapply LRTmRedConv| eapply LRTmEqRedConv].
-  1,3: now unshelve now eapply validTyEq.
-  1: now eapply validTm.
-  now eapply validTmExt.
+  constructor; intros; eapply LRTmEqConv.
+  2: now unshelve now eapply validTmExt.
+  now eapply validTyEqLeft.
 Qed.
 
 Lemma convsym {Γ t A B l} (VΓ : [||-v Γ])
@@ -30,10 +31,7 @@ Lemma convsym {Γ t A B l} (VΓ : [||-v Γ])
   (Vt : [Γ ||-v<l> t : B | VΓ | VB]) :
   [Γ ||-v<l> t : A | VΓ | VA].
 Proof.
-  constructor; intros; [eapply LRTmRedConv| eapply LRTmEqRedConv].
-  1,3: unshelve eapply LRTyEqSym; tea; [|now unshelve now eapply validTyEq].
-  1:  now unshelve now eapply validTm.
-  now eapply validTmExt.
+  eapply conv; tea; now eapply symValidTyEq.
 Qed.
 
 Lemma convEq {Γ t u A B l} (VΓ : [||-v Γ])
@@ -43,81 +41,42 @@ Lemma convEq {Γ t u A B l} (VΓ : [||-v Γ])
   (Vt : [Γ ||-v<l> t ≅ u : A | VΓ | VA]) :
   [Γ ||-v<l> t ≅ u : B | VΓ | VB].
 Proof.
-  constructor; intros; eapply LRTmEqRedConv.
-  1: now unshelve now eapply validTyEq.
+  constructor; intros; eapply LRTmEqConv.
+  1: (unshelve now eapply validTyEqLeft); cycle 2; tea.
   now eapply validTmEq.
 Qed.
 
 
-Lemma convSubstCtx1 {Γ Δ A B l σ} 
+Lemma convSubstEqCtx1 {Γ Δ A B l σ σ'}
   (VΓ : [||-v Γ])
   (wfΔ : [|- Δ])
-  (VΓA : [||-v Γ ,, A]) 
-  (VΓB : [||-v Γ ,, B]) 
+  (VΓA : [||-v Γ ,, A])
+  (VΓB : [||-v Γ ,, B])
   (VA : [_ ||-v<l> A | VΓ])
   (VB : [_ ||-v<l> B | VΓ])
   (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
-  (Vσ : [_ ||-v σ : _ | VΓA | wfΔ]) :
-  [_ ||-v σ : _ | VΓB | wfΔ].
+  (Vσσ': [_ ||-v σ ≅ σ' : _ | VΓA | wfΔ]) :
+  [_ ||-v σ ≅ σ' : _ | VΓB | wfΔ].
 Proof.
   pose proof (invValiditySnoc VΓA) as [? [? [?]]]; subst.
   pose proof (invValiditySnoc VΓB) as [? [? [?]]]; subst.
-  eapply irrelevanceSubstExt.
+  eapply irrelevanceSubstEqExt.
   1: rewrite <- scons_eta'; reflexivity.
-  unshelve eapply consSubstS.
-  1: epose (validTail Vσ); irrValid.
-  eapply LRTmRedConv.
-  2: irrelevanceRefl; eapply validHead.
-  now eapply validTyEq.
+  1: rewrite <- scons_eta'; reflexivity.
+  unshelve eapply consSubstEq.
+  1: epose (eqTail Vσσ'); irrValid.
+  eapply LRTmEqConv.
+  2: irrelevanceRefl; eapply eqHead.
+  eapply validTyEqLeft; [exact VB| exact VAB].
   Unshelve. 6: tea.
-    2: eapply irrelevanceSubst; now eapply validTail.
+    3: eapply irrelevanceSubstEq; now eapply eqTail.
     tea.
 Qed.
 
-Lemma convSubstEqCtx1 {Γ Δ A B l σ σ'} 
+Lemma convCtx1 {Γ A B P l}
   (VΓ : [||-v Γ])
-  (wfΔ : [|- Δ])
-  (VΓA : [||-v Γ ,, A]) 
-  (VΓB : [||-v Γ ,, B]) 
-  (VA : [_ ||-v<l> A | VΓ])
-  (VB : [_ ||-v<l> B | VΓ])
-  (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
-  (Vσ : [_ ||-v σ : _ | VΓA | wfΔ]) 
-  (Vσ' : [_ ||-v σ' : _ | VΓA | wfΔ]) 
-  (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA | wfΔ | Vσ]) 
-  (VσB : [_ ||-v σ : _ | VΓB | wfΔ]) :
-  [_ ||-v σ ≅ σ' : _ | VΓB | wfΔ | VσB].
-Proof.
-  pose proof (invValiditySnoc VΓA) as [? [? [?]]]; subst.
-  pose proof (invValiditySnoc VΓB) as [? [? [?]]]; subst.
-  eapply irrelevanceSubstEq.
-  eapply irrelevanceSubstEqExt.
-  1: rewrite <- scons_eta'; reflexivity.
-  unshelve eapply consSubstSEq'.
-  8: now eapply eqTail.
-  3: irrValid.
-  3: eapply LRTmEqRedConv.
-  4: now eapply eqHead.
-  2: irrelevanceRefl; eapply validTyEq; irrValid.
-  eapply LRTmRedConv.
-  2: irrelevanceRefl; eapply validHead.
-  eapply validTyExt.
-  1: now eapply validTail.
-  eapply reflSubst.
-  Unshelve.
-  1: now rewrite scons_eta'.
-  9: tea.
-  7: tea.
-  2,6: irrValid.
-  1,2: tea.
-  1,2: eapply irrelevanceSubst; now eapply validTail.
-Qed.
-
-
-Lemma convCtx1 {Γ A B P l} 
-  (VΓ : [||-v Γ])
-  (VΓA : [||-v Γ ,, A]) 
-  (VΓB : [||-v Γ ,, B]) 
+  (VΓA : [||-v Γ ,, A])
+  (VΓB : [||-v Γ ,, B])
   (VA : [_ ||-v<l> A | VΓ])
   (VB : [_ ||-v<l> B | VΓ])
   (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
@@ -125,18 +84,17 @@ Lemma convCtx1 {Γ A B P l}
   [_ ||-v<l> P | VΓB].
 Proof.
   opector; intros.
-  - eapply validTy; tea; eapply convSubstCtx1; tea; now eapply symValidTyEq.
+  - eapply validTy; tea; eapply convSubstEqCtx1; tea; now eapply symValidTyEq.
   - irrelevanceRefl; unshelve eapply validTyExt.
-    3,4: tea. 
-    1,2:  eapply convSubstCtx1; tea; now eapply symValidTyEq.
-    eapply convSubstEqCtx1; cycle 2; tea; now eapply symValidTyEq.
+    3,4: tea.
+    eapply convSubstEqCtx1; tea; now eapply symValidTyEq.
     Unshelve. all: tea.
 Qed.
 
-Lemma convEqCtx1 {Γ A B P Q l} 
+Lemma convEqCtx1 {Γ A B P Q l}
   (VΓ : [||-v Γ])
-  (VΓA : [||-v Γ ,, A]) 
-  (VΓB : [||-v Γ ,, B]) 
+  (VΓA : [||-v Γ ,, A])
+  (VΓB : [||-v Γ ,, B])
   (VA : [_ ||-v<l> A | VΓ])
   (VB : [_ ||-v<l> B | VΓ])
   (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
@@ -147,143 +105,71 @@ Lemma convEqCtx1 {Γ A B P Q l}
 Proof.
   constructor; intros; irrelevanceRefl.
   eapply validTyEq; tea.
-  Unshelve. 1: tea. 
-  unshelve eapply convSubstCtx1; cycle 5; tea; now eapply symValidTyEq.
+  Unshelve. 1: tea.
+  unshelve eapply convSubstEqCtx1; cycle 5; tea; now eapply symValidTyEq.
 Qed.
 
-Lemma convSubstCtx2 {Γ Δ A1 B1 A2 B2 l σ} 
+Lemma convSubstEqCtx2 {Γ Δ A1 B1 A2 B2 l σ σ'}
   (VΓ : [||-v Γ])
   (wfΔ : [|- Δ])
   (VA1 : [_ ||-v<l> A1 | VΓ])
   (VB1 : [_ ||-v<l> B1 | VΓ])
   (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
-  (VΓA1 := validSnoc VΓ VA1) 
-  (VΓB1 := validSnoc VΓ VB1) 
+  (VΓA1 := validSnoc VΓ VA1)
+  (VΓB1 := validSnoc VΓ VB1)
   (VA2 : [_ ||-v<l> A2 | VΓA1])
   (VB2 : [_ ||-v<l> B2 | VΓA1])
   (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
   (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VB1 VAB1 VB2)
-  (VΓA12 := validSnoc VΓA1 VA2) 
-  (VΓB12 := validSnoc VΓB1 VB2') 
-  (Vσ : [_ ||-v σ : _ | VΓA12 | wfΔ]) :
-  [_ ||-v σ : _ | VΓB12 | wfΔ].
+  (VΓA12 := validSnoc VΓA1 VA2)
+  (VΓB12 := validSnoc VΓB1 VB2')
+  (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA12 | wfΔ]) :
+  [_ ||-v σ ≅ σ' : _ | VΓB12 | wfΔ].
 Proof.
-  eapply irrelevanceSubstExt.
-  1: rewrite <- scons_eta'; reflexivity.
-  unshelve eapply consSubstS.
-  + eapply convSubstCtx1; tea.
-    now eapply validTail.
-  + eapply LRTmRedConv.
-    2: now eapply validHead.
-    eapply validTyEq; tea.
+  eapply irrelevanceSubstEqExt.
+  1,2: rewrite <- scons_eta'; reflexivity.
+  unshelve eapply consSubstEq.
+  + unshelve (eapply convSubstEqCtx1; tea); tea.
+    now eapply eqTail.
+  + unshelve eapply LRTmEqConv; cycle 3.
+    2: now eapply eqHead.
+    1: eapply validTyEqLeft; [|tea]; tea.
   Unshelve. all: tea.
 Qed.
 
-Lemma convSubstCtx2' {Γ Δ A1 B1 A2 B2 l σ} 
+Lemma convSubstEqCtx2' {Γ Δ A1 B1 A2 B2 l σ σ'}
   (VΓ : [||-v Γ])
   (wfΔ : [|- Δ])
-  (VΓA1 : [||-v Γ ,, A1]) 
-  (VΓA12 : [||-v Γ ,, A1 ,, A2]) 
-  (VΓB12 : [||-v Γ ,, B1 ,, B2]) 
+  (VΓA1 : [||-v Γ ,, A1])
+  (VΓA12 : [||-v Γ ,, A1 ,, A2])
+  (VΓB12 : [||-v Γ ,, B1 ,, B2])
   (VA1 : [_ ||-v<l> A1 | VΓ])
   (VB1 : [_ ||-v<l> B1 | VΓ])
   (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
   (VA2 : [_ ||-v<l> A2 | VΓA1])
   (VB2 : [_ ||-v<l> B2 | VΓA1])
   (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
-  (Vσ : [_ ||-v σ : _ | VΓA12 | wfΔ]) :
-  [_ ||-v σ : _ | VΓB12 | wfΔ].
-Proof.
-  eapply irrelevanceSubst.
-  eapply convSubstCtx2; irrValid.
-  Unshelve. all: tea; irrValid.
-Qed.
-
-Lemma convSubstEqCtx2 {Γ Δ A1 B1 A2 B2 l σ σ'} 
-  (VΓ : [||-v Γ])
-  (wfΔ : [|- Δ])
-  (VA1 : [_ ||-v<l> A1 | VΓ])
-  (VB1 : [_ ||-v<l> B1 | VΓ])
-  (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
-  (VΓA1 := validSnoc VΓ VA1) 
-  (VΓB1 := validSnoc VΓ VB1) 
-  (VA2 : [_ ||-v<l> A2 | VΓA1])
-  (VB2 : [_ ||-v<l> B2 | VΓA1])
-  (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
-  (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VB1 VAB1 VB2)
-  (VΓA12 := validSnoc VΓA1 VA2) 
-  (VΓB12 := validSnoc VΓB1 VB2') 
-  (Vσ : [_ ||-v σ : _ | VΓA12 | wfΔ]) 
-  (Vσ' : [_ ||-v σ' : _ | VΓA12 | wfΔ]) 
-  (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA12 | wfΔ | Vσ]) 
-  (VσB : [_ ||-v σ : _ | VΓB12 | wfΔ]) :
-  [_ ||-v σ ≅ σ' : _ | VΓB12 | wfΔ | VσB].
-Proof.
-  eapply irrelevanceSubstEq.
-  eapply irrelevanceSubstEqExt.
-  1: rewrite <- scons_eta'; reflexivity.
-  unshelve eapply consSubstSEq'.
-  8:{ eapply convSubstEqCtx1; tea.
-    1: now eapply validTail.
-    now eapply eqTail.
-  }
-  3,4: irrValid.
-  2: eapply convSubstCtx1; tea; now eapply validTail. 
-  3: eapply LRTmEqRedConv.
-  4: now eapply eqHead.
-  2: irrelevanceRefl; eapply validTyEq; irrValid.
-  eapply LRTmRedConv.
-  2: irrelevanceRefl; eapply validHead.
-  eapply validTyExt.
-  1: now eapply validTail.
-  eapply reflSubst.
-  Unshelve.
-  1: now rewrite scons_eta'.
-  11: tea.
-  1,2,6: irrValid.
-  1: tea.
-  2: eapply convSubstCtx1; tea.
-  1,2: now eapply validTail.
-Qed. 
-
-Lemma convSubstEqCtx2' {Γ Δ A1 B1 A2 B2 l σ σ'} 
-  (VΓ : [||-v Γ])
-  (wfΔ : [|- Δ])
-  (VA1 : [_ ||-v<l> A1 | VΓ])
-  (VB1 : [_ ||-v<l> B1 | VΓ])
-  (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
-  (VΓA1 : [||-v Γ ,, A1]) 
-  (VΓB1 : [||-v Γ ,, B1]) 
-  (VA2 : [_ ||-v<l> A2 | VΓA1])
-  (VB2 : [_ ||-v<l> B2 | VΓA1])
-  (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
-  (VB2' : [_ ||-v<l> B2 | VΓB1])
-  (VΓA12 : [||-v Γ ,, A1 ,, A2]) 
-  (VΓB12 : [||-v Γ ,, B1,, B2]) 
-  (Vσ : [_ ||-v σ : _ | VΓA12 | wfΔ]) 
-  (Vσ' : [_ ||-v σ' : _ | VΓA12 | wfΔ]) 
-  (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA12 | wfΔ | Vσ]) 
-  (VσB : [_ ||-v σ : _ | VΓB12 | wfΔ]) :
-  [_ ||-v σ ≅ σ' : _ | VΓB12 | wfΔ | VσB].
+  (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓA12 | wfΔ]) :
+  [_ ||-v σ ≅ σ' : _ | VΓB12 | wfΔ].
 Proof.
   eapply irrelevanceSubstEq.
   eapply convSubstEqCtx2; irrValid.
-  Unshelve.  all: tea; irrValid.
+  Unshelve. all: tea; irrValid.
 Qed.
 
-Lemma convCtx2 {Γ A1 B1 A2 B2 P l} 
+Lemma convCtx2 {Γ A1 B1 A2 B2 P l}
   (VΓ : [||-v Γ])
   (VA1 : [_ ||-v<l> A1 | VΓ])
   (VB1 : [_ ||-v<l> B1 | VΓ])
   (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
-  (VΓA1 := validSnoc VΓ VA1) 
-  (VΓB1 := validSnoc VΓ VB1) 
+  (VΓA1 := validSnoc VΓ VA1)
+  (VΓB1 := validSnoc VΓ VB1)
   (VA2 : [_ ||-v<l> A2 | VΓA1])
   (VB2 : [_ ||-v<l> B2 | VΓA1])
   (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
   (VB2' := convCtx1 VΓ VΓA1 VΓB1 VA1 VB1 VAB1 VB2)
-  (VΓA12 := validSnoc VΓA1 VA2) 
-  (VΓB12 := validSnoc VΓB1 VB2') 
+  (VΓA12 := validSnoc VΓA1 VA2)
+  (VΓB12 := validSnoc VΓB1 VB2')
   (VP : [_ ||-v<l> P | VΓA12]) :
   [_ ||-v<l> P | VΓB12].
 Proof.
@@ -291,26 +177,25 @@ Proof.
   assert [_ ||-v<l> B1 ≅ A1 | _ | VB1] by now eapply symValidTyEq.
   assert [_ ||-v<l> B2 ≅ A2 | _ | VB2'] by (eapply convEqCtx1; tea; now eapply symValidTyEq).
   opector; intros.
-  - eapply validTy; tea; now eapply convSubstCtx2'.
+  - eapply validTy; tea; now eapply convSubstEqCtx2'.
   - irrelevanceRefl; unshelve eapply validTyExt.
-    3,4: tea. 
-    1,2:  now eapply convSubstCtx2'.
+    3,4: tea.
     eapply convSubstEqCtx2'; tea.
     Unshelve. tea.
 Qed.
 
-Lemma convCtx2' {Γ A1 A2 B1 B2 P l} 
+Lemma convCtx2' {Γ A1 A2 B1 B2 P l}
   (VΓ : [||-v Γ])
   (VA1 : [_ ||-v<l> A1 | VΓ])
   (VB1 : [_ ||-v<l> B1 | VΓ])
   (VAB1 : [_ ||-v<l> A1 ≅ B1 | VΓ | VA1])
-  (VΓA1 : [||-v Γ ,, A1]) 
-  (VΓB1 : [||-v Γ ,, B1]) 
+  (VΓA1 : [||-v Γ ,, A1])
+  (VΓB1 : [||-v Γ ,, B1])
   (VA2 : [_ ||-v<l> A2 | VΓA1])
   (VB2 : [_ ||-v<l> B2 | VΓA1])
   (VAB : [_ ||-v<l> A2 ≅ B2 | VΓA1 | VA2])
   (VB2' : [_ ||-v<l> B2 | VΓB1])
-  (VΓA12 : [||-v Γ ,, A1 ,, A2]) 
+  (VΓA12 : [||-v Γ ,, A1 ,, A2])
   (VΓB12 : [||-v Γ ,, B1,, B2])
   (VP : [_ ||-v<l> P | VΓA12]) :
   [_ ||-v<l> P | VΓB12].

--- a/theories/Substitution/Conversion.v
+++ b/theories/Substitution/Conversion.v
@@ -109,6 +109,24 @@ Proof.
   unshelve eapply convSubstEqCtx1; cycle 5; tea; now eapply symValidTyEq.
 Qed.
 
+Lemma convTmEqCtx1 {Γ A B C t u l}
+  (VΓ : [||-v Γ])
+  (VΓA : [||-v Γ ,, A])
+  (VΓB : [||-v Γ ,, B])
+  (VA : [_ ||-v<l> A | VΓ])
+  (VB : [_ ||-v<l> B | VΓ])
+  (VC : [_ ||-v<l> C | VΓA])
+  (VC' : [_ ||-v<l> C | VΓB])
+  (VAB : [_ ||-v<l> A ≅ B | VΓ | VA])
+  (VPtu : [_ ||-v<l> t ≅ u : _ | VΓA | VC]) :
+  [_ ||-v<l> t ≅ u : _ | VΓB | VC'].
+Proof.
+  constructor; intros; irrelevanceRefl.
+  (unshelve now eapply validTmEq); tea.
+  now unshelve (eapply convSubstEqCtx1; tea; now eapply symValidTyEq).
+Qed.
+
+
 Lemma convSubstEqCtx2 {Γ Δ A1 B1 A2 B2 l σ σ'}
   (VΓ : [||-v Γ])
   (wfΔ : [|- Δ])

--- a/theories/Substitution/Escape.v
+++ b/theories/Substitution/Escape.v
@@ -57,4 +57,12 @@ Proof.
   now eapply reducibleTmEq.
 Qed.
 
+Lemma escapeTm {Γ l A t u} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) :
+  [Γ ||-v<l> t ≅ u : A | VΓ | VA] -> [Γ |- t : A].
+Proof.
+  intros; unshelve eapply escapeTerm; tea.
+  1: now eapply reducibleTy.
+  now eapply reducibleTmEq.
+Qed.
+
 End Escape.

--- a/theories/Substitution/Escape.v
+++ b/theories/Substitution/Escape.v
@@ -26,17 +26,7 @@ Proof.
   irrelevance.
 Qed.
 
-Lemma reducibleTm {Γ l A t} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) : 
-  [Γ ||-v<l> t : A | VΓ | VA] -> [Γ ||-<l> t : A | reducibleTy VΓ VA].
-Proof.
-  intros.
-  replace A with A[tRel] by now asimpl.
-  replace t with t[tRel] by now asimpl.
-  unshelve epose proof (validTm X _ (idSubstS VΓ)).
-  irrelevance.
-Qed.
-
-Lemma reducibleTmEq {Γ l A t u} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) : 
+Lemma reducibleTmEq {Γ l A t u} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) :
   [Γ ||-v<l> t ≅ u : A | VΓ | VA] -> [Γ ||-<l> t ≅ u : A | reducibleTy VΓ VA].
 Proof.
   intros.
@@ -51,7 +41,7 @@ Lemma escapeTy {Γ l A} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) : [Γ |- A
 Proof. eapply escape; now eapply reducibleTy. Qed.
 
 
-Lemma escapeEq {Γ l A B} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) : 
+Lemma escapeEq {Γ l A B} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) :
   [Γ ||-v<l> A ≅ B | VΓ | VA] -> [Γ |- A ≅ B].
 Proof.
   intros; unshelve eapply escapeEq; tea.
@@ -59,15 +49,7 @@ Proof.
   now eapply reducibleTyEq.
 Qed.
 
-Lemma escapeTm {Γ l A t} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) : 
-  [Γ ||-v<l> t : A | VΓ | VA] -> [Γ |- t : A].
-Proof.
-  intros; unshelve eapply escapeTerm; tea.
-  1: now eapply reducibleTy.
-  now eapply reducibleTm.
-Qed.
-
-Lemma escapeTmEq {Γ l A t u} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) : 
+Lemma escapeTmEq {Γ l A t u} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) :
   [Γ ||-v<l> t ≅ u : A | VΓ | VA] -> [Γ |- t ≅ u : A].
 Proof.
   intros; unshelve eapply escapeEqTerm; tea.

--- a/theories/Substitution/Introductions/Application.v
+++ b/theories/Substitution/Introductions/Application.v
@@ -12,26 +12,6 @@ Set Printing Primitive Projection Parameters.
 
 Set Printing Universes.
 
-Lemma appValid {Γ F G t u l}
-  {VΓ : [||-v Γ]}
-  {VF : [Γ ||-v<l> F | VΓ]}
-  {VΠFG : [Γ ||-v<l> tProd F G | VΓ]}
-  (Vt : [Γ ||-v<l> t : tProd F G | VΓ | VΠFG])
-  (Vu : [Γ ||-v<l> u : F | VΓ | VF])
-  (VGu := substSΠ VΠFG Vu) :
-  [Γ ||-v<l> tApp t u : G[u..] | VΓ | VGu].
-Proof.
-  opector; intros.
-  - instValid Vσ.
-    epose (appTerm RVΠFG RVt RVu (substSΠaux VΠFG Vu _ _ wfΔ Vσ)).
-    irrelevance.
-  - instAllValid Vσ Vσ' Vσσ'. 
-    unshelve epose (appcongTerm _ REVt RVu _ REVu (substSΠaux VΠFG Vu _ _ wfΔ Vσ)).
-    2: irrelevance.
-    eapply LRTmRedConv; tea.
-    unshelve eapply LRTyEqSym. 2,3: tea.
-Qed.
-
 Lemma appcongValid {Γ F G t u a b l}
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
@@ -43,10 +23,25 @@ Lemma appcongValid {Γ F G t u a b l}
   (VGa := substSΠ VΠFG Va) :
   [Γ ||-v<l> tApp t a ≅ tApp u b : G[a..] | VΓ | VGa].
 Proof.
-  constructor; intros; instValid Vσ.
-  unshelve epose proof (appcongTerm _ RVtu _ _ _ (substSΠaux VΠFG Va _ _ wfΔ Vσ)); fold subst_term; cycle 5.
-  all: try irrelevance.
-  now eapply LRCumulative.
+  constructor; intros; instValid Vσσ'.
+  pose proof (h := substSΠaux VΠFG Va _ _ _ wfΔ Vσσ').
+  pose proof (appcongTerm _ RVtu RVab h).
+  irrelevance.
 Qed.
+
+Lemma appValid {Γ F G t u l}
+  {VΓ : [||-v Γ]}
+  {VF : [Γ ||-v<l> F | VΓ]}
+  {VΠFG : [Γ ||-v<l> tProd F G | VΓ]}
+  (Vt : [Γ ||-v<l> t : tProd F G | VΓ | VΠFG])
+  (Vu : [Γ ||-v<l> u : F | VΓ | VF])
+  (VGu := substSΠ VΠFG Vu) :
+  [Γ ||-v<l> tApp t u : G[u..] | VΓ | VGu].
+Proof.
+  eapply lreflValidTm, appcongValid.
+  1,3: now eapply reflValidTm.
+  tea.
+Qed.
+
 
 End Application.

--- a/theories/Substitution/Introductions/Id.v
+++ b/theories/Substitution/Introductions/Id.v
@@ -1,129 +1,105 @@
+From Coq Require Import ssrbool CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
-From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity Reduction Application Universe Id.
+From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Irrelevance Weakening Neutral Transitivity Reduction Application Universe Id EqRedRight NormalRed InstKripke.
 From LogRel.Substitution Require Import Irrelevance Properties Conversion SingleSubst Reflexivity Reduction.
-From LogRel.Substitution.Introductions Require Import Universe Var.
+From LogRel.Substitution.Introductions Require Import Universe Var Poly.
+
+Set Universe Polymorphism.
+Set Printing Primitive Projection Parameters.
 
 Set Universe Polymorphism.
 
 Section Id.
 Context `{GenericTypingProperties}.
 
-  Lemma IdValid {Γ l A x y} 
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (Vy : [_ ||-v<l> y : _ | _ | VA]) :
+  Lemma IdValid {Γ l A x x' y y'}
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (Vx : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (Vy : [_ ||-v<l> y ≅ y' : _ | _ | VA]) :
     [_ ||-v<l> tId A x y | VΓ].
   Proof.
+    pose proof (lreflValidTm _ Vx).
+    pose proof (lreflValidTm _ Vy).
     unshelve econstructor; intros.
-    - instValid vσ; cbn; now eapply IdRed.
-    - instAllValid vσ vσ' vσσ'; eapply IdCongRed; refold; tea.
-      eapply wft_Id; now escape.
+    - instValid (lrefl vσ); cbn; now eapply IdRed.
+    - instValid vσσ'; eapply IdCongRed; refold; tea.
+      eapply wft_Id; escape; tea; now eapply ty_conv.
   Qed.
 
   Lemma IdCongValid {Γ l A A' x x' y y'}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (VA' : [_ ||-v<l> A' | VΓ]) 
-    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA])
     (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
-    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
-    (Vy' : [_ ||-v<l> y' : _ | _ | VA]) 
-    (Vyy' : [_ ||-v<l> y ≅ y' : _ | _ | VA]) 
+    (Vyy' : [_ ||-v<l> y ≅ y' : _ | _ | VA])
     (VId : [_ ||-v<l> tId A x y | VΓ]) :
     [_ ||-v<l> tId A x y ≅ tId A' x' y' | VΓ | VId].
   Proof.
     constructor; intros.
-    instValid Vσ; eapply IdCongRed; refold; tea.
-    eapply wft_Id. 
-    2,3: eapply ty_conv.
-    all: now escape.
+    instValid Vσσ'; eapply IdCongRed; refold; tea.
+    escape; eapply wft_Id; tea; now eapply ty_conv.
   Qed.
 
-
-  Lemma IdTmValid {Γ l A x y} 
-    (VΓ : [||-v Γ]) 
+  Lemma IdTmCongValid {Γ l A A' x x' y y'}
+    (VΓ : [||-v Γ])
     (VU := UValid VΓ)
-    (VAU : [_ ||-v<one> A : U | VΓ | VU]) 
+    (VAUeq : [_ ||-v<one> A ≅ A' : U | VΓ | VU])
+    (VAU := (lreflValidTm _ VAUeq))
+    (VA := univValid VΓ VU VAU)
+    (Vx : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (Vy : [_ ||-v<l> y ≅ y' : _ | _ | VA]) :
+    [_ ||-v<one> tId A x y ≅ tId A' x' y' : _ | VΓ | VU].
+  Proof.
+    constructor; intros; instValid Vσσ'.
+    unshelve eapply IdCongRedU; refold; tea.
+    1: now eapply univValid.
+    1: now eapply lrefl.
+    all: irrelevance.
+  Qed.
+
+  Lemma IdTmValid {Γ l A x y}
+    (VΓ : [||-v Γ])
+    (VU := UValid VΓ)
+    (VAU : [_ ||-v<one> A : U | VΓ | VU])
     (VA := univValid VΓ VU VAU)
     (Vx : [_ ||-v<l> x : _ | _ | VA])
     (Vy : [_ ||-v<l> y : _ | _ | VA]) :
     [_ ||-v<one> tId A x y : _ | VΓ | VU].
-  Proof. 
-    unshelve econstructor; intros.
-    - instValid Vσ. 
-      unshelve eapply IdRedU; refold; tea.
-      1: now eapply univValid.
-      all: irrelevance.
-    - instAllValid Vσ Vσ' Vσσ'.
-      unshelve eapply IdCongRedU; refold; tea.
-      1,2: now eapply univValid.
-      all: irrelevance.
-  Qed.
-    
-  Lemma IdTmCongValid {Γ l A A' x x' y y'}
-    (VΓ : [||-v Γ]) 
-    (VU := UValid VΓ)
-    (VAU : [_ ||-v<one> A : _ | VΓ | VU]) 
-    (VA := univValid VΓ VU VAU)
-    (VAU' : [_ ||-v<one> A' : _ | VΓ | VU]) 
-    (VAAU' : [_ ||-v<one> A ≅ A' : _ | VΓ | VU]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
-    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
-    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
-    (Vy' : [_ ||-v<l> y' : _ | _ | VA]) 
-    (Vyy' : [_ ||-v<l> y ≅ y' : _ | _ | VA]) :
-    [_ ||-v<one> tId A x y ≅ tId A' x' y' : _ | VΓ | VU].
   Proof.
-    constructor; intros; instValid Vσ.
-    unshelve eapply IdCongRedU; refold; tea.
-    1,2: now eapply univValid.
-    2,5: eapply LRTmRedConv; [eapply univEqValid; irrValid|].
-    all: irrelevance.
-    Unshelve. 3,9: now eapply univValid.
-    all: tea.
-  Qed.
-
-
-  Lemma reflValid {Γ l A x} 
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (VId : [_ ||-v<l> tId A x x | VΓ]) :
-    [_ ||-v<l> tRefl A x : _ | _ | VId].
-  Proof.
-    unshelve econstructor; intros.
-    - instValid Vσ; now unshelve eapply reflRed.
-    - instAllValid Vσ Vσ' Vσσ'; escape; now unshelve eapply reflCongRed.
+    unshelve eapply IdTmCongValid; tea; irrValid.
   Qed.
 
   Lemma reflCongValid {Γ l A A' x x'}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (VA' : [_ ||-v<l> A' | VΓ]) 
-    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
-    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA])
+    (Vx : [_ ||-v<l> x ≅ x' : _ | _ | VA])
     (VId : [_ ||-v<l> tId A x x | VΓ]) :
     [_ ||-v<l> tRefl A x ≅ tRefl A' x' : _ | _ | VId].
   Proof.
-    constructor; intros; instValid Vσ.
-    escape; unshelve eapply reflCongRed; refold; tea.
-    now eapply ty_conv.
+    constructor; intros; instValid Vσσ'.
+    escape; now unshelve eapply reflCongRed.
+  Qed.
+
+  Lemma reflValid {Γ l A x x'}
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (Vx : [_ ||-v<l> x ≅ x': _ | _ | VA])
+    (VId : [_ ||-v<l> tId A x x | VΓ]) :
+    [_ ||-v<l> tRefl A x : _ | _ | VId].
+  Proof.
+    eapply reflCongValid;[eapply reflValidTy| now eapply lreflValidTm].
   Qed.
 
   Lemma subst_scons2 (P e y : term) (σ : nat -> term) : P[e .: y..][σ] = P [e[σ] .: (y[σ] .: σ)].
   Proof. now asimpl. Qed.
-  
+
   Lemma subst_upup_scons2 (P e y : term) (σ : nat -> term) : P[up_term_term (up_term_term σ)][e .: y..] = P [e .: (y .: σ)].
   Proof. now asimpl. Qed.
 
-  Lemma consSubstS' {Γ σ t l A Δ} 
+  (* Lemma consSubstS' {Γ σ t l A Δ}
     (VΓ : [||-v Γ])
     (VΓA : [||-v Γ ,, A])
     (wfΔ : [|- Δ])
@@ -131,12 +107,12 @@ Context `{GenericTypingProperties}.
     (VA : [Γ ||-v<l> A | VΓ])
     (Vt : [ Δ ||-<l> t : A[σ] | validTy VA wfΔ Vσ]) :
     [Δ ||-v (t .: σ) : Γ ,, A | VΓA | wfΔ].
-  Proof. 
+  Proof.
     pose proof (invValiditySnoc VΓA) as [? [? [? ->]]].
     unshelve eapply consSubstS; [ irrValid| irrelevance].
   Qed.
 
-  Lemma consSubstSEq'' {Γ σ σ' t u l A Δ} 
+  Lemma consSubstSEq'' {Γ σ σ' t u l A Δ}
     (VΓ : [||-v Γ])
     (VΓA : [||-v Γ ,, A])
     (wfΔ : [|- Δ])
@@ -151,604 +127,208 @@ Context `{GenericTypingProperties}.
     pose proof (invValiditySnoc VΓA) as [? [? [? ->]]].
     pose proof (consSubstSEq' VΓ wfΔ Vσ Vσσ' VA Vt Vtu).
     irrValid.
-  Qed.  
+  Qed.
 
+  consSubstEq *)
 
-  Lemma idElimMotiveCtxIdValid {Γ l A x}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA]) :
+  Lemma idElimMotiveCtxIdValid {Γ l A x x'}
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (Vx : [_ ||-v<l> x ≅ x' : _ | _ | VA]) :
     [Γ,, A ||-v< l > tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) | validSnoc VΓ VA].
   Proof.
     unshelve eapply IdValid.
-    - now eapply wk1ValidTy.
-    - now eapply wk1ValidTm.
-    - exact (var0Valid VΓ VA).
+    3: now eapply wk1ValidTy.
+    3: now eapply wk1ValidTmEq.
+    2: exact (var0Valid VΓ VA).
   Qed.
-  
+
   Lemma idElimMotiveCtxIdCongValid {Γ l A A' x x'}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (VA' : [_ ||-v<l> A' | VΓ]) 
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
     (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA])
-    (Vx : [_ ||-v<l> x : _ | _ | VA]) 
-    (Vx' : [_ ||-v<l> x' : _ | _ | VA]) 
-    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA]) 
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
     (VId : [Γ,, A ||-v< l > tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) | validSnoc VΓ VA]) :
     [_ ||-v<l> _ ≅ tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0) | validSnoc VΓ VA | VId].
   Proof.
     assert (h : forall t, t⟨@wk1 Γ A'⟩ = t⟨@wk1 Γ A⟩) by reflexivity.
-    unshelve eapply IdCongValid.
+    unshelve eapply IdCongValid; rewrite ?h.
     - now eapply wk1ValidTy.
-    - rewrite h; now eapply wk1ValidTy.
-    - rewrite h; now eapply wk1ValidTyEq.
-    - now eapply wk1ValidTm.
-    - rewrite h; now eapply wk1ValidTm.
-    - rewrite h; now eapply wk1ValidTmEq.
+    - now eapply wk1ValidTyEq.
+    - now eapply wk1ValidTmEq.
     - eapply var0Valid.
-    - eapply var0Valid.
-    - eapply reflValidTm; eapply var0Valid.
   Qed.
-  
-  
-  Lemma idElimMotiveScons2Valid {Γ l A x y e}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (Vy : [Γ ||-v<l> y : _ | _ | VA])
-    (VId : [Γ ||-v<l> tId A x y | VΓ])
-    (Ve : [_ ||-v<l> e : _ | _ | VId]) 
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    Δ σ (wfΔ: [ |-[ ta ] Δ]) (vσ: [VΓ | Δ ||-v σ : _ | wfΔ]) :
-      [VΓext | Δ ||-v (e[σ] .: (y[σ] .: σ)) : _ | wfΔ].
+
+  Lemma idElimMotiveCtxEq {Γ l A A' x x'}
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA])
+    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA]) :
+    [||-v (Γ,, A ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)) ≅ (Γ,, A' ,, tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0))].
   Proof.
-    intros; unshelve eapply consSubstS'; tea.
-    2: now eapply consSubstSvalid.
-    1: now eapply idElimMotiveCtxIdValid.
-    instValid vσ; irrelevance.
+    unshelve eapply validCtxSnoc'.
+    2: unshelve eapply validCtxSnoc'; [| now eapply reflValidCtx|..]; cbn; tea.
+    3: cbn; now eapply idElimMotiveCtxIdCongValid.
+    cbn; now eapply idElimMotiveCtxIdValid.
+  Defined.
+
+
+  Lemma idElimMotiveScons2Valid {Γ l A x x' y y' e e'}
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (Vx : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+    (Vy : [Γ ||-v<l> y ≅ y' : _ | _ | VA])
+    (VId : [Γ ||-v<l> tId A x y | VΓ])
+    (Ve : [_ ||-v<l> e ≅ e' : _ | _ | VId])
+    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
+    Δ (wfΔ: [ |-[ ta ] Δ]) {σ σ'} (Vσσ': [VΓ | Δ ||-v σ ≅ σ' : _ | wfΔ]) :
+      [VΓext | Δ ||-v (e[σ] .: (y[σ] .: σ)) ≅ (e'[σ'] .: (y'[σ'] .: σ')) : _ | wfΔ].
+  Proof.
+    epose (Vσy := consSubstEqvalid Vσσ' Vy).
+    unshelve epose (consSubstEq _ _ Vσy (idElimMotiveCtxIdValid VΓ VA Vx) _).
+    4: irrValid.
+    instValid Vσσ'; irrelevance.
   Qed.
-  
-  Lemma substIdElimMotive {Γ l A x P y e}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
+
+  Lemma substIdElimMotive {Γ l A x x' P y y' e e'}
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (Vx : [_ ||-v<l> x ≅ x' : _ | _ | VA])
     (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
     (VP : [_ ||-v<l> P | VΓext])
-    (Vy : [Γ ||-v<l> y : _ | _ | VA])
+    (Vy : [Γ ||-v<l> y ≅ y' : _ | _ | VA])
     (VId : [Γ ||-v<l> tId A x y | VΓ])
-    (Ve : [_ ||-v<l> e : _ | _ | VId]) : 
+    (Ve : [_ ||-v<l> e ≅ e' : _ | _ | VId]) :
     [_ ||-v<l> P[e .: y ..] | VΓ].
   Proof.
     opector; intros.
     - rewrite subst_scons2; eapply validTy; tea; now eapply idElimMotiveScons2Valid.
     - irrelevance0 ; rewrite subst_scons2;[reflexivity|].
       unshelve eapply validTyExt.
-      5,6: eapply idElimMotiveScons2Valid; cycle 1; tea.
-      1: tea.
-      eapply consSubstSEq''.
-      + now unshelve eapply consSubstSEqvalid.
-      + instValid vσ; irrelevance.
-      + instAllValid vσ vσ' vσσ'; irrelevance.
-      Unshelve. 2: now eapply idElimMotiveCtxIdValid.
-  Qed.
-  
-
-  Lemma subst_idElimMotive_substupup {Γ Δ l A x P y e σ}
-    (VΓ : [||-v Γ]) 
-    (wfΔ : [|- Δ])
-    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (RVA := validTy VA wfΔ Vσ)
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext])
-    (Ry : [ RVA |  _ ||- y : _])
-    (RId : [Δ ||-<l> tId A[σ] x[σ] y])
-    (Re : [RId | _ ||- e : _]) :
-    [Δ ||-<l> P[up_term_term (up_term_term σ)][e .: y ..]].
-  Proof.
-    pose (VΓA := validSnoc VΓ VA). 
-    rewrite subst_upup_scons2.
-    unshelve eapply validTy; cycle 2; tea.
-    unshelve eapply consSubstS'; tea.
-    + now eapply consSubstS.
-    + now eapply idElimMotiveCtxIdValid.
-    + irrelevance.
-  Qed.
-  
-  Lemma irrelevanceSubst' {Γ} (VΓ VΓ' : [||-v Γ]) {σ Δ Δ'} (wfΔ : [|- Δ]) (wfΔ' : [|- Δ']) : Δ = Δ' ->
-    [Δ ||-v σ : Γ | VΓ | wfΔ] -> [Δ' ||-v σ : Γ | VΓ' | wfΔ'].
-  Proof.
-    intros ->; eapply irrelevanceSubst.
+      5: eapply idElimMotiveScons2Valid; cycle 1; first [now eapply lreflValidTm| tea].
+      tea.
   Qed.
 
-  Lemma idElimMotive_Idsubst_eq {Γ Δ A x σ} : 
+  Lemma up_twice_subst t a b σ :
+    t[up_term_term (up_term_term σ)][a[σ] .: b[σ]..] =
+    t[a .: b..][σ].
+  Proof. now bsimpl. Qed.
+
+  Lemma idElimMotive_Idsubst_eq {Γ Δ A x σ} :
     tId A[σ]⟨@wk1 Δ A[σ]⟩ x[σ]⟨@wk1 Δ A[σ]⟩ (tRel 0) = (tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0))[up_term_term σ].
   Proof. now bsimpl. Qed.
-  
-  Lemma red_idElimMotive_substupup {Γ Δ l A x P σ}
-    (VΓ : [||-v Γ]) 
-    (wfΔ : [|- Δ])
-    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
+
+  Lemma idElimMotiveScons2Red {Γ l A x x' y y' e e'}
+    {VΓ : [||-v Γ]}
+    {VA : [_ ||-v<l> A | VΓ]}
+    (Vx : [_ ||-v<l> x ≅ x' : _ | _ | VA])
     (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext]) :
-    [(Δ ,, A[σ]),, tId A[σ]⟨@wk1 Δ A[σ]⟩ x[σ]⟨@wk1 Δ A[σ]⟩ (tRel 0) ||-<l> P[up_term_term (up_term_term σ)]].
+    {Δ} {wfΔ : [|-Δ]}
+    {σ σ'} (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓ | wfΔ])
+    {RVA : [Δ ||-<l> A[σ]]}
+    (Ry : [ RVA |  _ ||- y ≅ y' : _])
+    {RId : [Δ ||-<l> tId A[σ] x[σ] y]}
+    (Re : [RId | _ ||- e ≅ e' : _]) :
+      [VΓext | Δ ||-v (e .: (y .: σ)) ≅ (e' .: (y' .: σ')) : _ | wfΔ].
   Proof.
-    pose (VΓA := validSnoc VΓ VA). 
-    instValid Vσ.
-    unshelve eapply validTy; cycle 2; tea.
-    * escape. 
-      assert [|- Δ,, A[σ]] by now eapply wfc_cons.
-      eapply wfc_cons; tea.
-      eapply wft_Id.
-      1: now eapply wft_wk.
-      1: now eapply ty_wk.
-      rewrite wk1_ren_on; now eapply ty_var0.
-    * epose (v1:= liftSubstS' VA Vσ).
-      epose (v2:= liftSubstS' _ v1).
-      eapply irrelevanceSubst'.
-      1: now erewrite idElimMotive_Idsubst_eq.
-      eapply v2.
-      Unshelve. 2: now eapply idElimMotiveCtxIdValid.
+    pose proof (invValiditySnoc VΓext) as (?&VΓA& VIdA &->).
+    pose proof (invValiditySnoc VΓA) as (?&?& ? &->).
+    do 2 (unshelve eapply consSubstEq; [|irrelevance]); irrValid.
   Qed.
 
-  Lemma irrelevanceSubstEq' {Γ} (VΓ VΓ' : [||-v Γ]) {σ σ' Δ Δ'} (wfΔ : [|- Δ]) (wfΔ' : [|- Δ'])
-    (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) (Vσ' : [Δ' ||-v σ : Γ | VΓ' | wfΔ']) :
-    Δ = Δ' ->
-    [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] -> [Δ' ||-v σ ≅ σ' : Γ | VΓ' | wfΔ' | Vσ'].
-  Proof.
-    intros ->; eapply irrelevanceSubstEq.
-  Qed.
-  
-  Lemma red_idElimMotive_substupup_cong {Γ Δ l A x P σ σ'}
-    (VΓ : [||-v Γ]) 
-    (wfΔ : [|- Δ])
-    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
-    (Vσ' : [_ ||-v σ' : _ | VΓ | wfΔ])
-    (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓ | wfΔ | Vσ])
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext]) 
-    (RPσ : [(Δ ,, A[σ]),, tId A[σ]⟨@wk1 Δ A[σ]⟩ x[σ]⟨@wk1 Δ A[σ]⟩ (tRel 0) ||-<l> P[up_term_term (up_term_term σ)]]) :
-    [RPσ | _ ||- _ ≅ P[up_term_term (up_term_term σ')]].
-  Proof.
-    pose (VΓA := validSnoc VΓ VA). 
-    instAllValid Vσ Vσ' Vσσ'.
-    irrelevanceRefl; unshelve eapply validTyExt; cycle 2; tea.
-    * escape. 
-      assert [|- Δ,, A[σ]] by now eapply wfc_cons.
-      eapply wfc_cons; tea.
-      eapply wft_Id.
-      1: now eapply wft_wk.
-      1: now eapply ty_wk.
-      rewrite wk1_ren_on; now eapply ty_var0.
-    * epose (v1:= liftSubstS' VA Vσ).
-      epose (v2:= liftSubstS' _ v1).
-      eapply irrelevanceSubst'.
-      1: now erewrite idElimMotive_Idsubst_eq.
-      eapply v2.
-      Unshelve. 2: now eapply idElimMotiveCtxIdValid.
-    * eapply irrelevanceSubst'.
-      1: now erewrite idElimMotive_Idsubst_eq.
-      eapply liftSubstSrealign'.
-      + now eapply liftSubstSEq'.
-      + now eapply liftSubstSrealign'.
-      Unshelve. 
-      2: now eapply idElimMotiveCtxIdValid.
-    * eapply irrelevanceSubstEq'.
-      1: now erewrite idElimMotive_Idsubst_eq.
-      eapply liftSubstSEq'.
-      now eapply liftSubstSEq'.
-      Unshelve.
-      2: now eapply idElimMotiveCtxIdValid.
-  Qed.
-
-  Lemma redEq_idElimMotive_substupup {Γ Δ l A A' x x' P P' σ}
-    (VΓ : [||-v Γ]) 
-    (wfΔ : [|- Δ])
-    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (VA' : [_ ||-v<l> A' | VΓ]) 
-    (VAA' : [_ ||-v<l> A ≅ A' | _ | VA])
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
-    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
+  Lemma IdElimValid {Γ l A A' x x' P P' hr hr' y y' e e'}
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA])
+    (Vx : [_ ||-v<l> x ≅ x' : _ | _ | VA])
     (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
     (VP : [_ ||-v<l> P | VΓext])
-    (VP' : [_ ||-v<l> P' | VΓext])
-    (VPP' : [_ ||-v<l> P ≅ P' | _ | VP]) 
-    (VPsubstupup : [(Δ ,, A[σ]),, tId A[σ]⟨@wk1 Δ A[σ]⟩ x[σ]⟨@wk1 Δ A[σ]⟩ (tRel 0) ||-<l> P[up_term_term (up_term_term σ)]]) :
-    [_ ||-<l> _ ≅ P'[up_term_term (up_term_term σ)] | VPsubstupup].
-  Proof.
-    pose (VΓA := validSnoc VΓ VA). 
-    instValid Vσ.
-    irrelevanceRefl; unshelve eapply validTyEq; cycle 2; tea.
-    * escape. 
-      assert [|- Δ,, A[σ]] by now eapply wfc_cons.
-      eapply wfc_cons; tea.
-      eapply wft_Id.
-      1: now eapply wft_wk.
-      1: now eapply ty_wk.
-      rewrite wk1_ren_on; now eapply ty_var0.
-    * epose (v1:= liftSubstS' VA Vσ).
-      epose (v2:= liftSubstS' _ v1).
-      eapply irrelevanceSubst'.
-      1: now erewrite idElimMotive_Idsubst_eq.
-      eapply v2.
-      Unshelve. 2: now eapply idElimMotiveCtxIdValid.
-  Qed.
-
-
-  Lemma substEq_idElimMotive_substupupEq {Γ Δ l A x P y y' e e' σ σ'}
-    (VΓ : [||-v Γ]) 
-    (wfΔ : [|- Δ])
-    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
-    (Vσ' : [_ ||-v σ' : _ | VΓ | wfΔ])
-    (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓ | wfΔ | Vσ])
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (RVA := validTy VA wfΔ Vσ)
-    (RVA' := validTy VA wfΔ Vσ')
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext])
-    (Ry : [ RVA |  _ ||- y : _])
-    (Ry' : [ RVA' |  _ ||- y' : _])
-    (Ryy' : [ RVA |  _ ||- y ≅ y' : _])
-    (RId : [Δ ||-<l> tId A[σ] x[σ] y])
-    (RId' : [Δ ||-<l> tId A[σ'] x[σ'] y'])
-    (Re : [RId | _ ||- e : _])
-    (Re' : [RId' | _ ||- e' : _])
-    (Ree' : [RId | _ ||- e ≅ e' : _])
-    (RPsubst : [Δ ||-<l> P[up_term_term (up_term_term σ)][e .: y ..]]) :
-    [RPsubst | Δ ||- P[up_term_term (up_term_term σ)][e .: y ..] ≅ P[up_term_term (up_term_term σ')][e' .: y' ..]].
-  Proof.
-    pose (VΓA := validSnoc VΓ VA). 
-    irrelevance0; rewrite subst_upup_scons2; [reflexivity|].
-    unshelve eapply validTyExt; cycle 2; tea.
-    - unshelve eapply consSubstS'; tea.
-      + now eapply consSubstS.
-      + now eapply idElimMotiveCtxIdValid.
-      + irrelevance.
-    - unshelve eapply consSubstS'; tea.
-      + now eapply consSubstS.
-      + now eapply idElimMotiveCtxIdValid.
-      + irrelevance.
-    - unshelve eapply consSubstSEq''; tea.
-      4,5: irrelevance.
-      2: now eapply idElimMotiveCtxIdValid.
-      2: unshelve eapply consSubstSEq'; tea.
-  Qed.
-
-  Lemma substEq_idElimMotive_substupup {Γ Δ l A x P y y' e e' σ}
-    (VΓ : [||-v Γ]) 
-    (wfΔ : [|- Δ])
-    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (RVA := validTy VA wfΔ Vσ)
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext])
-    (Ry : [ RVA |  _ ||- y : _])
-    (Ry' : [ RVA |  _ ||- y' : _])
-    (Ryy' : [ RVA |  _ ||- y ≅ y' : _])
-    (RId : [Δ ||-<l> tId A[σ] x[σ] y])
-    (RId' : [Δ ||-<l> tId A[σ] x[σ] y'])
-    (Re : [RId | _ ||- e : _])
-    (Re' : [RId' | _ ||- e' : _])
-    (Ree' : [RId | _ ||- e ≅ e' : _])
-    (RPsubst : [Δ ||-<l> P[up_term_term (up_term_term σ)][e .: y ..]]) :
-    [RPsubst | Δ ||- P[up_term_term (up_term_term σ)][e .: y ..] ≅ P[up_term_term (up_term_term σ)][e' .: y' ..]].
-  Proof.
-    eapply substEq_idElimMotive_substupupEq; tea; eapply reflSubst.
-  Qed.
-
-  Set Printing Primitive Projection Parameters.
-
-  Lemma substExt_idElimMotive_substupup {Γ Δ l A A' x x' P P' y y' e e' σ}
-    (VΓ : [||-v Γ]) 
-    (wfΔ : [|- Δ])
-    (Vσ : [_ ||-v σ : _ | VΓ | wfΔ])
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (VA' : [_ ||-v<l> A' | VΓ]) 
-    (VAA' : [_ ||-v<l> A ≅ A' | _ | VA])
-    (RVA := validTy VA wfΔ Vσ)
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
-    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext])
-    (VP' : [_ ||-v<l> P' | VΓext])
-    (VPP' : [_ ||-v<l> P ≅ P' | _ | VP]) 
-    (Ry : [ RVA |  _ ||- y : _])
-    (Ry' : [ RVA |  _ ||- y' : _])
-    (Ryy' : [ RVA |  _ ||- y ≅ y' : _])
-    (RId : [Δ ||-<l> tId A[σ] x[σ] y])
-    (RId' : [Δ ||-<l> tId A[σ] x[σ] y'])
-    (Re : [RId | _ ||- e : _])
-    (Re' : [RId' | _ ||- e' : _])
-    (Ree' : [RId | _ ||- e ≅ e' : _])
-    (RPsubst : [Δ ||-<l> P[up_term_term (up_term_term σ)][e .: y ..]]) :
-    [RPsubst | Δ ||- P[up_term_term (up_term_term σ)][e .: y ..] ≅ P'[up_term_term (up_term_term σ)][e' .: y' ..]].
-  Proof.
-    pose (VΓA := validSnoc VΓ VA). 
-    eapply LRTransEq.
-    eapply substEq_idElimMotive_substupup.
-    2,4,8: tea. all:tea.
-    irrelevance0; rewrite subst_upup_scons2; [reflexivity|].
-    unshelve eapply validTyEq; cycle 2; tea.
-    eapply irrelevanceSubst.
-    unshelve eapply consSubstS.
-    3: now eapply idElimMotiveCtxIdValid.
-    1: now eapply consSubstS.
-    irrelevance.
-    Unshelve. 2: eapply subst_idElimMotive_substupup; cycle 1; tea.
-  Qed.
-
-
-  Lemma substExtIdElimMotive {Γ l A x P y y' e e'}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext])
-    (Vy : [Γ ||-v<l> y : _ | _ | VA])
-    (Vy' : [Γ ||-v<l> y' : _ | _ | VA])
-    (Vyy' : [Γ ||-v<l> y ≅ y' : _ | _ | VA])
+    (VPP' : [_ ||-v<l> P ≅ P' | VΓext | VP])
+    (VIdxx := (IdValid VΓ VA Vx Vx))
+    (VPhr := substIdElimMotive VΓ VA Vx VΓext VP Vx VIdxx (reflValid VΓ VA Vx _))
+    (Vhr : [_ ||-v<l> hr ≅ hr' : _ | _ | VPhr ])
+    (Vy : [_ ||-v<l> y ≅ y' : _ | _ | VA])
     (VId : [Γ ||-v<l> tId A x y | VΓ])
-    (VId' : [Γ ||-v<l> tId A x y' | VΓ])
-    (Ve : [_ ||-v<l> e : _ | _ | VId]) 
-    (Ve' : [_ ||-v<l> e' : _ | _ | VId']) 
-    (Vee' : [_ ||-v<l> e ≅ e' : _ | _ | VId]) 
-    (VPey : [_ ||-v<l> P[e .: y ..] | VΓ]) : 
-    [_ ||-v<l> P[e .: y ..] ≅ P[e' .: y' ..] | VΓ | VPey].
-  Proof.
-    constructor; intros.
-    irrelevance0; rewrite subst_scons2; [reflexivity|]. 
-    unshelve eapply validTyExt.
-    5,6: eapply idElimMotiveScons2Valid; cycle 1; tea.
-    1: tea.
-    instValid Vσ; unshelve eapply consSubstSEq''.
-    4: now eapply idElimMotiveCtxIdValid.
-    2: eapply consSubstSEq'; [now eapply reflSubst|]; irrelevance.
-    all: irrelevance.
-    Unshelve. 1:tea. irrelevance.
-  Qed.
-
-  Lemma substEqIdElimMotive {Γ l A A' x x' P P' y y' e e'}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (VA' : [_ ||-v<l> A' | VΓ]) 
-    (VAA' : [_ ||-v<l> A ≅ A' | VΓ | VA]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
-    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext])
-    (VP' : [_ ||-v<l> P | VΓext])
-    (VPP' : [_ ||-v<l> P ≅ P' | _ | VP])
-    (Vy : [Γ ||-v<l> y : _ | _ | VA])
-    (Vy' : [Γ ||-v<l> y' : _ | _ | VA])
-    (Vyy' : [Γ ||-v<l> y ≅ y' : _ | _ | VA])
-    (VId : [Γ ||-v<l> tId A x y | VΓ])
-    (Ve : [_ ||-v<l> e : _ | _ | VId]) 
-    (Ve' : [_ ||-v<l> e' : _ | _ | VId]) 
-    (Vee' : [_ ||-v<l> e ≅ e' : _ | _ | VId]) 
-    (VPey : [_ ||-v<l> P[e .: y ..] | VΓ]) : 
-    [_ ||-v<l> P[e .: y ..] ≅ P'[e' .: y' ..] | VΓ | VPey].
-  Proof.
-    assert (VId' : [Γ ||-v<l> tId A x y' | VΓ]) by now eapply IdValid.
-    assert [Γ ||-v< l > e' : tId A x y' | VΓ | VId'].
-    1:{
-      eapply conv; tea.
-      eapply IdCongValid; tea.
-      1: eapply reflValidTy.
-      now eapply reflValidTm.
-    }
-    eapply transValidTyEq.
-    - eapply substExtIdElimMotive.
-      2: tea. all: tea.
-      Unshelve. eapply substIdElimMotive; cycle 1; tea.
-    - constructor; intros; irrelevance0; rewrite subst_scons2; [reflexivity|].
-      unshelve eapply validTyEq.
-      6: tea. 1: tea.
-      eapply idElimMotiveScons2Valid; tea.
-  Qed.
-    
-  (* Lemma liftSubstS' {Γ σ Δ lF F} 
-    {VΓ : [||-v Γ]} 
-    {wfΔ : [|- Δ]}
-    (VF : [Γ ||-v<lF> F | VΓ])
-    (VΓF : [||-v Γ,, F])
-    {wfΔF : [|- Δ ,, F[σ]]}
-    (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
-    [Δ ,, F[σ] ||-v up_term_term σ : Γ ,, F | VΓF | wfΔF ].
-  Proof.
-    eapply irrelevanceSubst.
-    now unshelve eapply liftSubstS'.
-  Qed. *)
-
-
-  Lemma IdElimValid {Γ l A x P hr y e}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext])
-    (VPhr := substIdElimMotive VΓ VA Vx VΓext VP Vx (IdValid VΓ VA Vx Vx) (reflValid VΓ VA Vx _))
-    (Vhr : [_ ||-v<l> hr : _ | _ | VPhr ])
-    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
-    (VId : [Γ ||-v<l> tId A x y | VΓ])
-    (Ve : [_ ||-v<l> e : _ | _ | VId])
-    (VPye := substIdElimMotive VΓ VA Vx VΓext VP Vy VId Ve) :
-    [_ ||-v<l> tIdElim A x P hr y e : _ | _ | VPye].
-  Proof.
-    unshelve epose (h := _ : [||-v Γ,, A]). 1: now eapply validSnoc.
-    constructor; intros.
-    - instValid Vσ.
-      irrelevance0.
-      2: unshelve eapply idElimRed; refold; tea.
-      1: refold; now rewrite subst_upup_scons2, subst_scons2.
-      2,5: irrelevance.
-      + intros; eapply subst_idElimMotive_substupup; cycle 1; tea.
-      + now eapply red_idElimMotive_substupup.
-      + intros; eapply substEq_idElimMotive_substupup; cycle 1; tea.
-        eapply LRTmRedConv; tea; now eapply LRTyEqSym.
-    - instAllValid Vσ Vσ' Vσσ'.
-      irrelevance0.
-      2: unshelve eapply idElimCongRed; refold.
-      1: refold; now rewrite subst_upup_scons2, subst_scons2.
-      all: try now eapply LRCumulative.
-      all: tea; try irrelevanceCum.
-      2,4: now eapply red_idElimMotive_substupup.
-      + intros; eapply subst_idElimMotive_substupup; cycle 1; tea; irrelevanceCum.
-        Unshelve. all: tea. irrelevanceCum.
-      + intros; eapply subst_idElimMotive_substupup; cycle 1; tea; irrelevanceCum.
-        Unshelve. all: tea.
-      + now eapply red_idElimMotive_substupup_cong.
-      + intros; eapply substEq_idElimMotive_substupupEq; cycle 2; tea; irrelevanceCum.
-        Unshelve. all: tea. now eapply LRCumulative.
-      + intros; eapply substEq_idElimMotive_substupup; cycle 1; tea.
-        1,3-6: irrelevanceCum.
-        eapply LRTmRedConv;[|irrelevanceCum]; eapply LRTyEqSym; irrelevanceCum.
-        Unshelve. all: tea; now eapply LRCumulative.
-      + Set Printing Primitive Projection Parameters.
-        intros; eapply substEq_idElimMotive_substupup; cycle 1; tea.
-        1,3: irrelevanceCum.
-        eapply LRTmRedConv; [|irrelevanceCum]; eapply LRTyEqSym; irrelevanceCum.
-        Unshelve. all: tea.
-  Qed.
-
-  Lemma IdElimCongValid {Γ l A A' x x' P P' hr hr' y y' e e'}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (VA' : [_ ||-v<l> A' | VΓ]) 
-    (VAA' : [_ ||-v<l> A ≅ A' | _ | VA])
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
-    (Vx' : [_ ||-v<l> x' : _ | _ | VA])
-    (Vxx' : [_ ||-v<l> x ≅ x' : _ | _ | VA])
-    (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
-    (VP : [_ ||-v<l> P | VΓext])
-    (VP' : [_ ||-v<l> P' | VΓext])
-    (VPP' : [_ ||-v<l> P ≅ P' | _ | VP])
-    (VPhr := substIdElimMotive VΓ VA Vx VΓext VP Vx (IdValid VΓ VA Vx Vx) (reflValid VΓ VA Vx _))
-    (Vhr : [_ ||-v<l> hr : _ | _ | VPhr ])
-    (Vhr' : [_ ||-v<l> hr' : _ | _ | VPhr ])
-    (Vhrhr' : [_ ||-v<l> hr ≅ hr' : _ | _ | VPhr])
-    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
-    (Vy' : [_ ||-v<l> y' : _ | _ | VA]) 
-    (Vyy' : [_ ||-v<l> y ≅ y' : _ | _ | VA]) 
-    (VId : [Γ ||-v<l> tId A x y | VΓ])
-    (Ve : [_ ||-v<l> e : _ | _ | VId])
-    (Ve' : [_ ||-v<l> e' : _ | _ | VId])
-    (Vee' : [_ ||-v<l> e ≅ e' : _ | _ | VId])
+    (Ve : [_ ||-v<l> e ≅ e' : _ | _ | VId])
     (VPye := substIdElimMotive VΓ VA Vx VΓext VP Vy VId Ve) :
     [_ ||-v<l> tIdElim A x P hr y e ≅ tIdElim A' x' P' hr' y' e' : _ | _ | VPye].
   Proof.
-    assert [_ ||-v<l> x' : _ | _ | VA'] by now eapply conv.
-    assert [_ ||-v<l> y' : _ | _ | VA'] by now eapply conv.
-    assert (VΓext' : [||-v (Γ ,, A'),, tId A'⟨@wk1 Γ A'⟩ x'⟨@wk1 Γ A'⟩ (tRel 0)]).
-    1: eapply validSnoc; now eapply idElimMotiveCtxIdValid.
-    assert (h : forall t, t⟨@wk1 Γ A'⟩ = t⟨@wk1 Γ A⟩) by reflexivity.
-    assert (VPalt' : [_ ||-v<l> P' | VΓext']).
-    1:{
-      eapply convCtx2'; tea.
-      1: eapply convCtx1; tea; [now eapply symValidTyEq| ].
-      1,3: now eapply idElimMotiveCtxIdValid.
-      eapply idElimMotiveCtxIdCongValid; tea.
-      Unshelve. 1: now eapply idElimMotiveCtxIdValid. tea.
-    }
-    constructor; intros.
-    instValid Vσ.
-    irrelevance0.
-    2: unshelve eapply idElimCongRed; refold.
-    1: refold; now rewrite subst_upup_scons2, subst_scons2.
-    all: first [now eapply LRCumulative | solve [irrelevance | irrelevanceCum] | now eapply LRTmRedConv | tea].
-    + intros ; eapply subst_idElimMotive_substupup; cycle 1; tea; irrelevanceCum.
-      Unshelve. all: tea. irrelevanceCum.
-    + intros; eapply red_idElimMotive_substupup; tea.
-    + intros; eapply subst_idElimMotive_substupup; cycle 1; tea.
-      irrelevance.
-      Unshelve. all: tea.
-    + unshelve eapply IdRed; tea; eapply LRTmRedConv; tea.
-    + eapply red_idElimMotive_substupup; tea.
-    + eapply redEq_idElimMotive_substupup.
-      6-8: tea. 3-5: tea. all: tea.
-    + intros.
-      assert [_ ||-<l> y'0 : _ | RVA] by (eapply LRTmRedConv; tea; now eapply LRTyEqSym).
-      eapply substExt_idElimMotive_substupup.
-      7: tea. 2,3,5,6: tea. all: tea; try solve [irrelevanceCum].
-      1: eapply LRTmRedConv; tea; eapply LRTyEqSym; tea.
-      eapply IdCongRed; tea; [now escape|  now eapply reflLRTmEq].
-      Unshelve. 1: now eapply LRCumulative. 1,2: now eapply IdRed.
-    + intros; eapply substEq_idElimMotive_substupup; cycle 1; tea; try solve [irrelevanceCum].
-      eapply LRTmRedConv. 2:irrelevanceCum. eapply LRTyEqSym; irrelevanceCum.
-      Unshelve. all: tea; now eapply LRCumulative.
-    + intros; eapply substEq_idElimMotive_substupup; cycle 1; tea; try solve [irrelevanceCum].
-      eapply LRTmRedConv. 2:irrelevanceCum. eapply LRTyEqSym; irrelevanceCum.
-      Unshelve. all: tea; now eapply LRCumulative.
-    + eapply LRTmRedConv; tea.
-      rewrite subst_upup_scons2; change (tRefl A'[σ] x'[σ]) with (tRefl A' x')[σ].
-      rewrite <- subst_scons2.
-      eapply validTyEq. eapply substEqIdElimMotive.
-      6,7: tea.  5-8: tea. 2-4: tea. 1: tea.
-      2: eapply conv.
-      1,3: now eapply reflValid.
-      1: eapply symValidTyEq; now eapply IdCongValid.
-      now eapply reflCongValid.
-      Unshelve. all: now eapply IdValid.
-    + eapply LRTmRedConv; tea.
-      now eapply IdCongValid.
+    constructor; intros; cbn.
+    instValid Vσσ'.
+    pose proof (Vuu0 := liftSubstEq' (idElimMotiveCtxIdValid VΓ VA Vx) (liftSubstEq' VA Vσσ')).
+    set (wfΔ' := wfc_cons _ _) in Vuu0.
+    epose proof (Vuu := irrelevanceSubstEq _ VΓext _ wfΔ' Vuu0).
+    instValid Vuu.
+    irrelevance0; [now rewrite <-up_twice_subst|].
+    unshelve (eapply idElimCongRed; tea); tea.
+    - intros * Ry ? Re.
+      epose proof (Vext := idElimMotiveScons2Red Vx VΓext Vσσ' Ry Re).
+      instValid Vext; now rewrite subst_upup_scons2.
+    - erewrite idElimMotive_Idsubst_eq; now eapply escape.
+    - erewrite idElimMotive_Idsubst_eq.
+      epose proof (VA' := ureflValidTy VAA').
+      epose proof (X := liftSubstEq' VA' (urefl Vσσ')).
+      epose proof (X0 :=idElimMotiveCtxIdValid _ VA' (conv _ _ VA' VAA' (ureflValidTm Vx))).
+      pose proof (Vuu1 := liftSubstEq' X0 X).
+      set (wfΔ'' := wfc_cons _ _) in Vuu1.
+      pose proof (eqvCtx := idElimMotiveCtxEq VΓ VA VAA' Vx).
+      pose proof (Vuu2 := irrelevanceSubstEq _ eqvCtx.π2.π1 _ wfΔ'' Vuu1).
+      pose proof (VP' := convVTy eqvCtx (irrelevanceTy _ _ (ureflValidTy VPP'))).
+      instValid Vuu2; now eapply escape.
+    - erewrite idElimMotive_Idsubst_eq; now eapply escapeEq.
+    - intros ???? Ry ? Re.
+      epose proof (Vext := idElimMotiveScons2Red Vx VΓext Vσσ' Ry Re).
+      instValid Vext; irrelevance0; now rewrite subst_upup_scons2.
+    - intros ???????? Ry ? Re.
+      pose proof (reflValidTy VP).
+      epose proof (Vext := idElimMotiveScons2Red Vx VΓext (lrefl Vσσ') Ry Re).
+      instValid Vext; irrelevance0; now rewrite subst_upup_scons2.
+    - irrelevance0; tea; clear; now bsimpl.
   Qed.
 
+  Lemma subst_subst_twice t a b σ :
+    t[a .: b..][σ] = t[a[σ] .: (b[σ] .: σ)].
+  Proof. now bsimpl. Qed.
+
+  Lemma subst_refl A x σ : (tRefl A x)[σ] = tRefl A[σ] x[σ].
+  Proof. reflexivity. Qed.
 
   Lemma IdElimReflValid {Γ l A x P hr y B z}
-    (VΓ : [||-v Γ]) 
-    (VA : [_ ||-v<l> A | VΓ]) 
-    (Vx : [_ ||-v<l> x : _ | _ | VA])
+    (VΓ : [||-v Γ])
+    (VA : [_ ||-v<l> A | VΓ])
+    (Vxy : [_ ||-v<l> x ≅ y : _ | _ | VA])
     (VΓext : [||-v (Γ ,, A) ,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)])
     (VP : [_ ||-v<l> P | VΓext])
-    (VPhr := substIdElimMotive VΓ VA Vx VΓext VP Vx (IdValid VΓ VA Vx Vx) (reflValid VΓ VA Vx _))
+    (VIdxx := (IdValid VΓ VA Vxy Vxy))
+    (Vrflx := reflValid VΓ VA Vxy _)
+    (VPhr := substIdElimMotive VΓ VA Vxy VΓext VP Vxy VIdxx Vrflx)
     (Vhr : [_ ||-v<l> hr : _ | _ | VPhr ])
-    (Vy : [_ ||-v<l> y : _ | _ | VA]) 
-    (Vxy : [_ ||-v<l> x ≅ y : _ | _ | VA]) 
-    (VB : [_ ||-v<l> B | VΓ])
     (VAB : [_ ||-v<l> _ ≅ B | VΓ | VA])
-    (Vz : [_ ||-v<l> z : _ | _ | VB]) 
-    (Vxz : [_ ||-v<l> x ≅ z : _ | _ | VA]) 
-    (VId : [Γ ||-v<l> tId A x y | VΓ]) 
+    (Vxz : [_ ||-v<l> x ≅ z : _ | _ | VA])
+    (VId : [Γ ||-v<l> tId A x y | VΓ])
     (VRefl : [_ ||-v<l> tRefl B z : _ | _ | VId])
-    (VPye := substIdElimMotive VΓ VA Vx VΓext VP Vy VId VRefl) :
+    (VPye := substIdElimMotive VΓ VA Vxy VΓext VP (ureflValidTm Vxy) VId VRefl) :
     [_ ||-v<l> tIdElim A x P hr y (tRefl B z) ≅ hr : _ | _ | VPye].
   Proof.
-    constructor; intros.
-    assert [Γ ||-v< l > P[tRefl A x .: x..] ≅ P[tRefl B z .: y..] | VΓ | VPhr].
-    1:{
-      eapply substExtIdElimMotive; cycle 1; tea.
-      1: now eapply reflValid.
-      eapply reflCongValid; tea.
-      eapply conv; tea.
-      now eapply symValidTyEq.
-      Unshelve. now eapply IdValid.
-    }
-    eapply redwfSubstValid; cycle 1.
+    eapply redSubstValid.
+    + constructor; intros; cbn; rewrite <-up_twice_subst.
+      pose proof (Vuu0 := liftSubstEq' (idElimMotiveCtxIdValid VΓ VA Vxy) (liftSubstEq' VA Vσσ')).
+      set (wfΔ' := wfc_cons _ _) in Vuu0.
+      epose proof (Vuu := irrelevanceSubstEq _ VΓext _ wfΔ' Vuu0).
+      instValid (lrefl Vσσ') ; instValid Vuu ; escape.
+      eapply redtm_idElimRefl; tea.
+      - now erewrite idElimMotive_Idsubst_eq.
+      - now rewrite <-subst_refl, up_twice_subst.
     + eapply conv; tea.
-    + constructor; intros.
-      instValid Vσ0; escape.
-      constructor.
-      - eapply ty_conv; tea.
-      - rewrite subst_scons2, <- subst_upup_scons2.
-        eapply redtm_idElimRefl; refold; tea.
-        * eapply escape. now eapply red_idElimMotive_substupup.
-        * rewrite subst_upup_scons2; change (tRefl ?A[?σ] ?x[_]) with (tRefl A x)[σ].
-          now rewrite <- subst_scons2.
-        * now eapply ty_conv.
+      constructor; intros.
+      epose (Vr := reflCongValid _ _ VAB Vxz VIdxx).
+      epose (Vext := idElimMotiveScons2Valid _ VA Vxy Vxy _ Vr VΓext _ _ Vσσ').
+      instValid Vext.
+      irrelevance0; now rewrite subst_subst_twice.
   Qed.
 
 End Id.
 
 
-  
+
 

--- a/theories/Substitution/Introductions/Lambda.v
+++ b/theories/Substitution/Introductions/Lambda.v
@@ -72,10 +72,10 @@ Lemma lamPiRedTm {F' G'}
   : PiRedTm R (tLambda F' t')[σ'].
 Proof.
   refold.
-  pose proof (VG'':=convCtx1 VΓ VΓF (validSnoc VΓ VF') VF VF' VFF' VG').
+  pose proof (VG'':=convCtx1 VΓ VΓF (validSnoc VΓ VF') VF  VFF' VG').
   epose proof (PiCong VΓ VF VG VF' VG'' VFF' VGG').
-  epose proof (VtG' := convEq VΓF VG VG' VGG' Vtt').
-  epose proof (convTmEqCtx1 VΓ VΓF (validSnoc VΓ VF') VF VF' VG' VG'' VFF' VtG').
+  epose proof (VtG' := conv VΓF VG VG' VGG' Vtt').
+  epose proof (convTmEqCtx1 VΓ VΓF (validSnoc VΓ VF') VF  VG' VG'' VFF' VtG').
   instValid (liftSubstEq' VF' (urefl Vσσ'));
   instValid Vσσ'; instValid (urefl Vσσ'). escape.
 
@@ -88,7 +88,7 @@ Proof.
   1: now unshelve eapply wkEq.
 
   rewrite 2! consWkEq'.
-  pose proof (ureflValidTm _ _ Vtt').
+  pose proof (ureflValidTm Vtt').
   unshelve epose (Vaσ' := consWkSubstEq VF (urefl Vσσ') ρ h _).
   4: eapply LRTmEqConv; [|tea]; irrelevanceRefl; eapply wkEq; tea.
   1: now eapply wk.
@@ -111,15 +111,15 @@ Lemma lamCongValid {F' G'}
 Proof.
   econstructor; intros. cbn -[PiValid].
   normRedΠ R; refold.
-  pose proof (VG'':=convCtx1 VΓ VΓF (validSnoc VΓ VF') VF VF' VFF' VG').
+  pose proof (VG'':=convCtx1 VΓ VΓF (validSnoc VΓ VF') VF VFF' VG').
   epose proof (PiCong VΓ VF VG VF' VG'' VFF' VGG').
-  epose proof (VtG' := convEq VΓF VG VG' VGG' Vtt').
-  epose proof (convTmEqCtx1 VΓ VΓF (validSnoc VΓ VF') VF VF' VG' VG'' VFF' VtG').
+  epose proof (VtG' := conv VΓF VG VG' VGG' Vtt').
+  epose proof (convTmEqCtx1 VΓ VΓF (validSnoc VΓ VF') VF VG' VG'' VFF' VtG').
   simple refine (let ht : PiRedTm R (tLambda F t)[σ] := _ in _).
   1:{
-    pose proof (VFF := reflValidTy _ VF).
-    pose proof (VGG := reflValidTy _ VG).
-    pose proof (Vtt := reflValidTm _ _ (lreflValidTm _ _ Vtt')).
+    pose proof (VFF := reflValidTy VF).
+    pose proof (VGG := reflValidTy VG).
+    pose proof (Vtt := lreflValidTm _ Vtt').
     eapply (lamPiRedTm VF VFF VG VGG Vtt wfΔ (lrefl Vσσ') _).
   }
   simple refine (let ht' : PiRedTm R (tLambda F' t')[σ'] := _ in _).
@@ -174,16 +174,13 @@ Lemma betaValid {t a} (Vt : [Γ ,, F ||-v<l> t : G | VΓF | VG])
   (Va : [Γ ||-v<l> a : F | VΓ | VF]) :
   [Γ ||-v<l> tApp (tLambda F t) a ≅ t[a..] : G[a..] | VΓ | substS VG Va].
 Proof.
-  eapply redwfSubstValid.
-  2: eapply substSTm; irrValid.
-  econstructor; intros; cbn.
-  econstructor.
-  - rewrite 2! singleSubst_subst_eq'.
-    instValid (consSubstEqvalid Vσσ' Va); now escape.
-  - rewrite 2!singleSubst_subst_eq.
-    instValid (lrefl Vσσ').
-    instValid (liftSubstEq' VF (lrefl Vσσ')).
-    escape; now eapply redtm_beta.
+  eapply redSubstValid.
+  2: eapply substSTm ; irrValid.
+  constructor; intros; cbn.
+  rewrite 2!singleSubst_subst_eq.
+  instValid (lrefl Vσσ').
+  instValid (liftSubstEq' VF (lrefl Vσσ')).
+  escape; now eapply redtm_beta.
 Qed.
 
 

--- a/theories/Substitution/Introductions/Nat.v
+++ b/theories/Substitution/Introductions/Nat.v
@@ -1,8 +1,8 @@
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
-From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity Reduction Application Universe SimpleArr.
-From LogRel.Substitution Require Import Irrelevance Properties Conversion SingleSubst Reflexivity.
-From LogRel.Substitution.Introductions Require Import Universe Pi SimpleArr Var.
+From LogRel.LogicalRelation Require Import Induction  Escape Irrelevance Reflexivity Irrelevance Weakening Neutral Transitivity Reduction Application Universe EqRedRight SimpleArr.
+From LogRel.Substitution Require Import Irrelevance Properties Conversion SingleSubst Reflexivity Reduction.
+From LogRel.Substitution.Introductions Require Import Universe Pi SimpleArr Var Application.
 
 Set Universe Polymorphism.
 
@@ -13,7 +13,7 @@ Set Printing Primitive Projection Parameters.
 
 
 Lemma natRed {Γ l} : [|- Γ] -> [Γ ||-<l> tNat].
-Proof. 
+Proof.
   intros; eapply LRNat_; constructor; eapply redtywf_refl; gen_typing.
 Defined.
 
@@ -24,7 +24,7 @@ Proof.
   + cbn; constructor; eapply redtywf_refl; gen_typing.
 Defined.
 
-Lemma natconvValid {Γ l} (VΓ : [||-v Γ]) (VNat : [Γ ||-v<l> tNat | VΓ]) : 
+Lemma natconvValid {Γ l} (VΓ : [||-v Γ]) (VNat : [Γ ||-v<l> tNat | VΓ]) :
   [Γ ||-v<l> tNat ≅ tNat | VΓ | VNat].
 Proof.
   constructor; intros.
@@ -32,197 +32,94 @@ Proof.
   constructor; cbn; eapply redtywf_refl; gen_typing.
 Qed.
 
-Lemma redUOne {Γ} : [|- Γ] -> [Γ ||-U<one> U].
+Lemma natURedTm {Δ} (wfΔ : [|-Δ]) : URedTm (LogRelRec one) Δ tNat U (redUOneCtx wfΔ).
 Proof.
-  intros ; econstructor; [easy| gen_typing|eapply redtywf_refl; gen_typing].
+  exists tNat; [| constructor].
+  eapply redtmwf_refl; gen_typing.
 Defined.
 
-Lemma natTermRed {Δ} (wfΔ : [|-Δ]) : [Δ ||-<one> tNat : U | LRU_ (redUOne wfΔ)].
+Lemma natTermRed {Δ} (wfΔ : [|-Δ]) : [Δ ||-<one> tNat : U | LRU_ (redUOneCtx wfΔ)].
 Proof.
-  econstructor.
-  + eapply redtmwf_refl; gen_typing.
-  + constructor.
-  + gen_typing.
-  + now eapply (natRed (l:= zero)).
+  unshelve eexists (natURedTm wfΔ) (natURedTm wfΔ) _; cbn.
+  1,3: now eapply (natRed (l:=zero)).
+  1: gen_typing.
+  apply reflLRTyEq.
 Defined.
 
 Lemma natTermValid {Γ} (VΓ : [||-v Γ]):  [Γ ||-v<one> tNat : U | VΓ | UValid VΓ].
 Proof.
-  constructor; intros.
-  - eapply natTermRed. 
-  - eexists (natTermRed wfΔ) (natTermRed wfΔ) (natRed wfΔ); cbn.
-    + gen_typing.
-    + now eapply (natRed (l:=zero)).
-    + constructor; eapply redtywf_refl; gen_typing.
+  constructor; intros; eapply natTermRed.
 Qed.
 
 Lemma zeroRed {Γ l} {NN : [Γ ||-Nat tNat]} (wfΓ : [|- Γ]): [Γ ||-<l> tZero : _ | LRNat_ l NN].
-Proof.
-  exists tZero.
-  1,2: gen_typing.
-  constructor.
-Defined.
-
-Lemma zeroRedEq {Γ l} {NN : [Γ ||-Nat tNat]} (wfΓ : [|- Γ]): [Γ ||-<l> tZero ≅ tZero : _ | LRNat_ l NN].
 Proof.
   exists tZero tZero.
   1-3: gen_typing.
   constructor.
 Defined.
 
-Lemma zeroValid {Γ l} (VΓ : [||-v Γ]): 
+Lemma zeroRedEq {Γ l} {NN : [Γ ||-Nat tNat]} (wfΓ : [|- Γ]): [Γ ||-<l> tZero ≅ tZero : _ | LRNat_ l NN].
+Proof. now apply zeroRed. Defined.
+
+Lemma zeroValid {Γ l} (VΓ : [||-v Γ]):
   [Γ ||-v<l> tZero : tNat | VΓ | natValid VΓ].
 Proof.
-  constructor; intros; cbn; [unshelve eapply zeroRed| unshelve eapply zeroRedEq]; tea.
+  constructor; intros; cbn; unshelve eapply zeroRed; tea.
 Qed.
+
+Lemma succRedEq {Γ l n n'} {NN : [Γ ||-Nat tNat]} :
+  [Γ ||-<l> n ≅ n' : _ | LRNat_ l NN] ->
+  [Γ ||-<l> tSucc n ≅ tSucc n' : _ | LRNat_ l NN].
+Proof.
+  intros h; pose proof (h' :=h); inversion h'; subst.
+  escape; exists (tSucc n) (tSucc n').
+  1,2: eapply redtmwf_refl; eapply ty_succ; gen_typing.
+  + eapply convtm_succ; eapply convtm_exp; gen_typing.
+  + now constructor.
+Defined.
 
 Lemma succRed {Γ l n} {NN : [Γ ||-Nat tNat]} :
   [Γ ||-<l> n : _ | LRNat_ l NN] ->
   [Γ ||-<l> tSucc n : _ | LRNat_ l NN].
-Proof.
-  intros Rn; exists (tSucc n).
-  + eapply redtmwf_refl; eapply ty_succ; now escape.
-  + eapply convtm_succ; eapply escapeEqTerm; now eapply reflLRTmEq.
-  + now constructor.
-Defined.
+Proof. eapply succRedEq. Defined.
 
-Lemma succRedEq {Γ l n n'} {NN : [Γ ||-Nat tNat]} :
-  [Γ ||-<l> n : _ | LRNat_ l NN] ->
-  [Γ ||-<l> n' : _ | LRNat_ l NN] ->
-  [Γ ||-<l> n ≅ n' : _ | LRNat_ l NN] ->
-  [Γ ||-<l> tSucc n ≅ tSucc n' : _ | LRNat_ l NN].
-Proof.
-  intros ???; escape; exists (tSucc n) (tSucc n').
-  1,2: eapply redtmwf_refl; now eapply ty_succ.
-  + now eapply convtm_succ.
-  + now constructor.
-Defined.
 
-Lemma succRedInv {Γ l n} {NN : [Γ ||-Nat tNat]} :
-  [Γ ||-<l> tSucc n : _ | LRNat_ l NN] ->
-  [Γ ||-<l> n : _ | LRNat_ l NN].
+Lemma succRedInv {Γ l n m } {NN : [Γ ||-Nat tNat]} :
+  [Γ ||-<l> tSucc n ≅ tSucc m : _ | LRNat_ l NN] ->
+  [Γ ||-<l> n ≅ m : _ | LRNat_ l NN].
 Proof.
-  intros RSn; inversion RSn; subst. 
-  unshelve epose proof (redtmwf_whnf red _). 1: constructor.
+  intros RSn; inversion RSn; subst.
+  unshelve epose proof (redtmwf_whnf redL _); try constructor.
+  unshelve epose proof (redtmwf_whnf redR _); try constructor.
   subst. inversion prop; subst; tea.
-  match goal with H : [ _ ||-NeNf _ : _] |- _ => destruct H; apply convneu_whne in refl; inv_whne end.
+  match goal with H : [ _ ||-NeNf _ ≅ _ : _] |- _ => destruct H as [?? refl] end.
+  apply convneu_whne in refl; inv_whne.
 Qed.
 
-Lemma succValid {Γ l n} (VΓ : [||-v Γ]) 
-  (Vn : [Γ ||-v<l> n : tNat | VΓ | natValid VΓ]) :
-  [Γ ||-v<l> tSucc n : tNat | VΓ | natValid VΓ].
-Proof.
-  constructor; intros; cbn.
-  - instValid Vσ ; now unshelve eapply succRed.
-  - instAllValid Vσ Vσ' Vσσ'; now unshelve eapply succRedEq.
-Qed.
 
-Lemma succcongValid {Γ l n n'} (VΓ : [||-v Γ]) 
-  (Vn : [Γ ||-v<l> n : tNat | VΓ | natValid VΓ])
-  (Vn' : [Γ ||-v<l> n' : tNat | VΓ | natValid VΓ])
+Lemma succcongValid {Γ l n n'} (VΓ : [||-v Γ])
   (Veqn : [Γ ||-v<l> n ≅ n' : tNat | VΓ | natValid VΓ]) :
   [Γ ||-v<l> tSucc n ≅ tSucc n' : tNat | VΓ | natValid VΓ].
 Proof.
-  constructor; intros; cbn; instValid Vσ; now unshelve eapply succRedEq.
+  constructor; intros; cbn; instValid Vσσ'; now unshelve eapply succRedEq.
 Qed.
 
+Lemma succValid {Γ l n} (VΓ : [||-v Γ])
+  (Vn : [Γ ||-v<l> n : tNat | VΓ | natValid VΓ]) :
+  [Γ ||-v<l> tSucc n : tNat | VΓ | natValid VΓ].
+Proof. now eapply lreflValidTm, succcongValid, reflValidTm. Qed.
 
 Lemma elimSuccHypTy_subst {P} σ :
   elimSuccHypTy P[up_term_term σ] = (elimSuccHypTy P)[σ].
 Proof.
   unfold elimSuccHypTy.
   cbn. rewrite shift_up_eq.
-  rewrite liftSubstComm. cbn. 
+  rewrite liftSubstComm. cbn.
   now rewrite up_liftSubst_eq.
 Qed.
 
 Lemma liftSubst_singleSubst_eq {t u v: term} : t[u]⇑[v..] = t[u[v..]..].
 Proof. now bsimpl. Qed.
-
-Definition natElim {Γ A} (P hz hs : term) {n} {NA : [Γ ||-Nat A]} (p : NatProp NA n) : term.
-Proof.
-  destruct p.
-  - exact hz.
-  - exact (tApp (tApp hs n) (tNatElim P hz hs n)).
-  - exact (tNatElim P hz hs ne).
-Defined.
-
-Section NatElimRed.
-  Context {Γ l P hs hz}
-    (wfΓ : [|- Γ])
-    (NN : [Γ ||-Nat tNat])
-    (RN := LRNat_ _ NN)
-    (RP : [Γ,, tNat ||-<l> P])
-    (RPpt : forall n, [Γ ||-<l> n : _ | RN] -> [Γ ||-<l> P[n..]])
-    (RPext : forall n n' (Rn : [Γ ||-<l> n : _ | RN]),
-      [Γ ||-<l> n' : _ | RN] ->
-      [Γ ||-<l> n ≅ n' : _ | RN] ->
-      [Γ ||-<l> P[n..] ≅ P[n'..] | RPpt _ Rn])
-    (RPz := RPpt _ (zeroRed wfΓ))
-    (Rhz : [Γ ||-<l> hz : P[tZero..] | RPz]) 
-    (RPs : [Γ ||-<l> elimSuccHypTy P])
-    (Rhs : [Γ ||-<l> hs : _ | RPs]).
-
-  Definition natRedElimStmt :=
-    (forall n (Rn : [Γ ||-<l> n : _ | RN]), 
-      [Γ ||-<l> tNatElim P hz hs n : _ | RPpt _ Rn ] ×
-      [Γ ||-<l> tNatElim P hz hs n ≅ tNatElim P hz hs (NatRedTm.nf Rn) : _ | RPpt _ Rn]) ×
-    (forall n (Nn : NatProp NN n) (Rn : [Γ ||-<l> n : _ | RN]), 
-      [Γ ||-<l> tNatElim P hz hs n : _ | RPpt _ Rn ] ×
-      [Γ ||-<l> tNatElim P hz hs n ≅ natElim P hz hs Nn : _ | RPpt _ Rn]).
-
-  Lemma natElimRedAux : natRedElimStmt.
-  Proof.
-    escape.
-    apply NatRedInduction.
-    - intros ? nf red ? nfprop ih.
-      assert [Γ ||-<l> nf : _ | RN]. 1:{
-        econstructor; tea.
-        eapply redtmwf_refl; gen_typing.
-      }
-      eapply redSubstTerm.
-      + eapply LRTmRedConv. 
-        2: unshelve eapply ih; tea.
-        eapply RPext. 
-        2: eapply LRTmEqSym.
-        1,2: eapply redwfSubstTerm; tea.
-      + eapply redtm_natelim; tea.
-        cbn; gen_typing.
-    - intros. 
-      eapply redSubstTerm.
-      2: eapply redtm_natElimZero; tea.
-      irrelevance.
-    - intros n Rn ih RSucc; change [Γ ||-<l> n : tNat | RN] in Rn.
-      eapply redSubstTerm.
-      2: eapply redtm_natElimSucc; tea.
-      2: now escape.
-      eapply simple_appTerm.
-      2: eapply ih.
-      irrelevance0.
-      2: unshelve eapply (appTerm RPs Rhs Rn).
-      now bsimpl.
-    - intros ? [] ?.
-      apply reflect.
-      + apply completeness.
-      + now eapply ty_natElim.
-      + now eapply ty_natElim.
-      + eapply convneu_natElim; tea.
-        { eapply escapeEq, reflLRTyEq. }
-        { eapply escapeEqTerm; now eapply reflLRTmEq. }
-        { eapply escapeEqTerm; now eapply reflLRTmEq. }
-    Unshelve.
-    * eapply ArrRedTy; now eapply RPpt.
-    * rewrite subst_arr. eapply ArrRedTy.
-      2: rewrite liftSubst_singleSubst_eq; cbn.
-      all: now eapply RPpt.
-    * exact l.
-    * assumption.
-  Qed.
-
-  Lemma natElimRed : forall n (Rn : [Γ ||-<l> n : _ | RN]), [Γ ||-<l> tNatElim P hz hs n : _ | RPpt _ Rn ].
-  Proof. intros. apply (fst natElimRedAux). Qed.
-End NatElimRed.
-
 
 Section NatElimRedEq.
   Context {Γ l P Q hs hs' hz hz'}
@@ -232,128 +129,94 @@ Section NatElimRedEq.
     (RP : [Γ,, tNat ||-<l> P])
     (RQ : [Γ,, tNat ||-<l> Q])
     (eqPQ : [Γ,, tNat |- P ≅ Q])
-    (RPpt : forall n, [Γ ||-<l> n : _ | RN] -> [Γ ||-<l> P[n..]])
-    (RQpt : forall n, [Γ ||-<l> n : _ | RN] -> [Γ ||-<l> Q[n..]])
-    (RPQext : forall n n' (Rn : [Γ ||-<l> n : _ | RN]),
-      [Γ ||-<l> n' : _ | RN] ->
-      [Γ ||-<l> n ≅ n' : _ | RN] ->
-      [Γ ||-<l> P[n..] ≅ Q[n'..] | RPpt _ Rn])
-    (RPz := RPpt _ (zeroRed wfΓ))
-    (RQz := RQpt _ (zeroRed wfΓ))
-    (Rhz : [Γ ||-<l> hz : P[tZero..] | RPz]) 
-    (RQhz : [Γ ||-<l> hz' : Q[tZero..] | RQz]) 
-    (RPQhz : [Γ ||-<l> hz ≅ hz' : _ | RPz])
+    (RPpt : forall n n', [Γ ||-<l> n ≅ n' : _ | RN] -> [Γ ||-<l> P[n..]])
+    (* (RQpt : forall n n', [Γ ||-<l> n ≅ n': _ | RN] -> [Γ ||-<l> Q[n..]]) *)
+    (RPQext : forall n n' (Rn : [Γ ||-<l> n ≅ n' : _ | RN]),
+      [Γ ||-<l> P[n..] ≅ Q[n'..] | RPpt _ _ Rn])
+    (RPz := RPpt _ _ (zeroRed wfΓ))
+    (RPQz := RPQext _ _ (zeroRedEq wfΓ))
+    (Rhz : [Γ ||-<l> hz ≅ hz' : _ | RPz])
     (RPs : [Γ ||-<l> elimSuccHypTy P])
     (RQs : [Γ ||-<l> elimSuccHypTy Q])
-    (Rhs : [Γ ||-<l> hs : _ | RPs])
-    (RQhs : [Γ ||-<l> hs' : _ | RQs])
-    (RPQhs : [Γ ||-<l> hs ≅ hs' : _ | RPs ])
+    (RPQs : [Γ ||-<l> elimSuccHypTy P ≅ elimSuccHypTy Q | RPs])
+    (Rhs : [Γ ||-<l> hs ≅ hs' : _ | RPs ])
     .
 
-  Lemma RPext : forall n n' (Rn : [Γ ||-<l> n : _ | RN]),
-      [Γ ||-<l> n' : _ | RN] ->
-      [Γ ||-<l> n ≅ n' : _ | RN] ->
-      [Γ ||-<l> P[n..] ≅ P[n'..] | RPpt _ Rn].
-  Proof.
-    intros. eapply transEq; [| eapply LRTyEqSym ]; eapply RPQext; cycle 1; tea.
-    now eapply reflLRTmEq.
-    Unshelve. 2,3: eauto.
-  Qed.
+  #[local]
+  Lemma RQpt : forall n n', [Γ ||-<l> n ≅ n': _ | RN] -> [Γ ||-<l> Q[n..]].
+  Proof. intros; now unshelve eapply LRTyEqRedRight, RPQext. Qed.
 
-  Lemma natElimRedAuxLeft : @natRedElimStmt _ _ P hs hz NN RPpt.
-  Proof.
-    eapply natElimRedAux; tea.
-    + eapply RPext.
-  Qed.
+  Let RQz := RQpt _ _ (zeroRed wfΓ).
 
-  Lemma natElimRedAuxRight : @natRedElimStmt _ _ Q hs' hz' NN RQpt.
+  #[local]
+  Lemma RPext : forall n n' (Rn : [Γ ||-<l> n ≅ n' : _ | RN]),
+      [Γ ||-<l> P[n..] ≅ P[n'..] | RPpt _ _ Rn].
   Proof.
-    eapply natElimRedAux; tea.
-    + intros. eapply transEq; [eapply LRTyEqSym |]; eapply RPQext; cycle 1; tea.
-      now eapply reflLRTmEq.
-    Unshelve. all:tea.
+    intros; eapply transEq; [| eapply LRTyEqSym ].
+    all: unshelve (eapply RPQext; cycle 1; tea); now eapply urefl.
+    Unshelve. 2: eapply RQpt; now symmetry.
   Qed.
 
   Lemma natElimRedEqAux :
-    (forall n n' (Rnn' : [Γ ||-<l> n ≅ n' : _ | RN]) (Rn : [Γ ||-<l> n : _ | RN]) (Rn' : [Γ ||-<l> n' : _ | RN]), 
-      [Γ ||-<l> tNatElim P hz hs n ≅ tNatElim Q hz' hs' n' : _ | RPpt _ Rn ]) ×
-    (forall n n' (Rnn' : NatPropEq NN n n') (Rn : [Γ ||-<l> n : _ | RN]) (Rn' : [Γ ||-<l> n' : _ | RN]), 
-      [Γ ||-<l> tNatElim P hz hs n ≅ tNatElim Q hz' hs' n' : _ | RPpt _ Rn ]).
+    (forall n n' (Rnn' : [Γ ||-<l> n ≅ n' : _ | RN]), [Γ ||-<l> n ≅ n' : _ | RN] ->
+      [Γ ||-<l> tNatElim P hz hs n ≅ tNatElim Q hz' hs' n' : _ | RPpt _ _ Rnn' ]) ×
+    (forall n n' (Rnn' : NatPropEq NN n n') (RP : [Γ ||-<l> P[n..]]),
+    (* (Rn : [Γ ||-<l> n ≅ n' : _ | RN]), *)
+      [Γ ||-<l> tNatElim P hz hs n ≅ tNatElim Q hz' hs' n' : _ | RP (*RPpt _ _ Rn*) ]).
   Proof.
     apply NatRedEqInduction.
-    - intros ?? nfL nfR redL redR ? prop ih RL RR; destruct (NatPropEq_whnf prop).
-      assert [Γ ||-<l> nfL : _ | RN] by (eapply redTmFwd; cycle 1; tea).
-      assert [Γ ||-<l> nfR : _ | RN] by (eapply redTmFwd; cycle 1; tea).
-      eapply LREqTermHelper.
-      * eapply (fst natElimRedAuxLeft).
-      * eapply (fst natElimRedAuxRight).
-      * eapply RPQext. 1: tea.
-        now econstructor.
-      * eapply LRTmEqRedConv.
-        + eapply RPext; tea. 
-          eapply LRTmEqSym; eapply redwfSubstTerm; cycle 1; tea.
-        + unshelve erewrite (redtmwf_det _ _ (NatRedTm.red RL) redL); tea.
-          1: dependent inversion RL; subst; cbn; now eapply NatProp_whnf.
-          unshelve erewrite (redtmwf_det _ _ (NatRedTm.red RR) redR); tea.
-          1: dependent inversion RR; subst; cbn; now eapply NatProp_whnf.
-          now eapply ih.
-        Unshelve. tea.
-    - intros. eapply LREqTermHelper.
-      * unshelve eapply (snd natElimRedAuxLeft); constructor.
-      * unshelve eapply (snd natElimRedAuxRight); tea; constructor.
-      * eapply RPQext; [unshelve eapply zeroRed| unshelve eapply zeroRedEq]; tea.
-      * cbn; irrelevance.
-    - intros ??? ih Rn Rn'. pose proof (succRedInv Rn); pose proof (succRedInv Rn').
-      eapply LREqTermHelper.
-      * unshelve eapply (snd natElimRedAuxLeft); now constructor.
-      * unshelve eapply (snd natElimRedAuxRight); tea; now constructor.
-      * eapply RPQext; [unshelve eapply succRed| unshelve eapply succRedEq]; tea.
-      * cbn.
-        eapply simple_appcongTerm.
-        4: now eapply ih.
-        + irrelevance0. 2: eapply appcongTerm; tea.
-          now bsimpl.
-        + eapply (fst natElimRedAuxLeft).
-        + eapply LRTmRedConv. 2: eapply (fst natElimRedAuxRight).
-          eapply LRTyEqSym; now eapply RPQext.
-        Unshelve. 2,4,5: tea.
-        1: eapply ArrRedTy; now eapply RPpt.
-        rewrite subst_arr. eapply ArrRedTy.
-        2: rewrite liftSubst_singleSubst_eq; cbn.
-        all: now eapply RPpt.
-    - intros ?? neueq ??. escape. inversion neueq.
-      assert [Γ |- P[ne..] ≅ Q[ne'..]]. 1:{
-        eapply escapeEq. eapply RPQext; tea.
-        econstructor.
-        1,2: now eapply redtmwf_refl.
-        2: now constructor.
-        gen_typing.
-      }
-      eapply neuTermEq.
-      + eapply ty_natElim; tea.
-      + eapply ty_conv. 
-        1: eapply ty_natElim; tea.
-        now symmetry.
-      + eapply convneu_natElim ; tea.
-      Unshelve. tea.
+    - intros ?? nfL nfR redL redR ? prop ih Rtu ; destruct (NatPropEq_whnf prop).
+      eapply redSubstTmEq.
+      + eapply LRTmEqConv, ih; unshelve eapply RPext.
+        eapply redTmEqFwd; tea; now eapply lrefl.
+      + escape; eapply redtm_natelim; tea; gen_typing.
+      + escape; eapply redtm_natelim; tea; [..| gen_typing].
+        1,2: now eapply ty_conv.
+      + now unshelve eapply escapeEq, RPQext.
+    - intros. eapply redSubstTmEq.
+      + irrelevanceRefl; eapply Rhz.
+      + escape; eapply redtm_natElimZero; tea.
+      + escape; eapply redtm_natElimZero; tea.
+        1,2: now eapply ty_conv.
+      + now escape.
+    - intros n n' Rn ih ?; change [Γ ||-<l> n ≅ n' : _ | RN] in Rn.
+      eapply redSubstTmEq; cycle 1.
+      + escape; eapply redtm_natElimSucc; tea.
+      + escape; eapply redtm_natElimSucc; tea.
+        1,2: now eapply ty_conv.
+      + unshelve eapply escapeEq, RPQext.
+        now eapply succRedEq.
+      + assert [Γ ||-<l> arr P[n..] P[(tSucc n)..]].
+        1: now (eapply ArrRedTy; eapply RPpt; [| eapply succRedEq]).
+        unshelve eapply simple_appcongTerm; [..| eauto]; tea.
+        unshelve (irrelevance0; [| eapply appcongTerm; tea]).
+        all: now rewrite subst_arr, liftSubst_singleSubst_eq.
+    - intros n n' Rn RP0.
+      pose proof (neNfTermEq RN Rn).
+      eapply neuTermEq. 2: eapply ty_conv ; [| eapply escapeEq; eapply LRTyEqSym].
+      + escape; now eapply ty_natElim.
+      + escape; eapply ty_natElim; tea.
+        all: now eapply ty_conv.
+      + now unshelve eapply RPQext.
+      + escape ; destruct Rn; now eapply convneu_natElim.
+      Unshelve. 2: eapply RQpt; now eapply urefl.
   Qed.
 
   Lemma natElimRedEq :
-    (forall n n' (Rnn' : [Γ ||-<l> n ≅ n' : _ | RN]) (Rn : [Γ ||-<l> n : _ | RN]) (Rn' : [Γ ||-<l> n' : _ | RN]), 
-      [Γ ||-<l> tNatElim P hz hs n ≅ tNatElim Q hz' hs' n' : _ | RPpt _ Rn ]).
-  Proof. apply natElimRedEqAux. Qed.
+    (forall n n' (Rnn' : [Γ ||-<l> n ≅ n' : _ | RN]),
+      [Γ ||-<l> tNatElim P hz hs n ≅ tNatElim Q hz' hs' n' : _ | RPpt _ _ Rnn' ]).
+  Proof. intros; now apply (fst natElimRedEqAux). Qed.
 End NatElimRedEq.
 
 
-
 Section NatElimValid.
-  Context {Γ l P}
+  Context {Γ l}
     (VΓ : [||-v Γ])
     (VN := natValid (l:=l) VΓ)
-    (VΓN := validSnoc VΓ VN)
-    (VP : [Γ ,, tNat ||-v<l> P | VΓN]).
-  
-  Lemma elimSuccHypTyValid :
+    (VΓN := validSnoc VΓ VN).
+
+  Lemma elimSuccHypTyValid {P}
+    (VP : [Γ ,, tNat ||-v<l> P | VΓN]) :
     [Γ ||-v<l> elimSuccHypTy P | VΓ].
   Proof.
     unfold elimSuccHypTy.
@@ -367,183 +230,14 @@ Section NatElimValid.
     change tNat with tNat⟨@wk1 Γ tNat⟩ at 2.
     eapply var0Valid.
     Unshelve. all: tea.
-  Qed.
+  Defined.
 
-  Context {hz hs}
-    (VPz := substS VP (zeroValid VΓ))
-    (Vhz : [Γ ||-v<l> hz : P[tZero..] | VΓ | VPz]) 
-    (Vhs : [Γ ||-v<l> hs : _ | VΓ | elimSuccHypTyValid]).
-
-
-  Lemma natElimValid {n}
-    (Vn : [Γ ||-v<l> n : tNat | VΓ | VN])
-    (VPn := substS VP Vn)
-    : [Γ ||-v<l> tNatElim P hz hs n : _ | VΓ | VPn].
+  Lemma elimSuccHypTyCongValid {P P'}
+      (VP : [Γ ,, tNat ||-v<l> P | VΓN])
+      (VeqP : [Γ ,, tNat ||-v<l> P ≅ P' | VΓN | VP ]) :
+      [Γ ||-v<l> elimSuccHypTy P ≅ elimSuccHypTy P' | VΓ | elimSuccHypTyValid VP].
   Proof.
-    constructor; intros.
-    - instValid Vσ; cbn.
-      irrelevance0.  1: now rewrite singleSubstComm'.
-      epose proof (Vuσ := liftSubstS' VN Vσ).
-      instValid Vuσ; escape.
-      unshelve eapply natElimRed; tea.
-      + intros m Rm.
-        rewrite up_single_subst. 
-        unshelve eapply validTy; cycle 1; tea.
-        unshelve econstructor; [now bsimpl| now cbn].
-      + rewrite elimSuccHypTy_subst. eapply validTy; tea; eapply elimSuccHypTyValid.
-      + intros m m' Rm Rm' Rmm'; cbn.
-        irrelevance0. 1: now rewrite up_single_subst.
-        rewrite up_single_subst.
-        unshelve eapply validTyExt; cycle 1 ; tea.
-        1,2: unshelve econstructor; [now bsimpl| now cbn].
-        unshelve econstructor; [|now cbn].
-        bsimpl; cbn; eapply reflSubst.
-      + irrelevance.
-      + irrelevance. now rewrite elimSuccHypTy_subst. 
-    - instAllValid Vσ Vσ' Vσσ'.
-      irrelevance0.  1: now rewrite singleSubstComm'.
-      pose (Vuσ := liftSubstS' VN Vσ).
-      pose proof (Vuσ' := liftSubstS' VN Vσ').
-      pose proof (Vuσrea :=  liftSubstSrealign' VN Vσσ' Vσ').
-      pose proof (Vuσσ' := liftSubstSEq' VN Vσσ').
-      instValid Vuσ'; instAllValid Vuσ Vuσrea Vuσσ'; escape.
-      unshelve eapply natElimRedEq; tea; fold subst_term.
-      6-11: irrelevance; now rewrite elimSuccHypTy_subst.
-      3,4: rewrite elimSuccHypTy_subst; eapply validTy; tea; eapply elimSuccHypTyValid.
-      + intros m Rm.
-        rewrite up_single_subst. 
-        unshelve eapply validTy; cycle 1; tea.
-        unshelve econstructor; [now bsimpl| now cbn].
-      + intros m Rm.
-        rewrite up_single_subst. 
-        unshelve eapply validTy; cycle 1; tea.
-        unshelve econstructor; [now bsimpl| now cbn].
-      + intros m m' Rm Rm' Rmm'; cbn.
-        irrelevance0. 1: now rewrite up_single_subst.
-        rewrite up_single_subst.
-        unshelve eapply validTyExt; cycle 1 ; tea.
-        1,2: unshelve econstructor; [now bsimpl| now cbn].
-        unshelve econstructor; [|now cbn].
-        now bsimpl.
-  Qed.
-
-  Lemma natElimZeroValid  : 
-    [Γ ||-v<l> tNatElim P hz hs tZero ≅ hz : _ | VΓ | VPz].
-  Proof.
-    constructor; intros.
-    epose proof (Vuσ := liftSubstS' VN Vσ).
-    instValid Vσ; instValid Vuσ; escape.
-    irrelevance0.  1: now rewrite singleSubstComm'.
-    unshelve eapply (snd (natElimRedAux _ _ _ _ _ _ _ _) _ NatRedTm.zeroR); tea; fold subst_term.
-    7: eapply zeroValid.
-    + intros m Rm.
-      rewrite up_single_subst. 
-      unshelve eapply validTy; cycle 1; tea.
-      unshelve econstructor; [now bsimpl| now cbn].
-    + intros m m' Rm Rm' Rmm'; cbn.
-      irrelevance0. 1: now rewrite up_single_subst.
-      rewrite up_single_subst.
-      unshelve eapply validTyExt; cycle 1 ; tea.
-      1,2: unshelve econstructor; [now bsimpl| now cbn].
-      unshelve econstructor; [|now cbn].
-      bsimpl; cbn; eapply reflSubst.
-    + irrelevance.
-    + rewrite elimSuccHypTy_subst. eapply validTy; tea; eapply elimSuccHypTyValid.
-    + irrelevance. now rewrite elimSuccHypTy_subst. 
-    Unshelve. 4: tea.
-  Qed.
-
-  Lemma natElimSuccValid {n}
-    (Vn : [Γ ||-v<l> n : tNat | VΓ | VN]) 
-    (VPSn := substS VP (succValid _ Vn)) : 
-    [Γ ||-v<l> tNatElim P hz hs (tSucc n) ≅ tApp (tApp hs n) (tNatElim P hz hs n) : _ | VΓ | VPSn].
-  Proof.
-    constructor; intros.
-    epose proof (Vuσ := liftSubstS' VN Vσ).
-    instValid Vσ; instValid Vuσ; escape.
-    irrelevance0.  1: now rewrite singleSubstComm'.
-    pose (NSn := NatRedTm.succR RVn).
-    unshelve eapply (snd (natElimRedAux _ _ _ _ _ _ _ _) _ NSn); tea; fold subst_term.
-    + intros m Rm.
-      rewrite up_single_subst. 
-      unshelve eapply validTy; cycle 1; tea.
-      unshelve econstructor; [now bsimpl| now cbn].
-    + intros m m' Rm Rm' Rmm'; cbn.
-      irrelevance0. 1: now rewrite up_single_subst.
-      rewrite up_single_subst.
-      unshelve eapply validTyExt; cycle 1 ; tea.
-      1,2: unshelve econstructor; [now bsimpl| now cbn].
-      unshelve econstructor; [|now cbn].
-      bsimpl; cbn; eapply reflSubst.
-    + irrelevance.
-    + rewrite elimSuccHypTy_subst. eapply validTy; tea; eapply elimSuccHypTyValid.
-    + irrelevance. now rewrite elimSuccHypTy_subst. 
-    + now eapply succRed.
-  Qed.
-
-End NatElimValid.
-
-Lemma natElimCongValid {Γ l P Q hz hz' hs hs' n n'}
-    (VΓ : [||-v Γ])
-    (VN := natValid (l:=l) VΓ)
-    (VΓN := validSnoc VΓ VN)
-    (VP : [Γ ,, tNat ||-v<l> P | VΓN])
-    (VQ : [Γ ,, tNat ||-v<l> Q | VΓN])
-    (VPQ : [Γ ,, tNat ||-v<l> P ≅ Q | VΓN | VP])
-    (VPz := substS VP (zeroValid VΓ))
-    (VQz := substS VQ (zeroValid VΓ))
-    (Vhz : [Γ ||-v<l> hz : P[tZero..] | VΓ | VPz]) 
-    (Vhz' : [Γ ||-v<l> hz' : Q[tZero..] | VΓ | VQz])
-    (Vheqz : [Γ ||-v<l> hz ≅ hz' : P[tZero..] | VΓ | VPz])
-    (VPs := elimSuccHypTyValid VΓ VP)
-    (VQs := elimSuccHypTyValid VΓ VQ)
-    (Vhs : [Γ ||-v<l> hs : _ | VΓ | VPs]) 
-    (Vhs' : [Γ ||-v<l> hs' : _ | VΓ | VQs])
-    (Vheqs : [Γ ||-v<l> hs ≅ hs' : _ | VΓ | VPs]) 
-    (Vn : [Γ ||-v<l> n : _ | VΓ | VN])
-    (Vn' : [Γ ||-v<l> n' : _ | VΓ | VN])
-    (Veqn : [Γ ||-v<l> n ≅ n' : _ | VΓ | VN])
-    (VPn := substS VP Vn) :
-    [Γ ||-v<l> tNatElim P hz hs n ≅ tNatElim Q hz' hs' n' : _ | VΓ | VPn].
-Proof.
-  constructor; intros.
-  pose (Vuσ := liftSubstS' VN Vσ).
-  instValid Vσ; instValid Vuσ; escape.
-  irrelevance0.  1: now rewrite singleSubstComm'.
-  unshelve eapply natElimRedEq; tea; fold subst_term.
-  6-11: irrelevance; now rewrite elimSuccHypTy_subst.
-  3,4: rewrite elimSuccHypTy_subst; eapply validTy; tea; eapply elimSuccHypTyValid.
-  + intros m Rm.
-    rewrite up_single_subst. 
-    unshelve eapply validTy; cycle 1; tea.
-    unshelve econstructor; [now bsimpl| now cbn].
-  + intros m Rm.
-    rewrite up_single_subst. 
-    unshelve eapply validTy; cycle 1; tea.
-    unshelve econstructor; [now bsimpl| now cbn].
-  + intros m m' Rm Rm' Rmm'; cbn.
-    irrelevance0. 1: now rewrite up_single_subst.
-    rewrite up_single_subst.
-    eapply transEq; cycle 1.
-    - unshelve eapply validTyEq. 
-      7: tea. 1: tea.
-      unshelve econstructor; [now bsimpl| now cbn].
-    - unshelve eapply validTyExt; cycle 1 ; tea.
-    1,2: unshelve econstructor; [now bsimpl| now cbn].
-    unshelve econstructor; [|now cbn].
-    bsimpl. eapply reflSubst.
-Qed.
-
-Lemma elimSuccHypTyCongValid {Γ l P P'}
-    (VΓ : [||-v Γ])
-    (VN := natValid (l:=l) VΓ)
-    (VΓN := validSnoc VΓ VN)
-    (VP : [Γ ,, tNat ||-v<l> P | VΓN])
-    (VP' : [Γ ,, tNat ||-v<l> P' | VΓN])
-    (VeqP : [Γ ,, tNat ||-v<l> P ≅ P' | VΓN | VP]) :
-    [Γ ||-v<l> elimSuccHypTy P ≅ elimSuccHypTy P' | VΓ | elimSuccHypTyValid VΓ VP].
-  Proof.
-    unfold elimSuccHypTy.
+    unfold elimSuccHypTy.  pose proof (ureflValidTy VeqP).
     eapply irrelevanceTyEq.
     assert [Γ,, tNat ||-v< l > P'[tSucc (tRel 0)]⇑ | validSnoc VΓ VN]. 1:{
       eapply substLiftS; tea.
@@ -566,5 +260,107 @@ Lemma elimSuccHypTyCongValid {Γ l P P'}
     1,2 : tea.
     now bsimpl.
   Qed.
+
+
+
+  Context { P P' hz hz' hs hs'}
+    (VP : [Γ ,, tNat ||-v<l> P | VΓN])
+    (VPP' : [Γ ,, tNat ||-v<l> P ≅ P' | VΓN | VP ])
+    (VP' := ureflValidTy VPP')
+    (VPz := substS VP (zeroValid VΓ))
+    (Vhz : [Γ ||-v<l> hz ≅ hz' : P[tZero..] | VΓ | VPz])
+    (Vhs : [Γ ||-v<l> hs ≅ hs' : _ | VΓ | elimSuccHypTyValid VP]).
+
+  (* Lemma elimSuccHypTyCongValid ? *)
+
+  Lemma natElimCongValid {n n'}
+    (Vn : [Γ ||-v<l> n ≅ n' : tNat | VΓ | VN])
+    (VPn := substS VP Vn)
+    : [Γ ||-v<l> tNatElim P hz hs n ≅ tNatElim P' hz' hs' n' : _ | VΓ | VPn].
+  Proof.
+    pose proof (elimSuccHypTyValid VP).
+    pose proof (elimSuccHypTyValid VP').
+    pose proof (elimSuccHypTyCongValid VP VPP').
+    constructor; intros; instValid Vσσ'; epose proof (Vuσ := liftSubstEq' VN Vσσ').
+    instValid Vuσ; cbn -[elimSuccHypTy elimSuccHypTyValid] in *; escape.
+    irrelevance0. 1: now rewrite singleSubstComm'.
+    eapply natElimRedEq; rewrite ?elimSuccHypTy_subst; tea.
+    + intros; irrelevance0; rewrite up_single_subst; [reflexivity|].
+      unshelve eapply validTyEq; cycle 1 ; tea.
+      now unshelve eapply consSubstEq.
+    + irrelevance0; [exact (singleSubstComm' _ tZero σ)|]; tea.
+    + irrelevance0; [now rewrite elimSuccHypTy_subst|]; tea.
+    + irrelevance0; [now rewrite elimSuccHypTy_subst|]; tea.
+    Unshelve.
+      2,3: tea.
+      2: now rewrite elimSuccHypTy_subst.
+      intros ?? Rn; rewrite up_single_subst.
+      unshelve eapply validTy.
+      5: tea.
+      3: unshelve eapply consSubstEq; tea.
+  Qed.
+End NatElimValid.
+
+Lemma natElimValid {Γ l P hz hz' hs hs' n n'}
+    (VΓ : [||-v Γ])
+    (VN := natValid (l:=l) VΓ)
+    (VΓN := validSnoc VΓ VN)
+    (VP : [Γ ,, tNat ||-v<l> P | VΓN])
+    (VPz := substS VP (zeroValid VΓ))
+    (Vhz : [Γ ||-v<l> hz ≅ hz' : P[tZero..] | VΓ | VPz])
+    (Vhs : [Γ ||-v<l> hs ≅ hs' : _ | VΓ | elimSuccHypTyValid VΓ VP])
+    (Vn : [Γ ||-v<l> n ≅ n' : _ | VΓ | VN])
+    (VPn := substS VP Vn):
+    [Γ ||-v<l> tNatElim P hz hs n : _ | VΓ | VPn].
+Proof.
+  eapply lreflValidTm , natElimCongValid; tea.
+  now eapply reflValidTy.
+Qed.
+
+Section NatElimRedValid.
+  Context {Γ l}
+    (VΓ : [||-v Γ])
+    (VN := natValid (l:=l) VΓ)
+    (VΓN := validSnoc VΓ VN)
+    { P P' hz hz' hs hs'}
+    (VP : [Γ ,, tNat ||-v<l> P | VΓN])
+    (VPP' : [Γ ,, tNat ||-v<l> P ≅ P' | VΓN | VP ])
+    (VP' := ureflValidTy VPP')
+    (VPz := substS VP (zeroValid VΓ))
+    (Vhz : [Γ ||-v<l> hz ≅ hz' : P[tZero..] | VΓ | VPz])
+    (Vhs : [Γ ||-v<l> hs ≅ hs' : _ | VΓ | elimSuccHypTyValid VΓ VP]).
+
+  Lemma natElimZeroValid  :
+    [Γ ||-v<l> tNatElim P hz hs tZero ≅ hz : _ | VΓ | VPz].
+  Proof.
+    eapply redSubstValid. 2: now eapply lreflValidTm.
+    constructor; intros; cbn; rewrite singleSubstComm'.
+    instValid Vσσ'; instValid (liftSubstEq' VN Vσσ'); escape.
+    eapply redtm_natElimZero; tea.
+    + now rewrite <- (singleSubstComm' _ tZero σ).
+    + now rewrite elimSuccHypTy_subst.
+  Qed.
+
+  Lemma natElimSuccValid {n}
+    (Vn : [Γ ||-v<l> n : tNat | VΓ | VN])
+    (VPSn := substS VP (succValid _ Vn)) :
+    [Γ ||-v<l> tNatElim P hz hs (tSucc n) ≅ tApp (tApp hs n) (tNatElim P hz hs n) : _ | VΓ | VPSn].
+  Proof.
+    eapply redSubstValid.
+    * constructor; intros; rewrite singleSubstComm'.
+      instValid Vσσ'; instValid (liftSubstEq' VN Vσσ'); escape.
+      eapply redtm_natElimSucc; tea; refold.
+      + now rewrite <- (singleSubstComm' _ tZero σ).
+      + now rewrite elimSuccHypTy_subst.
+    * eapply simple_appValid.
+      2: now unshelve (eapply natElimValid; tea).
+      eapply irrelevanceTm'; [| exact (appValid (lreflValidTm _ Vhs) Vn)].
+      clear; now bsimpl.
+      Unshelve.
+        eapply simpleArrValid; eapply substS; tea.
+        now eapply succValid.
+  Qed.
+
+End NatElimRedValid.
 
 End Nat.

--- a/theories/Substitution/Introductions/Pi.v
+++ b/theories/Substitution/Introductions/Pi.v
@@ -119,15 +119,10 @@ Section PiTyDomValidity.
     unshelve econstructor.
     - intros Δ vΔ σ σ' [vσ v0]; instValid vσ; cbn in *.
       rewrite eq_subst_eta; eapply singleSubstΠ1; tea.
-      now eapply lrefl.
     - cbn; refold.
       intros Δ vΔ σ σ' [vσσ' v00']; instValid vσσ'; instValid (urefl vσσ'); cbn in *.
       pose proof (polyRedEqId _ (normEqRedΠ _ REvΠFG)) as [? _].
       rewrite 2!eq_subst_eta; eapply singleSubstΠ2; tea.
-      eapply singleSubstΠ1; tea.
-      eapply urefl, LRTmEqConv; [|tea].
-      irrelevance.
-      Unshelve. 2: now eapply LRTyEqRedRight.
     Qed.
 
 End PiTyDomValidity.
@@ -225,7 +220,7 @@ Section PiTmValidity.
 
   Lemma PiValidU : [ Γ ||-v< one > tProd F G : U | VΓ | UValid VΓ ].
   Proof.
-    eapply lreflValidTm, PiCongTm; tea; now eapply reflValidTm.
+    now eapply lreflValidTm, PiCongTm.
   Qed.
 
 End PiTmValidity.

--- a/theories/Substitution/Introductions/Pi.v
+++ b/theories/Substitution/Introductions/Pi.v
@@ -2,21 +2,12 @@ From Coq Require Import ssrbool.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening
   GenericTyping LogicalRelation Validity.
-From LogRel.LogicalRelation Require Import Escape Reflexivity Neutral Weakening Irrelevance.
-From LogRel.Substitution Require Import Irrelevance Properties.
+From LogRel.LogicalRelation Require Import Escape Reflexivity Neutral Weakening Irrelevance Induction NormalRed EqRedRight.
+From LogRel.Substitution Require Import Irrelevance Properties SingleSubst Reflexivity.
 From LogRel.Substitution.Introductions Require Import Universe Poly.
 
 Set Universe Polymorphism.
 
-(* Lemma eq_subst_1 F G Δ σ : G[up_term_term σ] = G[tRel 0 .: σ⟨ @wk1 Δ F[σ] ⟩].
-Proof.
-  now bsimpl.
-Qed.
-
-Lemma eq_subst_2 G a ρ σ : G[up_term_term σ][a .: ρ >> tRel] = G[a .: σ⟨ρ⟩].
-Proof.
-  bsimpl ; now substify.
-Qed. *)
 
 Section PolyRedPi.
   Context `{GenericTypingProperties}.
@@ -56,7 +47,7 @@ Section PolyRedPi.
   Proof.
     intros; irrelevanceRefl; now eapply LRPiPolyEq.
   Qed.
-  
+
 End PolyRedPi.
 
 
@@ -67,40 +58,39 @@ Section PiTyValidity.
     (vF : [Γ ||-v< l > F | vΓ ])
     (vG : [Γ ,, F ||-v< l > G | validSnoc vΓ vF]).
 
-  Lemma PiRed {Δ σ} (tΔ : [ |-[ ta ] Δ])
-    (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
+  Lemma PiRed {Δ σ σ'} (tΔ : [ |-[ ta ] Δ])
+    (vσ : [vΓ | Δ ||-v σ ≅ σ' : _ | tΔ])
     : [ Δ ||-< l > (tProd F G)[σ] ].
   Proof.
     eapply LRPi'.
-    pose (p := substPolyRed vΓ vF vG _ vσ).
+    pose (p := substPolyRed vΓ vF vG _ (lrefl vσ)).
     escape; cbn; econstructor; tea;
     destruct (polyRedId p);
-    destruct (polyRedEqId p (substPolyRedEq vΓ vF vG _ vσ vσ (reflSubst _ _ vσ))); escape.
+    destruct (polyRedEqId p (substPolyRedEq vΓ vF vG _ (lrefl vσ) p)); escape.
     - apply redtywf_refl; gen_typing.
     - gen_typing.
     - gen_typing.
   Defined.
 
   Lemma PiEqRed1 {Δ σ σ'} (tΔ : [ |-[ ta ] Δ])
-    (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    (vσ' : [vΓ | Δ ||-v σ' : _ | tΔ])
-    (vσσ' : [vΓ | Δ ||-v σ ≅ σ' : _ | tΔ | vσ])
-    : [ Δ ||-< l > (tProd F G)[σ] ≅ (tProd F G)[σ'] | PiRed tΔ vσ ].
+    (vσσ' : [vΓ | Δ ||-v σ ≅ σ' : _ | tΔ ])
+    : [ Δ ||-< l > (tProd F G)[σ] ≅ (tProd F G)[σ'] | PiRed tΔ vσσ' ].
   Proof.
-    pose (p := substPolyRed vΓ vF vG _ vσ).
-    pose (p' := substPolyRed vΓ vF vG _ vσ').
-    pose (peq := substPolyRedEq vΓ vF vG _ vσ vσ' vσσ').
-    destruct (polyRedId p); destruct (polyRedId p'); destruct (polyRedEqId p peq).
+    pose (p := substPolyRed vΓ vF vG _ vσσ').
+    pose (p' := substPolyRed vΓ vF vG _ (urefl vσσ')).
+    pose (peq := substPolyRedEq vΓ vF vG _ vσσ' p).
+    destruct (polyRedId p), (polyRedId p'), (polyRedEqId p peq).
     escape; econstructor; cbn; tea.
     - apply redtywf_refl; gen_typing.
     - gen_typing.
+    - now eapply substPolyRedEq.
   Defined.
 
   Lemma PiValid : [Γ ||-v< l > tProd F G | vΓ].
   Proof.
     unshelve econstructor.
-    - intros Δ σ. eapply PiRed.
-    - intros Δ σ σ'. eapply PiEqRed1.
+    - intros; now eapply PiRed.
+    - intros; eapply PiEqRed1.
   Defined.
 
 End PiTyValidity.
@@ -114,91 +104,31 @@ Section PiTyDomValidity.
   Lemma PiValidDom : [Γ ||-v< l > F | vΓ].
   Proof.
   unshelve econstructor.
-  - intros Δ σ vΔ vσ; instValid vσ.
-    cbn in RvΠFG; apply Induction.invLRΠ in RvΠFG.
-    destruct RvΠFG as [dom ? red ? ? ? [? ? Hdom]].
-    assert (Hrw : F[σ] = dom); [|subst dom].
-    { eapply redtywf_whnf in red as [=]; [tea|constructor]. }
-    rewrite <- (wk_id_ren_on Δ F[σ]).
-    now eapply Hdom.
-  - cbn; refold.
-    intros Δ σ σ' vΔ vσ vσ' vσσ'.
-    match goal with |- [ LRAd.pack ?P | _ ||- _ ≅ _] => set (vF := P); clearbody vF end.
-    instValid vσ.
-    cbn in RvΠFG; apply Induction.invLRΠ in RvΠFG.
-    assert (vΠ := validTyExt vΠFG _ vσ vσ' vσσ').
-    eapply LRTyEqIrrelevant' with (lrA' := LRPi' RvΠFG) in vΠ; [|reflexivity].
-    destruct RvΠFG as [dom ? red ? ? ? []].
-    destruct vΠ as [dom' ? red' ? ? [Heq _]]; simpl in *.
-    specialize (Heq Δ wk_id vΔ).
-    assert (Hrw : F[σ] = dom).
-    { eapply redtywf_whnf in red as [=]; [tea|constructor]. }
-    assert (Hrw' : F[σ'] = dom').
-    { eapply redtywf_whnf in red' as [=]; [tea|constructor]. }
-    rewrite wk_id_ren_on, <- Hrw' in Heq.
-    eapply Transitivity.transEq; [|eapply Heq].
-    rewrite <- (wk_id_ren_on Δ dom) in Hrw; rewrite <- Hrw.
-    eapply LRTyEqIrrelevant' with (lrA := vF); [reflexivity|].
-    eapply reflLRTyEq.
+  - intros Δ vΔ σ σ' vσ; instValid vσ.
+    now pose proof (polyRedId (normRedΠ0 (invLRΠ RvΠFG))) as [].
+  - intros Δ vΔ σ σ' vσσ'; instValid vσσ'.
+    pose proof (polyRedEqId _ (normEqRedΠ _ REvΠFG)) as [? _].
+    irrelevance.
   Qed.
+
+  Lemma eq_subst_eta A σ : A[σ] = A[up_term_term (↑ >> σ)][(σ var_zero)..].
+  Proof. bsimpl; now rewrite scons_eta'. Qed.
 
   Lemma PiValidCod : [Γ,, F ||-v< l > G | validSnoc vΓ PiValidDom].
   Proof.
-  unshelve econstructor.
-  - intros Δ σ vΔ [vσ v0].
-    instValid vσ; cbn in *.
-    apply Induction.invLRΠ in RvΠFG.
-    destruct RvΠFG as [dom cod red ? ? ? [? ? Hdom Hcod _]].
-    specialize (Hcod Δ (σ 0) wk_id vΔ).
-    assert (HF : F[↑ >> σ] = dom).
-    { eapply redtywf_whnf in red as [=]; [tea|constructor]. }
-    assert (HG0 : G[up_term_term (↑ >> σ)] = cod).
-    { eapply redtywf_whnf in red as [=]; [tea|constructor]. }
-    assert (HG : G[σ] = cod[σ 0 .: @wk_id Δ >> tRel]).
-    { rewrite <- HG0; bsimpl; apply ext_term; intros []; reflexivity. }
-    rewrite HG; apply Hcod.
-    irrelevance0; [|eapply v0].
-    now rewrite wk_id_ren_on.
-  - cbn; refold.
-    intros Δ σ σ' vΔ [vσ v0] [vσ' v0'] [vσσ' v00'].
-    match goal with |- [ LRAd.pack ?P | _ ||- _ ≅ _] => set (vG := P); clearbody vG end.
-    instValid vσ.
-    cbn in RvΠFG; apply Induction.invLRΠ in RvΠFG.
-    assert (vΠ := validTyExt vΠFG _ vσ vσ' vσσ').
-    eapply LRTyEqIrrelevant' with (lrA' := LRPi' RvΠFG) in vΠ; [|reflexivity].
-    destruct RvΠFG as [dom cod red ? ? ? [? ? ? ? Hcod]].
-    destruct vΠ as [dom' cod' red' ? ? [Hdom' Hcod']]; simpl in *.
-    specialize (Hcod' Δ (σ' 0) wk_id vΔ).
-    assert (HF : F[↑ >> σ] = dom).
-    { eapply redtywf_whnf in red as [=]; [tea|constructor]. }
-    assert (HF' : F[↑ >> σ'] = dom').
-    { eapply redtywf_whnf in red' as [=]; [tea|constructor]. }
-    assert (HG0 : G[up_term_term (↑ >> σ)] = cod).
-    { eapply redtywf_whnf in red as [=]; [tea|constructor]. }
-    assert (HG : G[σ] = cod[σ 0 .: @wk_id Δ >> tRel]).
-    { rewrite <- HG0; bsimpl; apply ext_term; intros []; reflexivity. }
-    assert (HG0' : G[up_term_term (↑ >> σ')] = cod').
-    { eapply redtywf_whnf in red' as [=]; [tea|constructor]. }
-    assert (HG' : G[σ'] = cod'[σ' 0 .: @wk_id Δ >> tRel]).
-    { rewrite <- HG0'; bsimpl; apply ext_term; intros []; reflexivity. }
-    rewrite HG'.
-    assert (Hσ0 : [shpRed Δ wk_id vΔ | _ ||- σ 0 : _]).
-    { irrelevance0; [|eapply v0].
-      now rewrite wk_id_ren_on. }
-    assert (Hσ0' : [shpRed Δ wk_id vΔ | _ ||- σ' 0 : _]).
-    { eapply LRTmRedConv; [|eapply v0'].
-      eapply LRTyEqSym; rewrite HF'.
-      rewrite <- (wk_id_ren_on Δ dom').
-      apply (Hdom' _ _ vΔ). }
-    eassert (Hcod0 := Hcod Δ (σ 0) (σ' 0) wk_id vΔ Hσ0 Hσ0').
-    eapply Transitivity.transEq; [|now unshelve eapply Hcod'].
-    eapply Transitivity.transEq; [|unshelve eapply Hcod0].
-    + unshelve (irrelevance0; [|eapply reflLRTyEq]); try now symmetry.
-      shelve.
-      now eauto.
-    + irrelevance0; [|eapply v00'].
-      now rewrite wk_id_ren_on.
-  Qed.
+    unshelve econstructor.
+    - intros Δ vΔ σ σ' [vσ v0]; instValid vσ; cbn in *.
+      rewrite eq_subst_eta; eapply singleSubstΠ1; tea.
+      now eapply lrefl.
+    - cbn; refold.
+      intros Δ vΔ σ σ' [vσσ' v00']; instValid vσσ'; instValid (urefl vσσ'); cbn in *.
+      pose proof (polyRedEqId _ (normEqRedΠ _ REvΠFG)) as [? _].
+      rewrite 2!eq_subst_eta; eapply singleSubstΠ2; tea.
+      eapply singleSubstΠ1; tea.
+      eapply urefl, LRTmEqConv; [|tea].
+      irrelevance.
+      Unshelve. 2: now eapply LRTyEqRedRight.
+    Qed.
 
 End PiTyDomValidity.
 
@@ -214,12 +144,12 @@ Section PiTyCongruence.
     (vFF' : [ Γ ||-v< l > F ≅ F' | vΓ | vF ])
     (vGG' : [ Γ ,, F ||-v< l > G ≅ G' | validSnoc vΓ vF | vG ]).
 
-  Lemma PiEqRed2 {Δ σ} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ||-< l > (tProd F G)[σ] ≅ (tProd F' G')[σ] | validTy (PiValid vΓ vF vG) tΔ vσ ].
+  Lemma PiEqRed2 {Δ σ σ'} (tΔ : [ |-[ ta ] Δ]) (vσ : [vΓ | Δ ||-v σ ≅ σ' : _ | tΔ])
+    : [ Δ ||-< l > (tProd F G)[σ] ≅ (tProd F' G')[σ'] | validTy (PiValid vΓ vF vG) tΔ vσ ].
   Proof.
-    pose (p := substPolyRed vΓ vF vG _ vσ).
-    pose (p' := substPolyRed vΓ vF' vG' _ vσ).
-    pose (peq := substEqPolyRedEq vΓ vF vG _ vσ vF' vG' vFF' vGG').
+    pose (p := substPolyRed vΓ vF vG _ (lrefl vσ)).
+    pose (p' := substPolyRed vΓ vF' vG' _ (urefl vσ)).
+    pose (peq := substEqPolyRedEq vΓ vF vG _ vσ vF' vG' vFF' vGG' p).
     destruct (polyRedId p); destruct (polyRedId p'); destruct (polyRedEqId p peq).
     escape; econstructor; cbn; tea.
     - apply redtywf_refl; gen_typing.
@@ -228,72 +158,11 @@ Section PiTyCongruence.
 
   Lemma PiCong : [ Γ ||-v< l > tProd F G ≅ tProd F' G' | vΓ | PiValid vΓ vF vG ].
   Proof.
-    econstructor. intros Δ σ. eapply PiEqRed2.
+    econstructor. intros *; eapply PiEqRed2.
   Qed.
 
 End PiTyCongruence.
 
-
-Section PiTmValidity.
-
-  Context `{GenericTypingProperties}.
-  Context {Γ F G} (VΓ : [||-v Γ])
-    (VF : [ Γ ||-v< one > F | VΓ ])
-    (VU : [ Γ ,, F ||-v< one > U | validSnoc VΓ VF ])
-    (VFU : [ Γ ||-v< one > F : U | VΓ | UValid VΓ ])
-    (VGU : [ Γ ,, F ||-v< one > G : U | validSnoc VΓ VF | VU ]) .
-    (* (VF := univValid (l':=zero) _ _ vFU)
-    (VG := univValid (l':=zero) _ _ vGU). *)
-
-  Lemma prodTyEqU {Δ σ σ'} (tΔ : [ |-[ ta ] Δ])
-    (Vσ : [VΓ | Δ ||-v σ : _ | tΔ])
-    (Vσ' : [VΓ | Δ ||-v σ' : _ | tΔ])
-    (Vσσ' : [VΓ | Δ ||-v σ ≅ σ' : _ | tΔ | Vσ ])
-    : [Δ |-[ ta ] tProd F[σ] G[up_term_term σ] ≅ tProd F[σ'] G[up_term_term σ'] : U].
-  Proof.
-    pose proof (Vuσ := liftSubstS' VF Vσ).
-    pose proof (Vureaσ' := liftSubstSrealign' VF Vσσ' Vσ').
-    pose proof (Vuσσ' := liftSubstSEq' VF Vσσ').
-    instAllValid Vσ Vσ' Vσσ'; instAllValid Vuσ Vureaσ' Vuσσ'; escape.
-    eapply convtm_prod; tea.
-  Qed.
-
-  Lemma PiRedU {Δ σ} (tΔ : [ |-[ ta ] Δ]) (Vσ : [VΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ||-< one > (tProd F G)[σ] : U | validTy (UValid VΓ) tΔ Vσ ].
-  Proof.
-    pose proof (Vσσ := reflSubst _ _ Vσ).
-    pose proof (Vuσ := liftSubstS' VF Vσ).
-    pose proof (Vuσσ := liftSubstSEq' VF Vσσ).
-    instAllValid Vσ Vσ Vσσ; instAllValid Vuσ Vuσ Vuσσ; escape.
-    econstructor; cbn.
-    - apply redtmwf_refl; cbn in *; now eapply ty_prod.
-    - constructor.
-    - now eapply convtm_prod.
-    - cbn. unshelve refine (LRCumulative (PiRed _ _ _ tΔ Vσ));
-      unshelve eapply univValid; tea; try irrValid.
-  Defined.
-
-  Lemma PiValidU : [ Γ ||-v< one > tProd F G : U | VΓ | UValid VΓ ].
-  Proof.
-    econstructor.
-    - intros Δ σ tΔ Vσ.
-      exact (PiRedU tΔ Vσ).
-    - intros Δ σ σ' tΔ Vσ Vσ' Vσσ'.
-      pose proof (univValid (l' := zero) _ _ VFU) as VF0.
-      pose proof (irrelevanceTy (validSnoc VΓ VF)
-                    (validSnoc (l := zero) VΓ VF0)
-                    (univValid (l' := zero) _ _ VGU)) as VG0.
-      unshelve econstructor ; cbn.
-      + exact (PiRedU tΔ Vσ).
-      + exact (PiRedU tΔ Vσ').
-      + exact (LRCumulative (PiRed VΓ VF0 VG0 tΔ Vσ)).
-      + exact (prodTyEqU tΔ Vσ Vσ' Vσσ').
-      + exact (LRCumulative (PiRed VΓ VF0 VG0 tΔ Vσ')).
-      + pose proof (PiEqRed1 VΓ VF0 VG0 tΔ Vσ Vσ' Vσσ').
-        irrelevanceCum.
-  Qed.
-
-End PiTmValidity.
 
 
 Section PiTmCongruence.
@@ -315,13 +184,13 @@ Section PiTmCongruence.
   Lemma PiCongTm : [ Γ ||-v< one > tProd F G ≅ tProd F' G' : U | vΓ | UValid vΓ ].
   Proof.
     econstructor.
-    intros Δ σ tΔ Vσ.
+    intros Δ tΔ σ σ' Vσσ'.
     pose proof (univValid (l' := zero) _ _ vFU) as vF0.
     pose proof (univValid (l' := zero) _ _ vF'U) as vF'0.
-    pose proof (Vσσ := reflSubst _ _ Vσ).
-    pose proof (Vuσ := liftSubstS' vF Vσ).
-    pose proof (Vuσσ := liftSubstSEq' vF Vσσ).
-    instAllValid Vσ Vσ Vσσ; instAllValid Vuσ Vuσ Vuσσ; escape.
+    pose proof (Vuσ := liftSubstEq' vF Vσσ').
+    (* pose proof (Vuσ' := liftSubstEq' vF (urefl Vσσ')). *)
+    pose proof (Vuσ' := liftSubstEq' vF' (urefl Vσσ')).
+    instValid Vσσ'; instValid (urefl Vσσ'); instValid Vuσ ; instValid Vuσ'; escape.
     pose proof (irrelevanceTy (validSnoc vΓ vF)
                   (validSnoc (l := zero) vΓ vF0)
                   (univValid (l' := zero) _ _ vGU)) as vG0.
@@ -329,13 +198,14 @@ Section PiTmCongruence.
                   (validSnoc (l := zero) vΓ vF'0)
                   (univValid (l' := zero) _ _ vG'U)) as vG'0.
     unshelve econstructor ; cbn.
-    - exact (PiRedU vΓ vF vU vFU vGU tΔ Vσ).
-    - exact (PiRedU vΓ vF' vU' vF'U vG'U tΔ Vσ).
-    - exact (LRCumulative (PiRed vΓ vF0 vG0 tΔ Vσ)).
+    1,2: econstructor; [apply redtmwf_refl; cbn; now eapply ty_prod| constructor].
+    - unshelve refine (LRCumulative (PiRed _ _ _ tΔ Vσσ')).
+      all: unshelve eapply univValid; tea; try irrValid.
     - now eapply convtm_prod.
-    - exact (LRCumulative (PiRed vΓ vF'0 vG'0 tΔ Vσ)).
-    - enough ([ Δ ||-< zero > (tProd F G)[σ] ≅ (tProd F' G')[σ] | PiRed vΓ vF0 vG0 tΔ Vσ]) by irrelevanceCum.
-      refine (PiEqRed2 vΓ vF0 vG0 vF'0 vG'0 _ _ tΔ Vσ).
+    - unshelve refine (LRCumulative (PiRed _ _ _ tΔ (urefl Vσσ'))).
+      all: unshelve eapply univValid; tea; try irrValid.
+    - enough ([ Δ ||-< zero > (tProd F G)[σ] ≅ (tProd F' G')[σ'] | PiRed vΓ vF0 vG0 tΔ Vσσ']) by irrelevanceCum.
+      refine (PiEqRed2 vΓ vF0 vG0 vF'0 vG'0 _ _ tΔ Vσσ').
       + exact (univEqValid vΓ (UValid vΓ) vF0 vFF').
       + pose proof (univEqValid (validSnoc vΓ vF) vU (univValid (l' := zero) _ _ vGU) vGG') as vGG'0.
         refine (irrelevanceTyEq _ _ _ _ vGG'0).
@@ -343,3 +213,19 @@ Section PiTmCongruence.
 
 End PiTmCongruence.
 
+
+Section PiTmValidity.
+
+  Context `{GenericTypingProperties}.
+  Context {Γ F G} (VΓ : [||-v Γ])
+    (VF : [ Γ ||-v< one > F | VΓ ])
+    (VU : [ Γ ,, F ||-v< one > U | validSnoc VΓ VF ])
+    (VFU : [ Γ ||-v< one > F : U | VΓ | UValid VΓ ])
+    (VGU : [ Γ ,, F ||-v< one > G : U | validSnoc VΓ VF | VU ]) .
+
+  Lemma PiValidU : [ Γ ||-v< one > tProd F G : U | VΓ | UValid VΓ ].
+  Proof.
+    eapply lreflValidTm, PiCongTm; tea; now eapply reflValidTm.
+  Qed.
+
+End PiTmValidity.

--- a/theories/Substitution/Introductions/Poly.v
+++ b/theories/Substitution/Introductions/Poly.v
@@ -2,8 +2,8 @@ From Coq Require Import ssrbool.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening
   GenericTyping LogicalRelation Validity.
-From LogRel.LogicalRelation Require Import Escape Reflexivity Neutral Weakening Irrelevance.
-From LogRel.Substitution Require Import Irrelevance Properties.
+From LogRel.LogicalRelation Require Import Escape Reflexivity Neutral Weakening Irrelevance Transitivity.
+From LogRel.Substitution Require Import Irrelevance Properties Reflexivity.
 From LogRel.Substitution.Introductions Require Import Universe.
 
 Set Universe Polymorphism.
@@ -21,6 +21,12 @@ Qed.
 Lemma subst_wk_id_tail Γ P t : P[t .: @wk_id Γ >> tRel] = P[t..].
 Proof. setoid_rewrite id_ren; now bsimpl. Qed.
 
+(* Also used in EqRedRight *)
+Lemma eq_id_subst_scons {Γ A} B : B = B[tRel 0 .: @wk1 Γ A >> tRel].
+Proof.
+  clear; bsimpl; rewrite scons_eta'; now bsimpl.
+Qed.
+
 
 Set Printing Primitive Projection Parameters.
 
@@ -29,27 +35,24 @@ Section PolyValidity.
   Context `{GenericTypingProperties}.
 
   Lemma mkPolyRed {Γ l A B} (wfΓ : [|-Γ])
-    (RA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]), [Δ ||-<l> A⟨ρ⟩]) 
-    (RB : forall Δ a (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]), [Δ ||-<l> a : _ | RA Δ ρ wfΔ] -> [Δ ||-<l> B[a .: ρ >> tRel]])
-    (RBext : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (Ra : [Δ ||-<l> a : _ | RA Δ ρ wfΔ]),
-      [Δ ||-<l> b : _ | RA Δ ρ wfΔ] ->
-      [Δ ||-<l> a ≅ b : _ | RA Δ ρ wfΔ] -> [Δ ||-<l> B[a .: ρ >> tRel] ≅ B[b .: ρ >> tRel] | RB Δ a ρ wfΔ Ra]) :
+    (RA : forall Δ (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]), [Δ ||-<l> A⟨ρ⟩])
+    (RB : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]), [Δ ||-<l> a ≅ b : _ | RA Δ ρ wfΔ] -> [Δ ||-<l> B[a .: ρ >> tRel]])
+    (RBext : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (Rab : [Δ ||-<l> a ≅ b : _ | RA Δ ρ wfΔ]),
+      [Δ ||-<l> B[a .: ρ >> tRel] ≅ B[b .: ρ >> tRel] | RB Δ a b ρ wfΔ Rab]) :
     PolyRed Γ l A B.
   Proof.
     assert [Γ |- A] by (eapply escape; now eapply instKripke).
     unshelve econstructor; tea.
-    unshelve epose proof (RB _ (tRel 0) (@wk1 Γ A) _ _).
+    unshelve epose proof (h := RB _ (tRel 0) (tRel 0) (@wk1 Γ A) _ _).
     + gen_typing.
     + eapply var0; tea; now rewrite wk1_ren_on.
-    + enough (B = B[tRel 0 .: @wk1 Γ A >> tRel]) as -> by now escape.
-      setoid_rewrite wk1_ren; rewrite scons_eta'; now asimpl.
+    + escape. now rewrite <- eq_id_subst_scons in Esch.
   Qed.
 
-  Lemma mkPolyRed' {Γ l A B} (RA : [Γ ||-<l> A]) 
-    (RB : forall Δ a (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]), [Δ ||-<l> a : _ | wk ρ wfΔ RA] -> [Δ ||-<l> B[a .: ρ >> tRel]])
-    (RBext : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (Ra : [Δ ||-<l> a : _ | wk ρ wfΔ RA]),
-      [Δ ||-<l> b : _ | wk ρ wfΔ RA] ->
-      [Δ ||-<l> a ≅ b : _ | wk ρ wfΔ RA] -> [Δ ||-<l> B[a .: ρ >> tRel] ≅ B[b .: ρ >> tRel] | RB Δ a ρ wfΔ Ra]) :
+  Lemma mkPolyRed' {Γ l A B} (RA : [Γ ||-<l> A])
+    (RB : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]), [Δ ||-<l> a ≅ b : _ | wk ρ wfΔ RA] -> [Δ ||-<l> B[a .: ρ >> tRel]])
+    (RBext : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|- Δ]) (Rab : [Δ ||-<l> a ≅ b : _ | wk ρ wfΔ RA]),
+      [Δ ||-<l> B[a .: ρ >> tRel] ≅ B[b .: ρ >> tRel] | RB Δ a b ρ wfΔ Rab]) :
     PolyRed Γ l A B.
   Proof.
     unshelve eapply mkPolyRed; tea.
@@ -57,10 +60,10 @@ Section PolyValidity.
   Qed.
 
 
-  Lemma polyCodSubstRed {Γ l F G} (RF : [Γ ||-<l> F]) : 
+  Lemma polyCodSubstRed {Γ l F G} (RF : [Γ ||-<l> F]) :
     PolyRed Γ l F G -> forall t, [Γ ||-<l> t : _ | RF] -> [Γ ||-<l> G[t..]].
   Proof.
-    intros PFG ??. 
+    intros PFG ??.
     escape. assert (wfΓ : [|- Γ]) by gen_typing.
     erewrite <- subst_wk_id_tail.
     eapply (PolyRed.posRed PFG wk_id wfΓ).
@@ -68,13 +71,13 @@ Section PolyValidity.
   Qed.
 
   Lemma polyCodSubstExtRed {Γ l F G} (RF : [Γ ||-<l> F]) (PFG : PolyRed Γ l F G) (RG := polyCodSubstRed RF PFG) :
-    forall t u (Rt : [Γ ||-<l> t : _ | RF]), [Γ ||-<l> u : _ | RF] -> [Γ ||-<l> t ≅ u : _ | RF] -> 
+    forall t u (Rt : [Γ ||-<l> t : _ | RF]), [Γ ||-<l> u : _ | RF] -> [Γ ||-<l> t ≅ u : _ | RF] ->
     [Γ ||-<l> G[t..] ≅ G[u..]| RG t Rt].
   Proof.
     intros. escape. assert (wfΓ : [|- Γ]) by gen_typing.
     irrelevance0; erewrite <- subst_wk_id_tail; [reflexivity|].
     unshelve eapply (PolyRed.posExt PFG wk_id wfΓ); irrelevance.
-  Qed.  
+  Qed.
 
 
   Lemma polyRedId {Γ l F G} : PolyRed Γ l F G -> [Γ ||-<l> F] × [Γ ,, F ||-<l> G].
@@ -99,15 +102,15 @@ Section PolyValidity.
       irrelevance0.
       2: eapply RGG'.
       bsimpl; rewrite scons_eta'; now asimpl.
-      Unshelve. 1: gen_typing.
-      eapply var0; tea; now bsimpl.
+      Unshelve. 2: gen_typing.
+      2: eapply var0; tea; now bsimpl.
   Qed.
 
-  Lemma polyRedSubst {Γ l A B t} (PAB : PolyRed Γ l A B) 
-    (Rt : forall Δ a (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), 
-      [Δ ||-<l> a : _ | PolyRed.shpRed PAB ρ wfΔ] ->
+  Lemma polyRedSubst {Γ l A B t} (PAB : PolyRed Γ l A B)
+    (Rt : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]),
+      [Δ ||-<l> a ≅ b : _ | PolyRed.shpRed PAB ρ wfΔ] ->
       [Δ ||-<l> t[a .: ρ >> tRel] : _ | PolyRed.shpRed PAB ρ wfΔ ])
-    (Rtext : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), 
+    (Rtext : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]),
       [Δ ||-<l> a : _ | PolyRed.shpRed PAB ρ wfΔ] ->
       [Δ ||-<l> b : _ | PolyRed.shpRed PAB ρ wfΔ] ->
       [Δ ||-<l> a ≅ b : _ | PolyRed.shpRed PAB ρ wfΔ] ->
@@ -116,30 +119,25 @@ Section PolyValidity.
   Proof.
     destruct PAB; opector; tea.
     + intros; rewrite liftSubst_scons_eq.
-      unshelve eapply posRed; tea; eapply Rt; now irrelevanceRefl.
-    + unshelve epose proof (posRed _ t (@wk1 Γ A) _ _).
+      unshelve eapply posRed; [..| eapply Rt]; tea ; now irrelevanceRefl.
+    + unshelve epose proof (posRed _ t t (@wk1 Γ A) _ _).
       - escape; gen_typing.
       - replace t with t[tRel 0 .: @wk1 Γ A >> tRel].
         2:{ bsimpl; rewrite scons_eta'; now asimpl. }
         eapply Rt.
         eapply var0; tea; now rewrite wk1_ren_on.
-      - escape. 
+      - escape.
         replace (B[_]) with B[t .: @wk1 Γ A >> tRel]; tea.
         now setoid_rewrite wk1_ren.
     + intros; irrelevance0; rewrite liftSubst_scons_eq;[reflexivity|].
-      unshelve eapply posExt; tea; eapply Rt + eapply Rtext; now irrelevanceRefl.
+      unshelve eapply posExt; tea; eapply Rt + eapply Rtext; cbn; irrelevanceRefl.
+      1: now eapply lrefl.
+      1: now eapply urefl.
+      eassumption.
   Qed.
 
-  Lemma polyRedEqSubst {Γ l A B t u} (PAB : PolyRed Γ l A B) 
-    (Rt : forall Δ a (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), 
-      [Δ ||-<l> a : _ | PolyRed.shpRed PAB ρ wfΔ] ->
-      [Δ ||-<l> t[a .: ρ >> tRel] : _ | PolyRed.shpRed PAB ρ wfΔ ])
-    (Ru : forall Δ a (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), 
-      [Δ ||-<l> a : _ | PolyRed.shpRed PAB ρ wfΔ] ->
-      [Δ ||-<l> u[a .: ρ >> tRel] : _ | PolyRed.shpRed PAB ρ wfΔ ])
-    (Rtu : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]), 
-      [Δ ||-<l> a : _ | PolyRed.shpRed PAB ρ wfΔ] ->
-      [Δ ||-<l> b : _ | PolyRed.shpRed PAB ρ wfΔ] ->
+  Lemma polyRedEqSubst {Γ l A B t u} (PAB : PolyRed Γ l A B)
+    (Rtu : forall Δ a b (ρ : Δ ≤ Γ) (wfΔ : [|-Δ]),
       [Δ ||-<l> a ≅ b : _ | PolyRed.shpRed PAB ρ wfΔ] ->
       [Δ ||-<l> t[a .: ρ >> tRel] ≅ u[b .: ρ >> tRel] : _ | PolyRed.shpRed PAB ρ wfΔ ])
     (PABt : PolyRed Γ l A B[t]⇑)
@@ -149,69 +147,52 @@ Section PolyValidity.
     - intros; eapply reflLRTyEq.
     - intros; irrelevance0; rewrite liftSubst_scons_eq; [reflexivity|].
       unshelve eapply PolyRed.posExt; cycle 1; tea.
-      + eapply Rt; now irrelevanceRefl.
-      + eapply Ru; now irrelevanceRefl.
-      + eapply Rtu; try eapply reflLRTmEq; now irrelevanceRefl.
+      eapply Rtu; irrelevanceRefl; now eapply lrefl.
   Qed.
-  
+
   Context {l Γ F G} (VΓ : [||-v Γ])
     (VF : [Γ ||-v< l > F | VΓ ])
     (VG : [Γ ,, F ||-v< l > G | validSnoc VΓ VF]).
 
-  Context {Δ σ} (tΔ : [ |-[ ta ] Δ]) (Vσ : [VΓ | Δ ||-v σ : _ | tΔ]).
-  
+  Context {Δ σ σ'} (tΔ : [ |-[ ta ] Δ]) (Vσσ' : [VΓ | Δ ||-v σ ≅ σ' : _ | tΔ]).
+
   Lemma substPolyRed : PolyRed Δ l F[σ] G[up_term_term σ].
   Proof.
-    pose proof (Vuσ := liftSubstS' VF Vσ).
-    instValid Vσ; instValid Vuσ; escape.
+    pose proof (Vuσ := liftSubstEq' VF Vσσ').
+    instValid Vσσ'; instValid Vuσ; escape.
     unshelve econstructor; tea.
     - intros; now eapply wk.
-    - cbn; intros ?? ρ wfΔ' ha.
+    - cbn; intros ??? ρ wfΔ' hab.
       rewrite eq_subst_2.
-      pose proof (Vawkσ := consWkSubstS VF ρ wfΔ' Vσ ha).
+      pose proof (Vawkσ := consWkSubstEq VF Vσσ' ρ wfΔ' hab).
       now instValid Vawkσ.
-    - cbn; intros ??? ρ wfΔ' ha hb hab.
-      irrelevance0; rewrite eq_subst_2.
-      1: reflexivity.
-      pose proof (Vawkσ := consWkSubstS VF ρ wfΔ' Vσ ha).
-      pose proof (Vbwkσ := consWkSubstS VF ρ wfΔ' Vσ hb).
-      epose proof (Vabwkσ := consWkSubstSEq' VF Vσ (reflSubst _ _ Vσ) ρ wfΔ' ha hab).
-      now instAllValid Vawkσ Vbwkσ Vabwkσ.
+    - cbn; intros ??? ρ wfΔ' hab.
+      epose proof (Vabwkσ := consWkSubstEq VF (lrefl Vσσ') ρ wfΔ' hab).
+      instValid Vabwkσ.
+      rewrite !eq_subst_2; irrelevance.
   Qed.
 
   Lemma substEqPolyRedEq {F' G'} (VF' : [Γ ||-v< l > F' | VΓ ])
     (VG' : [Γ ,, F' ||-v< l > G' | validSnoc VΓ VF'])
     (VFF' : [Γ ||-v< l > F ≅ F' | VΓ | VF])
     (VGG' : [Γ ,, F ||-v< l > G ≅ G' | validSnoc VΓ VF | VG])
-    : PolyRedEq substPolyRed F'[σ] G'[up_term_term σ].
+    (PFGσ : PolyRed Δ l F[σ] G[up_term_term σ])
+    : PolyRedEq PFGσ F'[σ'] G'[up_term_term σ'].
   Proof.
-    instValid Vσ.
+     instValid Vσσ'.
     unshelve econstructor.
-    - intros; irrelevanceRefl; now unshelve eapply wkEq.
-    - intros ?? ρ wfΔ' ha; irrelevance0; rewrite eq_subst_2.
-      1: reflexivity.
-      unshelve epose proof (Vabwkσ := consWkSubstSEq' VF Vσ (reflSubst _ _ Vσ) ρ wfΔ' ha _).
-      2: now eapply reflLRTmEq.
-      unshelve eapply validTyEq; cycle 2; tea. 
-      now eapply consWkSubstS.
+    - intros; irrelevanceRefl; now unshelve now eapply wkEq.
+    - intros ??? ρ wfΔ' hab; rewrite eq_subst_2.
+      unshelve epose proof (Vabwkσ := consWkSubstEq VF Vσσ' ρ wfΔ' (lrefl hab)).
+      instValid Vabwkσ; irrelevance0; [|tea].
+      now rewrite eq_subst_2.
   Qed.
 
-  Context {σ'} (Vσ' : [VΓ | Δ ||-v σ' : _ | tΔ]) (Vσσ' : [VΓ | Δ ||-v σ ≅ σ' : _ | tΔ | Vσ]).
-
-  Lemma substPolyRedEq : PolyRedEq substPolyRed F[σ'] G[up_term_term σ'].
+  Lemma substPolyRedEq (PFGσ : PolyRed Δ l F[σ] G[up_term_term σ])
+    : PolyRedEq PFGσ F[σ'] G[up_term_term σ'].
   Proof.
-    instAllValid Vσ Vσ' Vσσ'.
-    unshelve econstructor.
-    - intros; irrelevanceRefl; now eapply wkEq.
-    - intros ?? ρ wfΔ' ha; irrelevance0; rewrite eq_subst_2.
-      1: reflexivity.
-      unshelve epose proof (Vabwkσ := consWkSubstSEq' VF Vσ Vσσ' ρ wfΔ' ha _).
-      2: now eapply reflLRTmEq.
-      eapply validTyExt; tea.
-      eapply consWkSubstS; tea.
-      eapply LRTmRedConv; tea.
-      irrelevanceRefl; now eapply wkEq.
-      Unshelve. 1,3,5: tea. now eapply wk.
+    eapply substEqPolyRedEq; tea.
+    all: eapply reflValidTy.
   Qed.
 
 End PolyValidity.

--- a/theories/Substitution/Introductions/Poly.v
+++ b/theories/Substitution/Introductions/Poly.v
@@ -2,7 +2,7 @@ From Coq Require Import ssrbool.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening
   GenericTyping LogicalRelation Validity.
-From LogRel.LogicalRelation Require Import Escape Reflexivity Neutral Weakening Irrelevance Transitivity.
+From LogRel.LogicalRelation Require Import Escape Reflexivity Neutral Weakening Irrelevance Transitivity EqRedRight InstKripke.
 From LogRel.Substitution Require Import Irrelevance Properties Reflexivity.
 From LogRel.Substitution.Introductions Require Import Universe.
 
@@ -20,13 +20,6 @@ Qed.
 
 Lemma subst_wk_id_tail Γ P t : P[t .: @wk_id Γ >> tRel] = P[t..].
 Proof. setoid_rewrite id_ren; now bsimpl. Qed.
-
-(* Also used in EqRedRight *)
-Lemma eq_id_subst_scons {Γ A} B : B = B[tRel 0 .: @wk1 Γ A >> tRel].
-Proof.
-  clear; bsimpl; rewrite scons_eta'; now bsimpl.
-Qed.
-
 
 Set Printing Primitive Projection Parameters.
 

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -1,52 +1,54 @@
-From Coq Require Import ssrbool.
+From Coq Require Import ssrbool CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
-From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening
-  GenericTyping LogicalRelation Validity.
-From LogRel.LogicalRelation Require Import Escape Reflexivity Neutral Weakening Irrelevance Reduction NormalRed Induction Transitivity.
-From LogRel.Substitution Require Import Irrelevance Properties SingleSubst Reflexivity.
+From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
+From LogRel.LogicalRelation Require Import Induction Escape Irrelevance Reflexivity Irrelevance Weakening Neutral Transitivity Reduction Application Universe EqRedRight SimpleArr NormalRed InstKripke.
+From LogRel.Substitution Require Import Irrelevance Properties Conversion SingleSubst Reflexivity Reduction SingleSubst.
 From LogRel.Substitution.Introductions Require Import Universe Poly.
+
 
 Set Universe Polymorphism.
 Set Printing Primitive Projection Parameters.
 
-Section SigmaValidity.
-  Context `{GenericTypingProperties}.
-  Context {l Γ F G} (VΓ : [||-v Γ])
-    (VF : [Γ ||-v< l > F | VΓ ])
-    (VG : [Γ ,, F ||-v< l > G | validSnoc VΓ VF]).
+Section SigmaCongRed.
 
-  Lemma SigRed {Δ σ} (wfΔ : [ |-[ ta ] Δ]) (Vσ : [VΓ | Δ ||-v σ : _ | wfΔ])
+  Context `{GenericTypingProperties}.
+  Context {Γ F G F' G' l}
+    (VΓ : [||-v Γ])
+    (VF : [ Γ ||-v< l > F | VΓ ])
+    (VG : [ Γ ,, F ||-v< l > G | validSnoc VΓ VF ])
+    (VF' : [ Γ ||-v< l > F' | VΓ ])
+    (VG' : [ Γ ,, F' ||-v< l > G' | validSnoc VΓ VF' ])
+    (VFF' : [ Γ ||-v< l > F ≅ F' | VΓ | VF ])
+    (VGG' : [ Γ ,, F ||-v< l > G ≅ G' | validSnoc VΓ VF | VG ]).
+
+  Lemma SigRed {Δ σ σ'} (wfΔ : [ |-[ ta ] Δ]) (Vσ : [VΓ | Δ ||-v σ ≅ σ' : _ | wfΔ])
     : [ Δ ||-< l > (tSig F G)[σ] ].
   Proof.
     eapply LRSig'.
     pose (p := substPolyRed VΓ VF VG _ Vσ).
-    escape; cbn; econstructor; tea;
-    destruct (polyRedId p);
-    destruct (polyRedEqId p (substPolyRedEq VΓ VF VG _ Vσ Vσ (reflSubst _ _ Vσ))); escape.
-    - apply redtywf_refl; gen_typing.
-    - gen_typing.
-    - gen_typing.
+    set (pid := polyRedId p).
+    set (peq := polyRedEqId p (substPolyRedEq VΓ VF VG _ Vσ p)).
+    econstructor; tea.
+    - eapply redtywf_refl, wft_sig; refold; destruct pid; now escape.
+    - eapply lrefl; destruct peq; now escape.
+    - destruct pid, peq; escape; eapply convty_sig; tea; now eapply lrefl.
   Defined.
 
-  Lemma SigEqRed {Δ σ σ'} (tΔ : [ |-[ ta ] Δ])
-    (Vσ : [VΓ | Δ ||-v σ : _ | tΔ])
-    (Vσ' : [VΓ | Δ ||-v σ' : _ | tΔ])
-    (Vσσ' : [VΓ | Δ ||-v σ ≅ σ' : _ | tΔ | Vσ])
-    : [ Δ ||-< l > (tSig F G)[σ] ≅ (tSig F G)[σ'] | SigRed tΔ Vσ ].
+
+  Lemma SigCongRed {Δ σ σ'} (wfΔ : [|- Δ]) (Vσ : [VΓ | Δ ||-v σ ≅ σ' : _ | wfΔ])
+    : [ Δ ||-< l > (tSig F G)[σ] ≅ (tSig F' G')[σ'] | SigRed wfΔ Vσ ].
   Proof.
     pose (p := substPolyRed VΓ VF VG _ Vσ).
-    pose (p' := substPolyRed VΓ VF VG _ Vσ').
-    pose (peq := substPolyRedEq VΓ VF VG _ Vσ Vσ' Vσσ').
+    pose (p' := substPolyRed VΓ VF' VG' _ Vσ).
+    pose (peq := substEqPolyRedEq VΓ VF VG _ Vσ VF' VG' VFF' VGG' p).
     destruct (polyRedId p); destruct (polyRedId p'); destruct (polyRedEqId p peq).
     escape; econstructor; cbn; tea.
-    - apply redtywf_refl; gen_typing.
-    - gen_typing.
-  Defined.
+    - apply redtywf_refl; eapply wft_sig; tea.
+      eapply escape; now instValid (liftSubstEq' VF' (urefl Vσ)).
+    - now eapply convty_sig.
+  Qed.
 
-  Lemma SigValid : [Γ ||-v< l > tSig F G | VΓ].
-  Proof. unshelve econstructor; intros; [now eapply SigRed| now eapply SigEqRed].  Defined.
-  
-End SigmaValidity.
+End SigmaCongRed.
 
 Section SigmaCongValidity.
 
@@ -60,23 +62,16 @@ Section SigmaCongValidity.
     (VFF' : [ Γ ||-v< l > F ≅ F' | VΓ | VF ])
     (VGG' : [ Γ ,, F ||-v< l > G ≅ G' | validSnoc VΓ VF | VG ]).
 
-  Lemma SigCongRed {Δ σ} (wfΔ : [|- Δ]) (Vσ : [VΓ | Δ ||-v σ : _ | wfΔ])
-    : [ Δ ||-< l > (tSig F G)[σ] ≅ (tSig F' G')[σ] | validTy (SigValid VΓ VF VG) wfΔ Vσ ].
+  Lemma SigValid : [Γ ||-v< l > tSig F G | VΓ].
   Proof.
-    pose (p := substPolyRed VΓ VF VG _ Vσ).
-    pose (p' := substPolyRed VΓ VF' VG' _ Vσ).
-    pose (peq := substEqPolyRedEq VΓ VF VG _ Vσ VF' VG' VFF' VGG').
-    destruct (polyRedId p); destruct (polyRedId p'); destruct (polyRedEqId p peq).
-    escape; econstructor; cbn; tea.
-    - apply redtywf_refl; gen_typing.
-    - gen_typing.
+    unshelve econstructor; intros; [now eapply SigRed|].
+    eapply SigCongRed; tea; now eapply reflValidTy.
   Qed.
 
-  Lemma SigCong : [ Γ ||-v< l > tSig F G ≅ tSig F' G' | VΓ | SigValid VΓ VF VG ].
-  Proof.  econstructor; intros; eapply SigCongRed.  Qed.
+  Lemma SigCong : [ Γ ||-v< l > tSig F G ≅ tSig F' G' | VΓ | SigValid ].
+  Proof. econstructor; intros; irrelevanceRefl; now unshelve now eapply SigCongRed. Qed.
 
 End SigmaCongValidity.
-
 
 Lemma up_subst_single {t σ a} : t[up_term_term σ][a..] = t[a .: σ].
 Proof. now asimpl. Qed.
@@ -91,13 +86,13 @@ Proof.  now rewrite wk_id_shift, up_subst_single, scons_eta'. Qed.
 Section SigInjValid.
   Context `{GenericTypingProperties}.
   Context {l Γ F G} (VΓ : [||-v Γ]) (VΣ : [Γ ||-v<l> tSig F G | VΓ]).
-  
+
   Lemma domSigValid : [Γ ||-v<l> F | VΓ].
   Proof.
     unshelve econstructor.
-    - intros ??? Vσ; instValid Vσ.
+    - intros ???? Vσ; instValid Vσ.
       apply (polyRedId (normRedΣ0 (invLRΣ RVΣ))).
-    - intros ???? Vσ Vσ' Vσσ' ; instAllValid Vσ Vσ' Vσσ'.
+    - intros ???? Vσσ' ; instValid Vσσ'.
       set (P := (polyRedId _)); destruct P.
       pose (X := normEqRedΣ _ REVΣ); fold subst_term in *.
       irrelevanceRefl; apply (polyRedEqId _ X).
@@ -106,354 +101,309 @@ Section SigInjValid.
   Lemma codSigValid : [Γ,, F ||-v<l> G | validSnoc VΓ domSigValid ].
   Proof.
     pose (domSigValid).
-    assert (h : forall (Δ : context) (σ : nat -> term) (wfΔ : [ |-[ ta ] Δ]),
-      [validSnoc VΓ domSigValid | Δ ||-v σ : Γ,, F | wfΔ] -> [Δ ||-< l > G[σ]]).
+    assert (h : forall (Δ : context) (wfΔ : [ |-[ ta ] Δ]) (σ σ' : nat -> term),
+      [validSnoc VΓ domSigValid | Δ ||-v σ ≅ σ' : Γ,, F | wfΔ] -> [Δ ||-< l > G[σ]]).
     1:{
-      intros ?? wfΔ Vσ; instValid (validTail Vσ).
+      intros ? wfΔ ?? Vσ; instValid (eqTail Vσ).
       pose (p := normRedΣ0 (invLRΣ RVΣ)); fold subst_term in *.
       erewrite split_valid_subst_wk_id.
       unshelve eapply (PolyRed.posRed p (wk_id) wfΔ).
-      irrelevance0; [|exact (validHead Vσ)]; now rewrite wk_id_ren_on.
+      2: irrelevance0; [|exact (eqHead Vσ)]; now rewrite wk_id_ren_on.
     }
     unshelve econstructor; tea.
-    intros ??? wfΔ Vσ Vσ' Vσσ' ; instAllValid (validTail Vσ) (validTail Vσ') (eqTail Vσσ').
+    intros ? wfΔ ?? Vσσ' ; instValid (eqTail Vσσ').
     pose (p := normRedΣ0 (invLRΣ RVΣ));
     pose (q := normEqRedΣ _ REVΣ); fold subst_term in *.
     irrelevance0.
     1: now erewrite split_valid_subst_wk_id.
     assert [PolyRed.shpRed p wk_id wfΔ | Δ ||- σ' var_zero : (ParamRedTy.dom p)⟨wk_id⟩].
     1:{
-      eapply LRTmRedConv.
-      2: exact (validHead Vσ').
+      eapply LRTmEqConv.
+      2: exact (urefl (eqHead Vσσ')).
       rewrite wk_id_ren_on; cbn.
-      now eapply LRTyEqSym.
+      now eapply reflLRTyEq.
     }
     eapply transEq; cycle 1.
     + erewrite split_valid_subst_wk_id.
       unshelve eapply (PolyRedEq.posRed q wk_id wfΔ).
-      irrelevance.
+      2: irrelevance.
     + unshelve eapply (PolyRed.posExt p wk_id wfΔ); tea.
-      1: irrelevance0; [|exact (validHead Vσ)]; now rewrite wk_id_ren_on.
       irrelevance0; [|exact (eqHead Vσσ')]; now rewrite wk_id_ren_on.
   Qed.
-  
+
 End SigInjValid.
 
 
 
 Section SigTmValidity.
-
   Context `{GenericTypingProperties}.
-  Context {Γ F G} (VΓ : [||-v Γ])
-    (VF : [ Γ ||-v< one > F | VΓ ])
+
+  Section Lemmas.
+  Context {Γ F  F' G  G'} {VΓ : [||-v Γ]}
+    {VF : [ Γ ||-v< one > F | VΓ ]}
     (VU : [ Γ ,, F ||-v< one > U | validSnoc VΓ VF ])
-    (VFU : [ Γ ||-v< one > F : U | VΓ | UValid VΓ ])
-    (VGU : [ Γ ,, F ||-v< one > G : U | validSnoc VΓ VF | VU ]) .
+    (VFeqU : [ Γ ||-v< one > F ≅ F' : U | VΓ | UValid VΓ ])
+    (VGeqU : [ Γ ,, F ||-v< one > G ≅ G' : U | validSnoc VΓ VF | VU ]).
+
 
   Lemma sigTmEq {Δ σ σ'} (tΔ : [ |-[ ta ] Δ])
-    (Vσ : [VΓ | Δ ||-v σ : _ | tΔ])
-    (Vσ' : [VΓ | Δ ||-v σ' : _ | tΔ])
-    (Vσσ' : [VΓ | Δ ||-v σ ≅ σ' : _ | tΔ | Vσ ])
-    : [Δ |-[ ta ] tSig F[σ] G[up_term_term σ] ≅ tSig F[σ'] G[up_term_term σ'] : U].
+    (Vσσ' : [VΓ | Δ ||-v σ ≅ σ' : _ | tΔ ])
+    : [Δ |-[ ta ] tSig F[σ] G[up_term_term σ] ≅ tSig F'[σ'] G'[up_term_term σ'] : U].
   Proof.
-    pose proof (Vuσ := liftSubstS' VF Vσ).
-    pose proof (Vureaσ' := liftSubstSrealign' VF Vσσ' Vσ').
-    pose proof (Vuσσ' := liftSubstSEq' VF Vσσ').
-    instAllValid Vσ Vσ' Vσσ'; instAllValid Vuσ Vureaσ' Vuσσ'; escape.
+    pose proof (Vuσ := liftSubstEq' VF Vσσ').
+    instValid Vσσ'; instValid Vuσ; escape.
     eapply convtm_sig; tea.
   Qed.
 
-  Lemma SigRedU {Δ σ} (tΔ : [ |-[ ta ] Δ]) (Vσ : [VΓ | Δ ||-v σ : _ | tΔ])
-    : [ Δ ||-< one > (tSig F G)[σ] : U | validTy (UValid VΓ) tΔ Vσ ].
-  Proof.
-    pose proof (Vσσ := reflSubst _ _ Vσ).
-    pose proof (Vuσ := liftSubstS' VF Vσ).
-    pose proof (Vuσσ := liftSubstSEq' VF Vσσ).
-    instAllValid Vσ Vσ Vσσ; instAllValid Vuσ Vuσ Vuσσ; escape.
-    econstructor; cbn.
-    - apply redtmwf_refl; cbn in *; now eapply ty_sig.
-    - constructor.
-    - now eapply convtm_sig.
-    - cbn. unshelve refine (LRCumulative (SigRed _ _ _ tΔ Vσ));
-      unshelve eapply univValid; tea; try irrValid.
-  Defined.
 
-  Lemma SigValidU : [ Γ ||-v< one > tSig F G : U | VΓ | UValid VΓ ].
+  Lemma SigURedTm {Δ σ σ'} (tΔ : [ |-[ ta ] Δ]) (Vσ : [VΓ | Δ ||-v σ ≅ σ' : _ | tΔ])
+    : URedTm (LogRelRec _) Δ (tSig F G)[σ] U (redUOneCtx tΔ).
   Proof.
-    econstructor.
-    - intros Δ σ tΔ Vσ.
-      exact (SigRedU tΔ Vσ).
-    - intros Δ σ σ' tΔ Vσ Vσ' Vσσ'.
-      pose proof (univValid (l' := zero) _ _ VFU) as VF0.
-      pose proof (irrelevanceTy (validSnoc VΓ VF)
-                    (validSnoc (l := zero) VΓ VF0)
-                    (univValid (l' := zero) _ _ VGU)) as VG0.
-      unshelve econstructor ; cbn.
-      + exact (SigRedU tΔ Vσ).
-      + exact (SigRedU tΔ Vσ').
-      + exact (LRCumulative (SigRed VΓ VF0 VG0 tΔ Vσ)).
-      + exact (sigTmEq tΔ Vσ Vσ' Vσσ').
-      + exact (LRCumulative (SigRed VΓ VF0 VG0 tΔ Vσ')).
-      + pose proof (SigEqRed VΓ VF0 VG0 tΔ Vσ Vσ' Vσσ').
-        irrelevanceCum.
+    pose proof (Vuσσ := liftSubstEq' VF Vσ); instValid Vσ ; instValid Vuσσ; escape.
+    econstructor; [eapply redtmwf_refl; cbn; now eapply ty_sig|constructor].
+  Defined.
+  End Lemmas.
+
+  Context {Γ F  F' G  G'} {VΓ : [||-v Γ]}
+    {VF : [ Γ ||-v< one > F | VΓ ]}
+    {VU : [ Γ ,, F ||-v< one > U | validSnoc VΓ VF ]}
+    (VFeqU : [ Γ ||-v< one > F ≅ F' : U | VΓ | UValid VΓ ])
+    (VFU := lreflValidTm _ VFeqU)
+    (VGeqU : [ Γ ,, F ||-v< one > G ≅ G' : U | validSnoc VΓ VF | VU ])
+    (VGU := lreflValidTm _ VGeqU).
+
+  Lemma SigCongRedU {Δ σ σ'} (tΔ : [ |-[ ta ] Δ]) (Vσ : [VΓ | Δ ||-v σ ≅ σ' : _ | tΔ])
+    : [ Δ ||-< one > (tSig F G)[σ] ≅ (tSig F' G')[σ'] : U | validTy (UValid VΓ) tΔ Vσ ].
+  Proof.
+    pose proof (Vuσσ := liftSubstEq' VF Vσ); instValid Vσ ; instValid Vuσσ; escape.
+    set (RΣ := SigURedTm VU VFeqU VGeqU tΔ Vσ).
+    pose proof (symValidTmEq VFeqU).
+    epose proof (VF' := univValid _ _ (ureflValidTm VFeqU)).
+    epose proof (VFF' := univEqValid _ _ VF VFeqU).
+    epose proof (VGU' := convTmEqCtx1 _ _ (validSnoc VΓ VF') VF _ (UValid _) VFF' (ureflValidTm VGeqU)).
+    set (RΣ' := SigURedTm (UValid _) (ureflValidTm VFeqU) VGU' tΔ (urefl Vσ)).
+    unshelve eexists RΣ RΣ' _.
+    - unshelve (eapply RedTyRecBwd, LRCumulative, SigRed; [| tea]).
+      all: unshelve (eapply univValid, lreflValidTm; irrValid); eapply UValid.
+    - eapply convtm_sig; refold; tea; now eapply lrefl.
+    - unshelve (eapply RedTyRecBwd, LRCumulative, SigRed; [| now eapply urefl]).
+      all: unshelve (eapply univValid, lreflValidTm; irrValid); eapply UValid.
+    - irrelevanceCum0; [reflexivity|].
+      unshelve (eapply SigCongRed; tea; [now eapply univValid| now eapply univEqValid]); tea.
+      unshelve (eapply univValid, lreflValidTm; irrValid); eapply UValid.
   Qed.
+
+  Lemma SigCongValidU : [ Γ ||-v< one > tSig F G ≅ tSig F' G' : U | VΓ | UValid VΓ ].
+  Proof. econstructor; intros Δ tΔ  σ σ' Vσσ'; eapply SigCongRedU. Qed.
 
 End SigTmValidity.
 
 
-Section SigTmCongruence.
-
+Section SigRedTmEqHelper.
+  Import SigRedTmEq.
   Context `{GenericTypingProperties}.
-  Context {Γ F G F' G'}
-    (VΓ : [||-v Γ])
-    (VF : [ Γ ||-v< one > F | VΓ ])
-    (VU : [ Γ ,, F ||-v< one > U | validSnoc VΓ VF ])
-    (VFU : [ Γ ||-v< one > F : U | VΓ | UValid VΓ ])
-    (VGU : [ Γ ,, F ||-v< one > G : U | validSnoc VΓ VF | VU ])
-    (VF' : [ Γ ||-v< one > F' | VΓ ])
-    (VU' : [ Γ ,, F' ||-v< one > U | validSnoc VΓ VF' ])
-    (VF'U : [ Γ ||-v< one > F' : U | VΓ | UValid VΓ ])
-    (VG'U : [ Γ ,, F' ||-v< one > G' : U | validSnoc VΓ VF' | VU' ])
-    (VFF' : [ Γ ||-v< one > F ≅ F' : U | VΓ | UValid VΓ ])
-    (VGG' : [ Γ ,, F ||-v< one > G ≅ G' : U | validSnoc VΓ VF | VU ]).
 
-  Lemma SigCongTm : [ Γ ||-v< one > tSig F G ≅ tSig F' G' : U | VΓ | UValid VΓ ].
+  Lemma isLRPair_isWfPair {Γ A B l p} (ΣA : [Γ ||-Σ<l> tSig A B])
+    (RA : [Γ ||-<l> A])
+    (RΣ := (normRedΣ0 ΣA))
+    (Rp : isLRPair RΣ p) :
+      isWfPair Γ A B p.
   Proof.
-    econstructor.
-    intros Δ σ tΔ Vσ.
-    pose proof (univValid (l' := zero) _ _ VFU) as VF0.
-    pose proof (univValid (l' := zero) _ _ VF'U) as VF'0.
-    pose proof (Vσσ := reflSubst _ _ Vσ).
-    pose proof (Vuσ := liftSubstS' VF Vσ).
-    pose proof (Vuσσ := liftSubstSEq' VF Vσσ).
-    instAllValid Vσ Vσ Vσσ; instAllValid Vuσ Vuσ Vuσσ; escape.
-    pose proof (irrelevanceTy (validSnoc VΓ VF)
-                  (validSnoc (l := zero) VΓ VF0)
-                  (univValid (l' := zero) _ _ VGU)) as VG0.
-    pose proof (irrelevanceTy (validSnoc VΓ VF')
-                  (validSnoc (l := zero) VΓ VF'0)
-                  (univValid (l' := zero) _ _ VG'U)) as VG'0.
-    unshelve econstructor ; cbn.
-    - exact (SigRedU VΓ VF VU VFU VGU tΔ Vσ).
-    - exact (SigRedU VΓ VF' VU' VF'U VG'U tΔ Vσ).
-    - exact (LRCumulative (SigRed VΓ VF0 VG0 tΔ Vσ)).
-    - now eapply convtm_sig.
-    - exact (LRCumulative (SigRed VΓ VF'0 VG'0 tΔ Vσ)).
-    - enough ([ Δ ||-< zero > (tSig F G)[σ] ≅ (tSig F' G')[σ] | SigRed VΓ VF0 VG0 tΔ Vσ]) by irrelevanceCum.
-      refine (SigCongRed VΓ VF0 VG0 VF'0 VG'0 _ _ tΔ Vσ).
-      + exact (univEqValid VΓ (UValid VΓ) VF0 VFF').
-      + pose proof (univEqValid (validSnoc VΓ VF) VU (univValid (l' := zero) _ _ VGU) VGG') as VGG'0.
-        refine (irrelevanceTyEq _ _ _ _ VGG'0).
+    assert (wfΓ: [|- Γ]) by (escape ; gen_typing).
+    destruct Rp as [???? eqA eqB rfst rsnd|].
+    2: now econstructor.
+    pose proof (RFA := instKripkeEq wfΓ eqA).
+    pose proof (LRTyEqRedRight _ RFA).
+    pose proof (instKripkeSubstConv wfΓ eqA (PolyRed.posRed RΣ)).
+    pose proof (instKripkeSubstConvEq wfΓ eqA eqB).
+    pose proof (Ra := instKripkeTmEq wfΓ rfst).
+    pose proof (instKripkeSubstEq wfΓ eqB).
+    pose proof (polyCodSubstRed _ RΣ _ _ Ra).
+    unshelve epose proof (hB:=eqB _ _ _ (@wk_id Γ) wfΓ _).
+    3: irrelevance0; [| exact Ra]; now rewrite wk_id_ren_on.
+    pose proof (polyCodSubstExtRed _ RΣ _ _ Ra).
+    epose proof (hb := rsnd _ wk_id wfΓ).
+    cbn -[wk_id] in *.
+    escape.
+    rewrite 2!subst_wk_id_tail in EschB.
+    rewrite subst_wk_id_tail in EscRhB, Rlhb.
+    rewrite 2!wk_id_ren_on in Rlhb.
+    now econstructor.
   Qed.
 
-End SigTmCongruence.
+
+  Context {Γ l A} (RA : [Γ ||-Σ<l> A])
+    {t u} (Rt : SigRedTm RA t) (Ru : SigRedTm RA u).
+
+  (* Let Rout : [Γ ||-Σ<l> RA.(ParamRedTy.outTy)].
+  Proof.
+    apply normRedΣ0.
+    econstructor; [eapply redtywf_refl|..]; destruct RA; tea.
+    cbn in *; gen_typing.
+  Defined. *)
+
+  Lemma build_sigRedTmEq
+    (eqnf : [Γ |- nf Rt ≅ nf Ru : ParamRedTy.outTy RA])
+    (Rdom := fst (polyRedId RA))
+    (Rfst : [ Rdom | _ ||- tFst (nf Rt) ≅ tFst (nf Ru) : _ ])
+    (Rcod := polyCodSubstRed Rdom RA _ _ Rfst)
+    (Rsnd : [ Rcod | _ ||- tSnd (nf Rt) ≅ tSnd (nf Ru) : _ ]) :
+    [LRSig' RA | _ ||- t ≅ u : _].
+  Proof.
+    unshelve eexists Rt Ru _; tea.
+    - intros; unshelve (irrelevanceRefl; rewrite 2!wk_fst; now eapply wkTermEq); tea.
+    - intros; irrelevance0.
+      2: unshelve (rewrite 2!wk_snd; now eapply wkTermEq); tea.
+      rewrite wk_fst; clear; now bsimpl.
+  Qed.
+
+  Lemma redtmwf_fst {F G f f'} :
+    [ Γ |- f :⤳*: f' : tSig F G ] ->
+    [ Γ |- tFst f :⤳*: tFst f' : F ].
+  Proof.
+    intros [] ; constructor; [| now eapply redtm_fst].
+    timeout 1 gen_typing.
+  Qed.
+
+  Lemma redtmwf_snd {F G f f'} :
+    [ Γ |- f :⤳*: f' : tSig F G ] ->
+    [ Γ |- G[(tFst f)..] ≅ G[(tFst f')..]] ->
+    [ Γ |- tSnd f :⤳*: tSnd f' : G[(tFst f)..] ].
+  Proof.
+    intros [] ? ; constructor; [| now eapply redtm_snd].
+    eapply ty_conv; [| now symmetry]; timeout 1 gen_typing.
+  Qed.
+
+  (* Lemma build_sigRedTmEq'
+    (eqnf : [Γ |- nf Rt ≅ nf Ru : ParamRedTy.outTy RA])
+    (Rdom := fst (polyRedId RA))
+    (Rfst : [ Rdom | _ ||- tFst t ≅ tFst u : _ ])
+    (Rcod := polyCodSubstRed Rdom RA _ _ Rfst)
+    (Rsnd : [ Rcod | _ ||- tSnd t ≅ tSnd u : _ ]) :
+    [LRSig' RA | _ ||- t ≅ u : _].
+  Proof.
+    unshelve eapply build_sigRedTmEq; tea.
+    - dependent inversion Rt; dependent inversion Ru; eapply redTmEqFwdBoth.
+      2,3: cbn in *; now eapply redtmwf_fst.
+      1: tea.
+      cbn; constructor.
+      3:{ cbn in *. tea. }
+    try solve [constructor]. *)
+
+End SigRedTmEqHelper.
+
+Section SigRedTmEqHelper.
+  Context `{GenericTypingProperties}.
+  Import SigRedTmEq.
+
+  Lemma build_sigRedTmEq' {Γ l F G}
+    (RΣ0 : [Γ ||-Σ<l> tSig F G])
+    (RΣ := normRedΣ0 RΣ0)
+    {t u} (Rt : SigRedTm RΣ t) (Ru : SigRedTm RΣ u)
+    (Rdom := fst (polyRedId RΣ))
+    (Rfst : [ Rdom | _ ||- tFst (nf Rt) ≅ tFst (nf Ru) : _ ])
+    (Rcod := polyCodSubstRed Rdom RΣ _ _ Rfst)
+    (Rsnd : [ Rcod | _ ||- tSnd (nf Rt) ≅ tSnd (nf Ru) : _ ]) :
+    [LRSig' RΣ | _ ||- t ≅ u : _].
+  Proof.
+    eapply build_sigRedTmEq; tea.
+    cbn; destruct (polyRedId RΣ); escape; eapply convtm_eta_sig; tea.
+    2,4: eapply isLRPair_isWfPair; [| eapply ispair]; tea.
+    + destruct Rt; cbn in *; gen_typing.
+    + destruct Ru; cbn in *; gen_typing.
+  Qed.
+
+End SigRedTmEqHelper.
 
 Section ProjRed.
+  Import SigRedTmEq.
   Context `{GenericTypingProperties}.
 
-  Lemma fstRed {l Δ F G} {p}
+  (* Lemma redSigRedTm {l Δ F G} {p p'}
     (RΣ : [Δ ||-Σ<l> tSig F G])
-    (RF : [Δ ||-<l> F])
-    (Rp : [Δ ||-<l> p : _ | LRSig' (normRedΣ0 RΣ)]) :
-    ([Δ ||-<l> tFst p : _ | RF] × [Δ ||-<l> tFst p ≅ tFst Rp.(SigRedTm.nf) : _ | RF]) × [Δ ||-<l> tFst Rp.(SigRedTm.nf) : _ | RF].
+    (Rp : SigRedTm ΣA p) :
+    [Δ ||-<l> p ≅ p' : _ | LRSig' (normRedΣ0 RΣ)] ->
+    [Δ ||-<l> p ≅  : _ | LRSig' (normRedΣ0 RΣ)] ->
+
+SigRedTmEq.whnf *)
+
+  Lemma sigRedTmEqNf {l Δ F G p p'}
+    (RΣ : [Δ ||-Σ<l> tSig F G])
+    (Rp : [Δ ||-<l> p ≅ p' : _ | LRSig' (normRedΣ0 RΣ)]) :
+    [Δ ||-<l> p ≅ Rp.(redL).(nf) : _ | LRSig' (normRedΣ0 RΣ)].
   Proof.
-    assert [Δ ||-<l> tFst Rp.(SigRedTm.nf) : _ | RF].
-    1:{
-      assert (wfΔ : [|-Δ]) by (escape; gen_typing).
-      pose (r := SigRedTm.fstRed Rp (@wk_id Δ) wfΔ).
-      rewrite wk_id_ren_on in r.
-      irrelevance.
-    }
-    split; tea.
-    irrelevanceRefl.
-    eapply redSubstTerm; tea. 
-    eapply redtm_fst; now destruct (SigRedTm.red Rp).
+    symmetry; eapply redTmEqFwd.
+    + eapply lrefl; irrelevance.
+    + eapply Rp.(redL).(red).
+    + eapply whnf.
   Qed.
 
-  Lemma fstRedEq {l Δ F G} {p p'}
+
+  Lemma fstRed {l Δ F G p p'}
     (RΣ : [Δ ||-Σ<l> tSig F G])
     (RF : [Δ ||-<l> F])
-    (RΣn := LRSig' (normRedΣ0 RΣ))
-    (Rpp' : [Δ ||-<l> p ≅ p' : _ | RΣn]) 
-    (Rp := SigRedTmEq.redL Rpp')
-    (Rp' := SigRedTmEq.redR Rpp') :
-    [× [Δ ||-<l> tFst p ≅ tFst Rp.(SigRedTm.nf) : _ | RF],
-    [Δ ||-<l> tFst p' ≅ tFst Rp'.(SigRedTm.nf) : _ | RF] &
-    [Δ ||-<l> tFst Rp.(SigRedTm.nf) ≅ tFst Rp'.(SigRedTm.nf) : _ | RF]].
+    (Rp : [Δ ||-<l> p ≅ p' : _ | LRSig' (normRedΣ0 RΣ)]) :
+    [Δ ||-<l> tFst p ≅ tFst p' : _ | RF].
   Proof.
-    split.
-    - now eapply fstRed.
-    - now eapply fstRed.
-    - assert (wfΔ : [|-Δ]) by (escape; gen_typing).
-      epose (e := SigRedTmEq.eqFst Rpp' wk_id wfΔ).
-      do 2 rewrite wk_id_ren_on in e.
-      irrelevance.
+    eapply redSubstTmEq; cycle 1.
+    + eapply redtm_fst, tmr_wf_red; exact (SigRedTmEq.red (SigRedTmEq.redL Rp)).
+    + eapply redtm_fst, tmr_wf_red; exact (SigRedTmEq.red (SigRedTmEq.redR Rp)).
+    + cbn; now unshelve eapply escapeEq, reflLRTyEq.
+    + irrelevanceRefl; eapply instKripkeTmEq.
+      intros ? ρ h; rewrite <- 2!wk_fst; eapply (SigRedTmEq.eqFst Rp).
+      Unshelve. all: escape; gen_typing.
   Qed.
 
-  
-  Lemma sndRed {l Δ F G} {p}
+  Lemma sndRed {l Δ F G} {p p'}
     (RΣ : [Δ ||-Σ<l> tSig F G])
     (RF : [Δ ||-<l> F])
     (RΣn := LRSig' (normRedΣ0 RΣ))
-    (Rp : [Δ ||-<l> p : _ | LRSig' (normRedΣ0 RΣ)])
-    (RGfstp : [Δ ||-<l> G[(tFst p)..]]) 
-    (RGfstpEq : [Δ ||-<l> G[(tFst p)..] ≅ G[(tFst Rp.(SigRedTm.nf))..] | RGfstp]) :
-    [Δ ||-<l> tSnd p : _ | RGfstp] × [Δ ||-<l> tSnd p ≅ tSnd Rp.(SigRedTm.nf) : _ | RGfstp].
+    (Rp : [Δ ||-<l> p ≅ p' : _ | LRSig' (normRedΣ0 RΣ)])
+    (RGfstp : [Δ ||-<l> G[(tFst p)..]]) :
+    [Δ ||-<l> tSnd p ≅ tSnd p' : _ | RGfstp].
   Proof.
-    eapply redSubstTerm. 
-    2: eapply redtm_snd; now destruct (SigRedTm.red Rp).
-    assert (wfΔ : [|-Δ]) by (escape; gen_typing).
-    eapply LRTmRedConv; cycle 1.
-    + pose proof (r := SigRedTm.sndRed Rp (@wk_id Δ) wfΔ).
-      rewrite <- (wk_id_ren_on Δ (SigRedTm.nf Rp)).
-      eassumption.
-    + unshelve eapply LRTyEqSym. 2: tea.
-      rewrite wk_id_shift; rewrite wk_id_ren_on; tea.
+    eapply redSubstTmEq; cycle 1.
+    + eapply redtm_snd, tmr_wf_red; exact (SigRedTmEq.red (SigRedTmEq.redL Rp)).
+    + eapply redtm_snd, tmr_wf_red; exact (SigRedTmEq.red (SigRedTmEq.redR Rp)).
+    + epose proof (singleSubstEqΣ (fstRed RΣ RF Rp) RGfstp); cbn; now escape.
+    + irrelevanceRefl.
+      assert (wfΔ : [|- Δ]) by (escape; gen_typing).
+      pose proof (fstRed RΣ RF (sigRedTmEqNf RΣ Rp)).
+      erewrite <- wk_id_ren_on, <- (wk_id_ren_on  _ (tSnd (SigRedTmEq.nf (SigRedTmEq.redL _)))), <-2!wk_snd.
+      eapply LRTmEqConv; [| eapply (SigRedTmEq.eqSnd Rp wk_id wfΔ)].
+      symmetry in X.
+      cbn -[wk_id]; irrelevance0.
+      2: exact (singleSubstEqΣ (RFG:=LRSig' RΣ) X (singleSubstΣ1 (LRSig' RΣ) X)).
+      now rewrite subst_wk_id_tail, wk_id_ren_on.
+      Unshelve. 2,4: tea.
   Qed.
-
-  Lemma sndRedEq {l Δ F G} {p p'}
-    (RΣ : [Δ ||-Σ<l> tSig F G])
-    (RF : [Δ ||-<l> F])
-    (RΣn := LRSig' (normRedΣ0 RΣ))
-    (Rpp' : [Δ ||-<l> p ≅ p' : _ | RΣn]) 
-    (Rp := SigRedTmEq.redL Rpp')
-    (Rp' := SigRedTmEq.redR Rpp')
-    (RGfstp : [Δ ||-<l> G[(tFst p)..]]) 
-    (RGfstpEq : [Δ ||-<l> G[(tFst p)..] ≅ G[(tFst Rp.(SigRedTm.nf))..] | RGfstp])
-    (RGfstp' : [Δ ||-<l> G[(tFst p')..]]) 
-    (RGfstpEq' : [Δ ||-<l> G[(tFst p')..] ≅ G[(tFst Rp'.(SigRedTm.nf))..] | RGfstp']) :
-    [× [Δ ||-<l> tSnd p ≅ tSnd Rp.(SigRedTm.nf) : _ | RGfstp],
-    [Δ ||-<l> tSnd p' ≅ tSnd Rp'.(SigRedTm.nf) : _ | RGfstp'] &
-    [Δ ||-<l> tSnd Rp.(SigRedTm.nf) ≅ tSnd Rp'.(SigRedTm.nf) : _ | RGfstp]].
-  Proof.
-    split.
-    - now eapply sndRed.
-    - now eapply sndRed.
-    - assert (wfΔ : [|-Δ]) by (escape; gen_typing).
-      eapply LRTmEqRedConv; cycle 1.
-      + epose proof (e := SigRedTmEq.eqSnd Rpp' wk_id wfΔ).
-        rewrite <- (wk_id_ren_on Δ (SigRedTm.nf Rp)).
-        rewrite <- (wk_id_ren_on Δ (SigRedTm.nf Rp')).
-        tea.
-    + unshelve eapply LRTyEqSym. 2: tea.
-      rewrite wk_id_shift; rewrite wk_id_ren_on; tea.
-  Qed.
-
 
   Context {l Γ F G } (VΓ : [||-v Γ])
     (VF : [Γ ||-v< l > F | VΓ ])
     (VG : [Γ ,, F ||-v< l > G | validSnoc VΓ VF])
     (VΣ := SigValid VΓ VF VG).
 
-  Lemma fstValid {p} (Vp : [Γ ||-v<l> p : _ | VΓ | VΣ]): [Γ ||-v<l> tFst p : _ | VΓ | VF].
+  Lemma fstValid {p p'} (Vp : [Γ ||-v<l> p ≅ p' : _ | VΓ | VΣ]):
+    [Γ ||-v<l> tFst p ≅ tFst p' : _ | VΓ | VF].
   Proof.
-    unshelve econstructor.
-    - intros ?? wfΔ Vσ.
-      instValid Vσ.
-      pose proof (invLRΣ RVΣ); refold.
-      unshelve eapply fstRed. 2: tea. irrelevance.
-    - intros ??? wfΔ Vσ Vσ' Vσσ'.
-      instAllValid Vσ Vσ' Vσσ'.
-      pose (RΣinv := invLRΣ RVΣ); normRedΣin REVp; fold subst_term in *.
-      destruct (fstRedEq RΣinv RVF REVp).
-      eapply LREqTermHelper; tea; eapply reflLRTyEq.
-  Qed.  
-  
-  Lemma fstCongValid {p p'} 
-    (Vp : [Γ ||-v<l> p : _ | VΓ | VΣ])
-    (Vp' : [Γ ||-v<l> p' : _ | VΓ | VΣ]) 
-    (Vpp' : [Γ ||-v<l> p ≅ p' : _ | VΓ | VΣ])
-    : [Γ ||-v<l> tFst p ≅ tFst p' : _ | VΓ | VF].
-  Proof.
-    constructor; intros ?? wfΔ Vσ.
-    instValid Vσ; instValidExt Vσ (reflSubst _ _ Vσ).
-    pose (RΣinv := invLRΣ RVΣ); normRedΣin RVpp'; fold subst_term in *.
-    destruct (fstRedEq RΣinv RVF RVpp').
-    eapply LREqTermHelper; tea.
-  Qed.  
-  
-  Lemma sndValid {p} (Vp : [Γ ||-v<l> p : _ | VΓ | VΣ])
-    (VGfst := substS VG (fstValid Vp)) : 
-    [Γ ||-v<l> tSnd p : _ | VΓ | VGfst].
-  Proof.
-    unshelve econstructor.
-    - intros ?? wfΔ Vσ.
-      instValid Vσ.
-      pose (RΣinv := invLRΣ RVΣ); normRedΣin RVp; fold subst_term in *.
-      destruct (fstRed RΣinv RVF RVp) as [[Rfstp Rfstpeq] Rfstnf].
-      pose (Vpσ := consSubstS _ _ Vσ VF Rfstp).
-      pose (Vnfσ := consSubstS _ _ Vσ VF Rfstnf).
-      pose (Veqσ := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VF Rfstp Rfstpeq).
-      instAllValid Vpσ Vnfσ Veqσ.
-      unshelve epose (fst (sndRed RΣinv RVF RVp _ _)).
-      + now rewrite up_subst_single.
-      + irrelevance0; rewrite up_subst_single; tea; reflexivity.
-      + irrelevance.
-    - intros ??? wfΔ Vσ Vσ' Vσσ'.
-      pose proof (Vfstp := fstValid Vp).
-      instAllValid Vσ Vσ' Vσσ'.
-      pose (RΣinv := invLRΣ RVΣ); pose (RΣinv' := invLRΣ RVΣ0).
-      normRedΣin RVp; normRedΣin RVp0; normRedΣin REVp; fold subst_term in *.
-      destruct (fstRed RΣinv RVF REVp.(SigRedTmEq.redL)) as [[Rfstp Rfstpeq] Rfstnf].
-      pose (Vpσ := consSubstS _ _ Vσ VF Rfstp).
-      pose (Vnfσ := consSubstS _ _ Vσ VF Rfstnf).
-      pose (Veqσ := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VF Rfstp Rfstpeq).
-      instAllValid Vpσ Vnfσ Veqσ.
-      destruct (fstRed RΣinv RVF REVp.(SigRedTmEq.redR)) as [[Rfstp' Rfstpeq'] Rfstnf'].
-      pose (Vpσ' := consSubstS _ _ Vσ VF Rfstp').
-      pose (Vnfσ' := consSubstS _ _ Vσ VF Rfstnf').
-      pose (Veqσ' := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VF Rfstp' Rfstpeq').
-      instAllValid Vpσ' Vnfσ' Veqσ'.
-      unshelve epose  proof(r := sndRedEq RΣinv RVF REVp _ _ _ _).
-      + now rewrite up_subst_single.
-      + irrelevance0; rewrite up_subst_single; tea; reflexivity.
-      + now rewrite up_subst_single.
-      + irrelevance0; rewrite up_subst_single; tea; reflexivity.
-      + destruct r; irrelevance0; cycle 1.
-        1: eapply LREqTermHelper.
-        1,2,4: tea.
-        2: now rewrite singleSubstComm'.
-        epose (Veqσ0 := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VF Rfstp REVfstp).
-        instAllValid Vpσ Vpσ' Veqσ0.
-        irrelevance0; rewrite up_subst_single; tea; reflexivity.
-  Qed.  
+    constructor; intros; cbn; instValid Vσσ'.
+    unshelve (eapply fstRed; irrelevance); now apply invLRΣ.
+  Qed.
 
-  Lemma sndCongValid {p p'} 
-    (Vp : [Γ ||-v<l> p : _ | VΓ | VΣ])
-    (Vp' : [Γ ||-v<l> p' : _ | VΓ | VΣ]) 
-    (Vpp' : [Γ ||-v<l> p ≅ p' : _ | VΓ | VΣ])
-    (VGfst := substS VG (fstValid Vp)) : 
+  Lemma subst_fst {t σ} : tFst t[σ] = (tFst t)[σ].
+  Proof. reflexivity. Qed.
+
+  Lemma sndValid {p p'} (Vp : [Γ ||-v<l> p ≅ p' : _ | VΓ | VΣ])
+    (VGfst := substS VG (fstValid Vp)) :
     [Γ ||-v<l> tSnd p ≅ tSnd p' : _ | VΓ | VGfst].
   Proof.
-    constructor; intros ?? wfΔ Vσ.
-    pose proof (VGfsteq:= substSEq (reflValidTy _ VF) VG (reflValidTy _ VG) (fstValid Vp) (fstValid Vp') (fstCongValid Vp Vp' Vpp')). 
-    cbn in VGfsteq.
-    instValid Vσ ; instValidExt Vσ (reflSubst _ _ Vσ).
-    pose (RΣinv := invLRΣ RVΣ); normRedΣin RVpp'; fold subst_term in *.
-    destruct (fstRed RΣinv RVF RVpp'.(SigRedTmEq.redL)) as [[Rfstp Rfstpeq] Rfstnf].
-    pose (Vpσ := consSubstS _ _ Vσ VF Rfstp).
-    pose (Vnfσ := consSubstS _ _ Vσ VF Rfstnf).
-    pose (Veqσ := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VF Rfstp Rfstpeq).
-    instAllValid Vpσ Vnfσ Veqσ.
-    destruct (fstRed RΣinv RVF RVpp'.(SigRedTmEq.redR)) as [[Rfstp' Rfstpeq'] Rfstnf'].
-    pose (Vpσ' := consSubstS _ _ Vσ VF Rfstp').
-    pose (Vnfσ' := consSubstS _ _ Vσ VF Rfstnf').
-    pose (Veqσ' := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VF Rfstp' Rfstpeq').
-    instAllValid Vpσ' Vnfσ' Veqσ'.
-    unshelve epose  proof(r := sndRedEq RΣinv RVF RVpp' _ _ _ _).
-    + now rewrite up_subst_single.
-    + irrelevance0; rewrite up_subst_single; tea; reflexivity.
-    + now rewrite up_subst_single.
-    + irrelevance0; rewrite up_subst_single; tea; reflexivity.
-    + destruct r; irrelevance0; cycle 1.
-      1: eapply LREqTermHelper.
-      1,2,4: tea.
-      2: now rewrite singleSubstComm'.
-      irrelevance0; rewrite up_subst_single; change (tFst ?p[?σ]) with (tFst p)[σ]; rewrite <- singleSubstComm; tea.
-      reflexivity. 
-  Qed.  
+    constructor; intros; cbn; instValid Vσσ'.
+    unshelve (irrelevance0; [|eapply sndRed; [| irrelevance]; tea]).
+    all:refold. 3: now rewrite singleSubstComm'.
+    2: now apply invLRΣ.
+    now rewrite subst_fst, <- singleSubstComm'.
+  Qed.
 
-  
 End ProjRed.
 
 
@@ -461,299 +411,266 @@ End ProjRed.
 Section PairRed.
   Context `{GenericTypingProperties}.
 
-  Lemma pairFstRed {Γ A B a b l}
+  Lemma pairFstRed {Γ A A' B B' a a' b b' l}
     (RA : [Γ ||-<l> A])
+    (RAA : [Γ ||-<l> A ≅ A' | RA])
     (RB : [Γ ,, A ||-<l> B])
+    (RB' : [Γ ,, A' ||-<l> B'])
     (RBa : [Γ ||-<l> B[a..]])
-    (Ra : [Γ ||-<l> a : A | RA])
-    (Rb : [Γ ||-<l> b : _ | RBa ]) :
-    [Γ ||-<l> tFst (tPair A B a b) : _ | RA] × [Γ ||-<l> tFst (tPair A B a b) ≅ a : _ | RA].
+    (RBB : [Γ ||-<l> B[a..] ≅ B'[a'..] | RBa ])
+    (Ra : [Γ ||-<l> a ≅ a' : A | RA])
+    (Rb : [Γ ||-<l> b ≅ b' : _ | RBa ]) :
+    [Γ ||-<l> tFst (tPair A B a b) ≅ tFst (tPair A' B' a' b') : _ | RA].
   Proof.
+    pose proof (LRTyEqRedRight RA RAA).
     escape.
-    eapply redSubstTerm; tea.
-    eapply redtm_fst_beta; tea.
+    eapply redSubstTmEq; tea.
+    1,2: eapply redtm_fst_beta; tea; now eapply ty_conv.
   Qed.
 
-  Lemma pairSndRed {Γ A B a b l}
+  Lemma pairSndRed {Γ A A' B B' a a' b b' l}
     (RA : [Γ ||-<l> A])
+    (RAA : [Γ ||-<l> A ≅ A' | RA])
     (RB : [Γ ,, A ||-<l> B])
-    (RBa : [Γ ||-<l> B[a..]])
+    (RB' : [Γ ,, A' ||-<l> B'])
     (RBfst : [Γ ||-<l> B[(tFst (tPair A B a b))..] ])
-    (RBconv : [Γ ||-<l> B[a..] ≅ B[(tFst (tPair A B a b))..] | RBa ])
-    (Ra : [Γ ||-<l> a : A | RA])
-    (Rb : [Γ ||-<l> b : _ | RBa ]) :
-    [Γ ||-<l> tSnd (tPair A B a b) : _ | RBfst ] × [Γ ||-<l> tSnd (tPair A B a b) ≅ b : _ | RBfst].
+    (RBBfst : [Γ ||-<l> B[(tFst (tPair A B a b))..] ≅ B'[(tFst (tPair A' B' a' b'))..] | RBfst])
+    (RBa : [Γ ||-<l> B[a..]])
+    (RBfsta : [Γ ||-<l> B[a..] ≅ B[(tFst (tPair A B a b))..] | RBa])
+    (RBB : [Γ ||-<l> B[a..] ≅ B'[a'..] | RBa ])
+    (Ra : [Γ ||-<l> a ≅ a' : A | RA])
+    (Rb : [Γ ||-<l> b ≅ b' : _ | RBa ]) :
+    [Γ ||-<l> tSnd (tPair A B a b) ≅ tSnd (tPair A' B' a' b') : _ | RBfst ].
   Proof.
+    pose proof (LRTyEqRedRight RA RAA).
+    (* pose proof (LRTyEqRedRight _ RBBfst). *)
     escape.
-    eapply redSubstTerm; tea.
-    2: eapply redtm_snd_beta; tea.
-    now eapply LRTmRedConv.
+    eapply redSubstTmEq; tea.
+    1: now eapply LRTmEqConv.
+    1,2: eapply redtm_snd_beta; tea; now eapply ty_conv.
   Qed.
 
+  Import SigRedTmEq.
 
-  Lemma pairRed {Γ A B a b l}
+  (* #[program]
+  Definition pairSigRedTm {Γ A B a b l}
     (RΣ0 : [Γ ||-Σ<l> tSig A B])
     (RΣ := normRedΣ0 RΣ0)
     (RA : [Γ ||-<l> A])
     (RBa : [Γ ||-<l> B[a..]])
+    (Ra : [Γ ||-<l> a : A | RA])
+    (Rb : [Γ ||-<l> b : _ | RBa ]) :
+    SigRedTm RΣ (tPair A B a b) := {| nf := tPair A B a b |}.
+  Next Obligation.
+    destruct (polyRedId (normRedΣ0 RΣ0)); escape.
+    eapply redtmwf_refl; cbn; now eapply ty_pair.
+  Qed.
+  Next Obligation.
+    unshelve econstructor; intros; cbn.
+    * irrelevanceCumRefl; now eapply wkTermEq.
+    * eapply reflLRTyEq.
+    * irrelevanceRefl.
+      unshelve eapply (PolyRed.posExt (normRedΣ0 RΣ0)); tea.
+    * irrelevanceCum0.
+      2: now eapply wkTermEq.
+      clear; now bsimpl.
+    Unshelve. all: tea.
+  Qed. *)
+
+  Set Printing Universes.
+
+  Obligation Tactic :=  idtac.
+  #[program]
+   Definition pairSigRedTm@{i j k l} {Γ F G A B a b l}
+    (RΣ0 : ParamRedTy@{i j k l} tSig Γ l (tSig F G))
+    (RΣ := normRedΣ0@{i j k l} RΣ0)
+    (RΣ' := LRSig'@{i j k l} RΣ)
+    (RAB : [_ ||-<l> _ ≅ tSig A B | RΣ'])
+    (Rdom : [LogRel@{i j k l} l | Γ ||- F])
+    (Rcoda : [LogRel@{i j k l} l | Γ ||- G[a..]])
+    (Rcod := snd@{l l} (polyRedId RΣ))
+    (Ra : [Γ ||-<l> a : _ | Rdom])
+    (Rb : [Γ ||-<l> b : _ | Rcoda ])
+    (RA : [_ ||-<l> _ ≅ A | Rdom])
+    (RBa : [_ ||-<l> _ ≅ B[a..] | Rcoda]) :
+     SigRedTm RΣ (tPair A B a b) :=
+  {| nf := tPair A B a b |}.
+  Next Obligation.
+    intros.
+    destruct (polyRedId (normRedΣ0 (invLRΣ (LRTyEqRedRight _ RAB)))).
+    eapply redtmwf_refl; cbn; eapply ty_conv.
+    2: now (symmetry; eapply escapeEq).
+    eapply ty_pair; first [now eapply escape| eapply ty_conv; [now eapply escapeTerm| now eapply escapeEq]].
+  Qed.
+  Next Obligation.
+    unshelve econstructor; intros; cbn.
+      1-3:irrelevanceRefl.
+      * now eapply wkTermEq.
+      * now eapply wkEq.
+      * unshelve eapply (posRedExt (normEqRedΣ _ RAB)); tea; irrelevance.
+      * irrelevance0.
+        2: now eapply wkTermEq.
+        clear; now bsimpl.
+        Unshelve. all: tea.
+  Qed.
+
+   Definition pairSigRedTm0@{i j k l} {Γ A B a b l}
+    (RΣ0 : ParamRedTy@{i j k l} tSig Γ l (tSig A B))
+    (RΣ := normRedΣ0@{i j k l} RΣ0)
+    (RΣ' := LRSig'@{i j k l} RΣ)
+    (RA : [LogRel@{i j k l} l | Γ ||- A])
+    (RBa : [LogRel@{i j k l} l | Γ ||- B[a..]])
+    (* (RBfst : [Γ ||-<l> B[(tFst (tPair A B a b))..] ]) *)
+    (Ra : [Γ ||-<l> a : A | RA])
+    (Rb : [Γ ||-<l> b : _ | RBa ]) :
+     SigRedTm RΣ (tPair A B a b).
+  Proof.
+    unshelve eapply pairSigRedTm; tea; eapply reflLRTyEq.
+  Defined.
+
+  Lemma pairCongRed0 {Γ A A' B B' a a' b b' l}
+    (RΣ0 : [Γ ||-Σ<l> tSig A B])
+    (RΣ := normRedΣ0 RΣ0)
+    (RΣ' := LRSig' RΣ)
+    (RΣeq : [_ ||-<l> _ ≅ tSig A' B' | RΣ'])
+    (RA : [Γ ||-<l> A])
+    (RA' : [Γ ||-<l> A'])
+    (RBa : [Γ ||-<l> B[a..]])
+    (RBconv : [Γ ||-<l> B[a..] ≅ B[(tFst (tPair A B a b))..] | RBa ])
+    (Ra : [Γ ||-<l> a ≅ a' : A | RA])
+    (Rb : [Γ ||-<l> b ≅ b' : _ | RBa ]) :
+    [Γ ||-<l> tPair A B a b ≅ tPair A' B' a' b' : _ | RΣ'].
+  Proof.
+    pose proof (RBa' := polyCodSubstRed RA RΣ _ _ (urefl Ra)).
+    destruct (polyRedId RΣ) as [_ ?].
+    destruct (polyRedId (normRedΣ0 (invLRΣ (LRTyEqRedRight _ RΣeq)))).
+    destruct (polyRedEqId _ (normEqRedΣ _ RΣeq)) as [? ?].
+    assert (RAA' : [RA | _ ||- _ ≅ A']) by irrelevance.
+    epose proof (RBaeq := polyCodSubstExtRed _ RΣ _ _ Ra).
+    epose proof (polyRedEqCodSubstExt _ _ (normEqRedΣ _ RΣeq) _ _ (urefl Ra)).
+    assert (RBBa' : [RBa' | _ ||- _ ≅ B'[a'..]]) by irrelevance.
+    epose proof (polyRedEqCodSubstExt _ _ (normEqRedΣ _ RΣeq) _ _ Ra).
+    cbn in RBaeq.
+    assert (Rb' : [_ ||-<l> b' : _ | RBa']) by (eapply LRTmEqConv; tea; eapply urefl; irrelevance).
+    escape.
+    set (Rpair := pairSigRedTm0 RΣ0 RA RBa (lrefl Ra) (lrefl Rb)).
+    set (Rpair' := pairSigRedTm RΣ0 RΣeq RA RBa' (urefl Ra) Rb' RAA' RBBa').
+    assert [RA | _ ||- tFst (tPair A B a b) ≅ tFst (tPair A' B' a' b') : _].
+    1:{
+     eapply redSubstTmEq; tea.
+      all: eapply redtm_fst_beta; tea; cbn; eapply ty_conv; tea.
+    }
+    unshelve eapply (build_sigRedTmEq' _ Rpair Rpair'); subst Rpair Rpair'; cbn.
+    1: irrelevance.
+    eapply redSubstTmEq.
+    2,3: eapply redtm_snd_beta; tea; now eapply ty_conv.
+    1: now eapply LRTmEqConv.
+    cbn; unshelve eapply escapeEq, (polyRedEqCodSubstExt _ _ (normEqRedΣ _ RΣeq)); tea.
+  Qed.
+
+  (* Lemma pairRed0 {Γ A B a b l}
+    (RΣ0 : [Γ ||-Σ<l> tSig A B])
+    (RΣ := normRedΣ0 RΣ0)
+    (RΣ' := LRSig' RΣ)
+    (RA : [Γ ||-<l> A])
+    (RBa : [Γ ||-<l> B[a..]])
     (RBconv : [Γ ||-<l> B[a..] ≅ B[(tFst (tPair A B a b))..] | RBa ])
     (RBfst : [Γ ||-<l> B[(tFst (tPair A B a b))..] ])
     (Ra : [Γ ||-<l> a : A | RA])
     (Rb : [Γ ||-<l> b : _ | RBa ]) :
-    [Γ ||-<l> tPair A B a b : _ | LRSig' RΣ].
+    [Γ ||-<l> tPair A B a b : _ | RΣ'].
   Proof.
-    destruct (polyRedId RΣ); escape. 
-    unshelve eexists (tPair A B a b) _.
-    + intros ? ρ wfΔ.
-      rewrite wk_fst; irrelevanceRefl; unshelve eapply wkTerm.
-      1:tea. 
-      2: unshelve eapply pairFstRed; tea.
-    + eapply redtmwf_refl; cbn.
-      eapply ty_pair; tea.
-    + unshelve econstructor; cbn; intros.
-      - irrelevance0; [reflexivity|eapply wkTerm].
-        apply Ra.
-        Unshelve. tea.
-      - apply reflLRTyEq.
-      - apply reflLRTyEq.
-      - assert (Hrw : B[a⟨ρ⟩ .: ρ >> tRel] = B[a..]⟨ρ⟩) by now bsimpl.
-        irrelevance0; [symmetry; apply Hrw|eapply wkTerm].
-        apply Rb.
-        Unshelve. tea.
-    + eapply convtm_eta_sig; tea.
-      * now eapply ty_pair.
-      * constructor; tea; (unshelve eapply escapeEq, reflLRTyEq; [|tea]).
-      * now eapply ty_pair.
-      * constructor; tea; (unshelve eapply escapeEq, reflLRTyEq; [|tea]).
-      * enough [Γ |- tFst (tPair A B a b) ≅ a : A].
-        1: transitivity a; tea; now symmetry.
-        eapply convtm_exp.
-        - now eapply redtm_fst_beta.
-        - now eapply redtmwf_refl.
-        - tea.
-        - tea.
-        - tea.
-        - unshelve eapply escapeEq, reflLRTyEq; [|tea].
-        - eapply escapeEqTerm; now eapply reflLRTmEq.
-      * enough [Γ |- tSnd (tPair A B a b) ≅ b : B[(tFst (tPair A B a b))..]].
-        1: transitivity b; tea; now symmetry.
-        eapply convtm_conv; tea.
-        eapply convtm_exp.
-        - eapply redtm_conv; [| now symmetry]; now eapply redtm_snd_beta.
-        - now eapply redtm_refl.
-        - tea.
-        - tea.
-        - tea.
-        - unshelve eapply escapeEq, reflLRTyEq; [|tea].
-        - eapply escapeEqTerm; now eapply reflLRTmEq.
-    + intros ? ρ wfΔ.
-      irrelevance0.
-      2: rewrite wk_snd; eapply wkTerm; now eapply pairSndRed.
-      now rewrite subst_ren_subst_mixed.
-      Unshelve. all: tea.
+    destruct (polyRedId RΣ) as [_ ?]; escape.
+    set (Rpair := pairSigRedTm RΣ0 RA RBa Ra Rb).
+    unshelve eapply (build_sigRedTmEq' _ Rpair Rpair); subst Rpair; cbn.
+    + eapply redSubstTmEq.
+      2,3: now eapply redtm_fst_beta.
+      1: irrelevanceCum.
+      now unshelve eapply escapeEq, reflLRTyEq.
+    + eapply redSubstTmEq.
+      2,3: now eapply redtm_snd_beta.
+      1: now eapply LRTmEqConv.
+      now unshelve eapply escapeEq, reflLRTyEq.
   Qed.
 
-  Lemma isLRPair_isWfPair {Γ A B l p} (wfΓ : [|- Γ]) (ΣA : [Γ ||-Σ<l> tSig A B])
-  (RA : [Γ ||-<l> A])
-  (Rp : [Γ ||-Σ p : _ | normRedΣ0 ΣA]) :
-    isWfPair Γ A B (SigRedTm.nf Rp).
+  Lemma pairRed {Γ A B a b l}
+    (RΣ0 : [Γ ||-Σ<l> tSig A B])
+    (RΣ := normRedΣ0 RΣ0)
+    (RΣ' := LRSig' RΣ)
+    (RA : [Γ ||-<l> A])
+    (RBa : [Γ ||-<l> B[a..]])
+    (Ra : [Γ ||-<l> a : A | RA])
+    (Rb : [Γ ||-<l> b : _ | RBa ]) :
+    [Γ ||-<l> tPair A B a b : _ | RΣ'].
   Proof.
-  destruct Rp; simpl; intros.
-  destruct ispair as [A' B' a b HA HB Ha Hb|]; [|constructor; tea].
-  assert (Hrw : forall A t, t[tRel 0 .: @wk1 Γ A >> tRel] = t).
-  { intros; bsimpl; apply idSubst_term; intros []; reflexivity. }
-  assert (Hrw' : forall a t, t[a .: @wk_id Γ >> tRel] = t[a..]).
-  { intros; now bsimpl. }
-  assert [Γ |-[ ta ] A].
-  { now unshelve eapply escape. }
-  assert [Γ |-[ ta ] A'].
-  { rewrite <- (wk_id_ren_on Γ A'); now unshelve eapply escapeConv, HA. }
-  assert [|-[ ta ] Γ,, A'].
-  { now eapply wfc_cons. }
-  assert [Γ |-[ ta ] A ≅ A'].
-  { rewrite <- (wk_id_ren_on Γ A), <- (wk_id_ren_on Γ A').
-    eapply escapeEq; now unshelve apply HA. }
-  assert (RB :
-    forall (Δ : context) (a : term) (ρ : Δ ≤ Γ) (h : [ |-[ ta ] Δ])
-       (ha : [PolyRedPack.shpRed (normRedΣ0 ΣA) ρ h | Δ ||- a
-             : (ParamRedTyPack.dom (normRedΣ0 ΣA))⟨ρ⟩]),
-     [Δ ||-<l> B[a .: ρ >> tRel]]
-  ).
-  { intros Δ a0 ? ? ha0.
-    unshelve econstructor.
-    + eapply PolyRedPack.posRed, ha0.
-    + eapply PolyRedPack.posAd, PolyRed.toAd. }
-  constructor; tea.
-  - rewrite <- (Hrw A' B); unshelve eapply escape, RB; tea.
-    apply var0conv; cbn; [|tea].
-    rewrite <- (@wk1_ren_on Γ A' A'); apply convty_wk; [tea|now symmetry].
-  - rewrite <- (Hrw A' B'); unshelve eapply escapeConv, HB; tea.
-    apply var0conv; cbn; [|tea].
-    rewrite <- (@wk1_ren_on Γ A' A'); apply convty_wk; [tea|now symmetry].
-  - rewrite <- (Hrw A B'); unshelve eapply escapeConv, HB.
-    + apply wfc_cons; tea.
-    + apply var0; cbn; [now bsimpl|tea].
-  - rewrite <- (Hrw A B), <- (Hrw A B'); unshelve eapply escapeEq, HB.
-    + apply wfc_cons; tea.
-    + apply var0; cbn; [now bsimpl|tea].
-  - rewrite <- (Hrw A' B), <- (Hrw A' B'); unshelve eapply escapeEq, HB.
-    + apply wfc_cons; tea.
-    + apply var0conv; cbn; tea.
-      rewrite <- (@wk1_ren_on Γ A' A'); apply convty_wk; [tea|now symmetry].
-  - rewrite <- (wk_id_ren_on Γ A), <- (wk_id_ren_on Γ a).
-    now unshelve eapply escapeTerm, Ha.
-  - rewrite <- Hrw'.
-    unshelve eapply escape, RB; tea.
-    rewrite <- (wk_id_ren_on Γ a); now unshelve apply Ha.
-  - rewrite <- Hrw'; unshelve eapply escapeConv, HB; tea.
-    rewrite <- (wk_id_ren_on Γ a); now unshelve apply Ha.
-  - rewrite <- !Hrw'; unshelve eapply escapeEq, HB; tea.
-    rewrite <- (wk_id_ren_on Γ a); now unshelve apply Ha.
-  - rewrite <- Hrw', <- (wk_id_ren_on Γ b), <- (wk_id_ren_on Γ a).
-    now unshelve eapply escapeTerm, Hb.
-  Qed.
-
-  Lemma isLRPair_isPair {Γ A B l p} (ΣA : [Γ ||-Σ<l> tSig A B]) (Rp : [Γ ||-Σ p : _ | normRedΣ0 ΣA]) :
-    isPair (SigRedTm.nf Rp).
-  Proof.
-  destruct Rp; simpl; intros.
-  destruct ispair; constructor; tea.
-  now eapply convneu_whne.
-  Qed.
+    assert [_ ||-<l> a ≅ tFst (tPair A B a b) : _ | RA].
+    1:{ symmetry; eapply redSubstLeftTmEq; tea .
+      destruct (polyRedId RΣ) as [_ ?]; escape.
+      now eapply redtm_fst_beta. }
+    eapply pairRed0; tea.
+    + now unshelve now eapply singleSubstEqΣ.
+    + eapply singleSubstΣ1; tea; now symmetry.
+  Qed. *)
 
   Lemma sigEtaRed {Γ A B l p p'}
     (RΣ0 : [Γ ||-Σ<l> tSig A B])
-    (RΣ := LRSig' (normRedΣ0 RΣ0))
+    (RΣn := normRedΣ0 RΣ0)
+    (RΣ := LRSig' RΣn)
     (RA : [Γ ||-<l> A])
     (RBfst : [Γ ||-<l> B[(tFst p)..]])
-    (RBfst' : [Γ ||-<l> B[(tFst p')..]])
     (Rp : [Γ ||-<l> p : _ | RΣ])
-    (Rp' : [Γ ||-<l> p' : _ |  RΣ])
-    (RBfstEq0 : [Γ ||-<l> B[(tFst p)..] ≅ B[(tFst p')..] | RBfst])
-    (RBfstnf : [Γ ||-<l> B[(tFst Rp.(SigRedTm.nf))..]])
-    (RBfstEq : [Γ ||-<l> B[(tFst p)..] ≅ B[(tFst Rp.(SigRedTm.nf))..] | RBfst])
-    (RBfstEq' : [Γ ||-<l> B[(tFst p')..] ≅ B[(tFst Rp'.(SigRedTm.nf))..] | RBfst'])
+    (Rp' : [Γ ||-<l> p' : _ | RΣ])
     (Rfstpp' : [Γ ||-<l> tFst p ≅ tFst p' : _ | RA])
     (Rsndpp' : [Γ ||-<l> tSnd p ≅ tSnd p' : _ | RBfst]) :
     [Γ ||-<l> p ≅ p' : _ | RΣ].
   Proof.
-    exists Rp Rp'.
-    - destruct (polyRedId (normRedΣ0 RΣ0)) as [_ RB].
-      assert ([Γ ||-<l> SigRedTm.nf Rp : _ | RΣ] × [Γ ||-<l> p ≅ SigRedTm.nf Rp : _ | RΣ]) as [Rnf Rpnf].
-      1: eapply (redTmFwdConv Rp (SigRedTm.red Rp)), isPair_whnf, isLRPair_isPair.
-      assert ([Γ ||-<l> SigRedTm.nf Rp' : _ | RΣ]× [Γ ||-<l> p' ≅ SigRedTm.nf Rp' : _ | RΣ]) as [Rnf' Rpnf'].
-      1: eapply (redTmFwdConv Rp' (SigRedTm.red Rp')), isPair_whnf, isLRPair_isPair.
-      destruct (fstRed RΣ0 RA Rp) as [[Rfstp Rfsteq] Rfstnf].
-      destruct (fstRed RΣ0 RA Rp') as [[Rfstp' Rfsteq'] Rfstnf'].
-      destruct (sndRed RΣ0 RA Rp RBfst RBfstEq).
-      destruct (sndRed RΣ0 RA Rp' RBfst' RBfstEq').
-      escape.
-      assert [|- Γ] by now eapply wfc_wft.
-      eapply convtm_eta_sig; tea.
-      1, 2: now eapply isLRPair_isWfPair.
-      + transitivity (tFst p).
-        1: now symmetry.
-        transitivity (tFst p'); tea.
-      + eapply convtm_conv; tea.
-        transitivity (tSnd p).
-        1: now symmetry.
-        transitivity (tSnd p'); tea.
-        eapply convtm_conv; tea.
-        now symmetry.
-    - intros; do 2 rewrite wk_fst. 
-      irrelevanceRefl. eapply wkTermEq.
-      destruct (fstRed RΣ0 RA Rp) as [[Rfstp Rfsteq] Rfstnf].
-      destruct (fstRed RΣ0 RA Rp') as [[Rfstp' Rfsteq'] Rfstnf'].
-      eapply transEqTerm; tea.
-      eapply transEqTerm; tea.
-      now eapply LRTmEqSym.
-      Unshelve. tea.
-    - intros. do 2 rewrite wk_snd.
-      eapply LRTmEqRedConv.
-      2:{
-        eapply wkTermEq. 
-        destruct (sndRed RΣ0 RA Rp RBfst RBfstEq).
-        destruct (sndRed RΣ0 RA Rp' RBfst' RBfstEq').
-        eapply transEqTerm; tea.
-        eapply LRTmEqRedConv; tea.
-        eapply transEqTerm; tea.
-        now eapply LRTmEqSym.
-        Unshelve. tea.
-      }
-      rewrite wk_fst, <- subst_ren_subst_mixed.
-      eapply wkEq. cbn.
-      eapply LRTyEqSym.
-      eapply transEq; tea.
-      now eapply LRTyEqSym.
-      Unshelve. tea.
+    assert (RBfst' : [Γ ||-<l> B[(tFst p')..]]).
+    1: eapply singleSubstΣ1; tea; now symmetry.
+    pose proof (Rpnf := sigRedTmEqNf _ Rp).
+    pose proof (Rpnf' := sigRedTmEqNf _ Rp').
+    pose proof (fstRed _ RA Rpnf).
+    pose proof (fstRed _ RA Rpnf').
+    unshelve eapply (build_sigRedTmEq' _ Rp.(redL) Rp'.(redL)).
+    - transitivity (tFst p); [symmetry|transitivity (tFst p')]; irrelevance.
+    - pose proof (sndRed _ RA Rpnf RBfst).
+      pose proof (sndRed _ RA Rpnf' RBfst').
+      unshelve (eapply LRTmEqConv; [cbn; now unshelve now eapply singleSubstEqΣ|]); tea.
+      transitivity (tSnd p); [symmetry |transitivity (tSnd p')].
+      1,2: irrelevance.
+      eapply LRTmEqConv; tea.
+      now unshelve (eapply singleSubstEqΣ; now symmetry).
   Qed.
+
+
 
   Lemma subst_sig {A B σ} : (tSig A B)[σ] = (tSig A[σ] B[up_term_term σ]).
   Proof. reflexivity. Qed.
 
   Lemma subst_pair {A B a b σ} : (tPair A B a b)[σ] = (tPair A[σ] B[up_term_term σ] a[σ] b[σ]).
   Proof. reflexivity. Qed.
-  
-  Lemma subst_fst {p σ} : (tFst p)[σ] = tFst p[σ].
-  Proof. reflexivity. Qed.
-  
+
   Lemma subst_snd {p σ} : (tSnd p)[σ] = tSnd p[σ].
   Proof. reflexivity. Qed.
-  
-  Lemma pairFstRedEq {Γ A A' B B' a a' b b' l}
-    (RA : [Γ ||-<l> A])
-    (RA' : [Γ ||-<l> A'])
-    (RAA' :[Γ ||-<l> A ≅ A' | RA])
-    (RB : [Γ ,, A ||-<l> B])
-    (RB' : [Γ ,, A' ||-<l> B'])
-    (RBa : [Γ ||-<l> B[a..]])
-    (RBa' : [Γ ||-<l> B'[a'..]])
-    (Ra : [Γ ||-<l> a : A | RA])
-    (Ra' : [Γ ||-<l> a' : A' | RA'])
-    (Raa' : [Γ ||-<l> a ≅ a' : A | RA])
-    (Rb : [Γ ||-<l> b : _ | RBa ])
-    (Rb' : [Γ ||-<l> b' : _ | RBa' ]) :
-    [Γ ||-<l> tFst (tPair A B a b) ≅ tFst (tPair A' B' a' b') : _ | RA].
-  Proof.
-    destruct (pairFstRed RA RB RBa Ra Rb).
-    destruct (pairFstRed RA' RB' RBa' Ra' Rb').
-    eapply transEqTerm; tea.
-    eapply transEqTerm; tea.
-    eapply LRTmEqRedConv.
-    + now eapply LRTyEqSym.
-    + now eapply LRTmEqSym.
-  Qed.
-  
-  Lemma pairSndRedEq {Γ A A' B B' a a' b b' l}
-    (RA : [Γ ||-<l> A])
-    (RA' : [Γ ||-<l> A'])
-    (RAA' :[Γ ||-<l> A ≅ A' | RA])
-    (RB : [Γ ,, A ||-<l> B])
-    (RB' : [Γ ,, A' ||-<l> B'])
-    (RBa : [Γ ||-<l> B[a..]])
-    (RBa' : [Γ ||-<l> B'[a'..]])
-    (RBaBa' : [Γ ||-<l> B[a..] ≅ B'[a'..] | RBa ])
-    (RBfst : [Γ ||-<l> B[(tFst (tPair A B a b))..] ])
-    (RBconv : [Γ ||-<l> B[a..] ≅ B[(tFst (tPair A B a b))..] | RBa ])
-    (RBfst' : [Γ ||-<l> B'[(tFst (tPair A' B' a' b'))..] ])
-    (RBconv' : [Γ ||-<l> B'[a'..] ≅ B'[(tFst (tPair A' B' a' b'))..] | RBa' ])
-    (Ra : [Γ ||-<l> a : A | RA])
-    (Ra' : [Γ ||-<l> a' : A' | RA'])
-    (Rb : [Γ ||-<l> b : _ | RBa ])
-    (Rb' : [Γ ||-<l> b' : _ | RBa' ]) 
-    (Rbb' : [Γ ||-<l> b ≅ b' : _ | RBa]) :
-    [Γ ||-<l> tSnd (tPair A B a b) ≅ tSnd (tPair A' B' a' b') : _ | RBfst].
-  Proof.
-    destruct (pairSndRed RA RB RBa RBfst RBconv Ra Rb).
-    destruct (pairSndRed RA' RB' RBa' RBfst' RBconv' Ra' Rb').
-    eapply transEqTerm; tea.
-    eapply LRTmEqRedConv; tea.
-    eapply transEqTerm; tea.
-    eapply LRTmEqRedConv; cycle 1.
-    + now eapply LRTmEqSym.
-    + eapply LRTyEqSym; eapply transEq; cycle 1; tea.
-  Qed.
 
+  Lemma up_subst_single' t a σ : t[up_term_term σ][(a[σ])..] = t[a..][σ].
+  Proof. now bsimpl. Qed.
+
+  Lemma pairFstValid0 {Γ A B a b l}
+    (VΓ : [||-v Γ])
+    (VA : [ Γ ||-v<l> A | VΓ ])
+    (VB : [ Γ ,, A ||-v<l> B | validSnoc VΓ VA])
+    (VΣ := SigValid VΓ VA VB)
+    (Va : [Γ ||-v<l> a : A | VΓ | VA])
+    (VBa := substS VB Va)
+    (Vb : [Γ ||-v<l> b : B[a..] | VΓ | VBa]) :
+    [Γ ||-v<l> tFst (tPair A B a b) ≅ a : _ | VΓ | VA].
+  Proof.
+    eapply redSubstValid; tea.
+    constructor; intros; rewrite <-subst_fst, subst_pair.
+    instValid Vσσ'; instValid (liftSubstEq' VA Vσσ'); escape.
+    eapply redtm_fst_beta; tea.
+    now rewrite up_subst_single'.
+  Qed.
 
   Lemma pairFstValid {Γ A B a b l}
     (VΓ : [||-v Γ])
@@ -766,31 +683,34 @@ Section PairRed.
     [Γ ||-v<l> tFst (tPair A B a b) : _ | VΓ | VA] ×
     [Γ ||-v<l> tFst (tPair A B a b) ≅ a : _ | VΓ | VA].
   Proof.
-    assert (h : forall {Δ σ} (wfΔ : [|-  Δ]) (Vσ : [VΓ | Δ ||-v σ : Γ | wfΔ]),
-      [validTy VA wfΔ Vσ | Δ ||- (tFst (tPair A B a b))[σ] : A[σ]] ×
-      [validTy VA wfΔ Vσ | Δ ||- (tFst (tPair A B a b))[σ] ≅ a[σ] : A[σ]]).
-    1:{
-      intros ?? wfΔ Vσ; instValid Vσ.
-      pose (RVΣ0 := normRedΣ0 (invLRΣ RVΣ)).
-      pose (RVB := snd (polyRedId RVΣ0)).
-      unshelve eapply pairFstRed; tea; fold subst_term.
-      + now rewrite <- singleSubstComm'.
-      + irrelevance0; tea; now rewrite singleSubstComm'.
-    }
-    split; unshelve econstructor.
-    - apply h.
-    - intros ??? wfΔ Vσ Vσ' Vσσ'.
-      instAllValid Vσ Vσ' Vσσ'. 
-      pose (RΣ := normRedΣ0 (invLRΣ RVΣ));
-      pose (RΣ' := normRedΣ0 (invLRΣ RVΣ0)); fold subst_term in *.
-      pose (RVB := snd (polyRedId RΣ)).
-      pose (RVB' := snd (polyRedId RΣ')).
-      unshelve eapply pairFstRedEq; tea; fold subst_term.
-      1,2: now rewrite <- singleSubstComm'.
-      all: irrelevance0; tea; now rewrite singleSubstComm'.
-    - apply h.
+    split; [eapply lreflValidTm|]; now eapply pairFstValid0.
   Qed.
-  
+
+  Lemma pairSndValid0 {Γ A B a b l}
+    (VΓ : [||-v Γ])
+    (VA : [ Γ ||-v<l> A | VΓ ])
+    (VB : [ Γ ,, A ||-v<l> B | validSnoc VΓ VA])
+    (VΣ := SigValid VΓ VA VB)
+    (Va : [Γ ||-v<l> a : A | VΓ | VA])
+    (VBa := substS VB Va)
+    (Vb : [Γ ||-v<l> b : B[a..] | VΓ | VBa])
+    (Vfstall := pairFstValid VΓ VA VB Va Vb)
+    (VBfst := substS VB (fst Vfstall)) :
+    [Γ ||-v<l> tSnd (tPair A B a b) ≅ b : _ | VΓ | VBfst].
+  Proof.
+    eapply redSubstValid; cycle 1.
+    + eapply conv; tea.
+      pose proof (h := symValidTmEq (pairFstValid0 VΓ VA VB Va Vb)).
+      epose proof (substSEq (reflValidTy VA) (reflValidTy VB) h).
+      irrValid.
+    + constructor; intros.
+      rewrite <-up_subst_single', subst_snd, <-subst_fst, subst_pair.
+      instValid Vσσ'; instValid (liftSubstEq' VA Vσσ'); escape.
+      eapply redtm_snd_beta; tea.
+      now rewrite up_subst_single'.
+  Qed.
+
+
   Lemma pairSndValid {Γ A B a b l}
     (VΓ : [||-v Γ])
     (VA : [ Γ ||-v<l> A | VΓ ])
@@ -804,41 +724,8 @@ Section PairRed.
     [Γ ||-v<l> tSnd (tPair A B a b) : _ | VΓ | VBfst] ×
     [Γ ||-v<l> tSnd (tPair A B a b) ≅ b : _ | VΓ | VBfst].
   Proof.
-    pose proof (VBfsteq := substSEq (reflValidTy _ VA) VB (reflValidTy _ VB) Va (fst Vfstall) (symValidTmEq (snd (Vfstall)))).
-    cbn in VBfsteq.
-    assert (h : forall {Δ σ} (wfΔ : [|-  Δ]) (Vσ : [VΓ | Δ ||-v σ : Γ | wfΔ]),
-      [validTy VBfst wfΔ Vσ | Δ ||- (tSnd (tPair A B a b))[σ] : _ ] ×
-      [validTy VBfst wfΔ Vσ | Δ ||- (tSnd (tPair A B a b))[σ] ≅ b[σ] : _ ]).
-    1:{
-      intros ?? wfΔ Vσ ; instValid Vσ.
-      pose (RVΣ0 := normRedΣ0 (invLRΣ RVΣ)).
-      pose (RVB := snd (polyRedId RVΣ0)); fold subst_term in *.
-      irrelevance0. 1: now rewrite singleSubstComm'.
-      unshelve eapply pairSndRed; tea; fold subst_term.
-      + now rewrite <- singleSubstComm'.
-      + rewrite <- subst_pair, <- subst_fst; irrelevance0;
-        rewrite <- singleSubstComm'; tea; reflexivity.
-        Unshelve. now rewrite <- singleSubstComm'.
-      + irrelevance0; tea; now rewrite <- singleSubstComm'.
-    }
-    split; unshelve econstructor.
-    - apply h.
-    - intros ??? wfΔ Vσ Vσ' Vσσ' ; instAllValid Vσ Vσ' Vσσ'.
-      pose (RΣ := normRedΣ0 (invLRΣ RVΣ)).
-      pose (RΣ' := normRedΣ0 (invLRΣ RVΣ0)).
-      pose (RB := snd (polyRedId RΣ)); 
-      pose (RB' := snd (polyRedId RΣ')); fold subst_term in *.
-      irrelevance0. 1: now rewrite singleSubstComm'.
-      unshelve eapply pairSndRedEq; tea; fold subst_term.
-      1,2: now rewrite <- singleSubstComm'.
-      all: try (irrelevance0; tea; now rewrite <- singleSubstComm').
-      all: rewrite <- subst_pair, <- subst_fst.
-      2: rewrite <- singleSubstComm'; tea.
-      all: irrelevance0; rewrite <- singleSubstComm'; try reflexivity; tea.
-      Unshelve. now rewrite <- singleSubstComm'.
-    - apply h.
+    split; [eapply lreflValidTm|]; now eapply pairSndValid0.
   Qed.
-
 
   Lemma pairValid {Γ A B a b l}
     (VΓ : [||-v Γ])
@@ -850,87 +737,17 @@ Section PairRed.
     (Vb : [Γ ||-v<l> b : B[a..] | VΓ | VBa]) :
     [Γ ||-v<l> tPair A B a b : _ | VΓ | VΣ].
   Proof.
-    destruct (pairFstValid VΓ VA VB Va Vb) as [Vfst Vfsteq].
-    destruct (pairSndValid VΓ VA VB Va Vb) as [Vsnd Vsndeq].
-    pose proof (VBfst := substS VB Vfst).
-    pose proof (VBfsteq := substSEq (reflValidTy _ VA) VB (reflValidTy _ VB) Va Vfst (symValidTmEq Vfsteq)).
-    cbn in VBfsteq.
-    assert (pairSubstRed : forall (Δ : context) (σ : nat -> term) (wfΔ : [ |-[ ta ] Δ])
-      (Vσ : [VΓ | Δ ||-v σ : Γ | wfΔ]),
-      [Δ ||-<l> (tPair A B a b)[σ] : (tSig A B)[σ] | validTy VΣ wfΔ Vσ]).
-    1:{
-      intros ?? wfΔ Vσ.
-      instValid Vσ; instValidExt Vσ (reflSubst _ _ Vσ).
-      pose (RVΣ0 := normRedΣ0 (invLRΣ RVΣ)).
-      pose (RVB := snd (polyRedId RVΣ0)); fold subst_term in *.
-      pose (Vaσ := consSubstSvalid Vσ Va); instValid Vaσ.
-      rewrite <- up_subst_single in RVB0.
-      assert (RVb' : [RVB0 | Δ ||- b[σ] : B[up_term_term σ][(a[σ])..]])
-        by (irrelevance0; tea; apply  singleSubstComm').
-      unshelve epose (p := pairFstRed RVA RVB RVB0 RVa RVb').
-      destruct p as [Rfst Rfsteq%LRTmEqSym].
-      pose proof (Vfstσ := consSubstS _ _ Vσ VA Rfst).
-      epose proof (Veqσ := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VA RVa Rfsteq).
-      instValid Vfstσ; instValidExt Vfstσ Veqσ.
-      unshelve epose (pairRed RVΣ0 RVA RVB0 _ _ RVa RVb'); fold subst_term in *.
-      3: irrelevance.
-      + rewrite <- up_subst_single in REVB.
-        irrelevance0; tea; now rewrite up_subst_single.
-      + now rewrite <- up_subst_single in RVB1.
-    }
-    unshelve econstructor.
-    1: intros; now eapply pairSubstRed.
-    intros ??? wfΔ Vσ Vσ' Vσσ'.
-    instAllValid Vσ Vσ' Vσσ'.
-    set (p := _[_]); set (p' := _[_]).
-    pose (RΣ := normRedΣ RVΣ); pose (RΣ' := normRedΣ RVΣ0); fold subst_term in *.
-    pose proof (Rp0 := pairSubstRed _ _ wfΔ Vσ).
-    pose proof (Rp0' := pairSubstRed _ _ wfΔ Vσ').
-    assert (Rp : [Δ ||-<l> p : _ | RΣ]) by irrelevance.
-    assert (Rp' : [Δ ||-<l> p' : _ | RΣ]).
-    1: eapply LRTmRedConv; [|exact (pairSubstRed _ _ wfΔ Vσ')]; now eapply LRTyEqSym.
-    irrelevance0.
-    1: symmetry; apply subst_sig.
-    destruct (fstRed (invLRΣ RVΣ) RVA Rp) as [[Rfstp Rfsteq] Rfstnf].
-    destruct (fstRed (invLRΣ RVΣ) RVA Rp') as [[Rfstp' Rfsteq'] Rfstnf'].
-    pose (Vfstpσ := consSubstS _ _ Vσ VA Rfstp).
-    pose (Vfstnfσ := consSubstS _ _ Vσ VA Rfstnf).
-    pose proof (Vfsteqσ := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VA Rfstp Rfsteq).
-    epose (Vfstpσ' := consSubstS _ _ Vσ VA Rfstp').
-    pose (Vfstnfσ' := consSubstS _ _ Vσ VA Rfstnf').
-    pose proof (Vfsteqσ' := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VA Rfstp' Rfsteq').
-    pose (Vuσ := liftSubstS' VA Vσ).
-    pose (Vuσ' := liftSubstS' VA Vσ').
-    pose (Vurσ' := liftSubstSrealign' VA Vσσ' Vσ').
-    instValid Vuσ; instValid Vuσ'; instValid Vurσ'.
-    assert(Rfstpp' : [RVA | Δ ||- tFst p ≅ tFst p' : A[σ]]). 
-    1:{
-      eapply pairFstRedEq; tea; irrelevance0; tea; fold subst_term.
-      1,2: now rewrite singleSubstComm'.
-      Unshelve. all: fold subst_term. 
-      2: tea.
-      1,2: now rewrite <- singleSubstComm'.
-    }
-    pose proof (Vfstppσ := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VA Rfstp Rfstpp').
-    instAllValid Vfstpσ Vfstnfσ Vfsteqσ.
-    instAllValid Vfstpσ' Vfstnfσ' Vfsteqσ'.
-    instValidExt Vfstpσ' Vfstppσ.
-    rewrite <- up_subst_single in RVB2.
-    rewrite <- up_subst_single in RVB3, REVB.
-    rewrite <- up_subst_single in RVB4.
-    rewrite <- up_subst_single in RVB5, REVB0.
-    rewrite <- up_subst_single in REVB1.
-    eapply (sigEtaRed _ RVA RVB2 RVB4 Rp Rp');tea.
-    + irrelevance0; tea; now rewrite up_subst_single.
-    + irrelevance0; tea; now rewrite up_subst_single.
-    + irrelevance0; tea; now rewrite up_subst_single.
-    + unshelve eapply pairSndRedEq; tea; fold subst_term.
-      7-9: irrelevance0; tea; now rewrite singleSubstComm'.
-      1,2: now rewrite <- singleSubstComm'.
-      1: irrelevance0; fold subst_term; now rewrite <- singleSubstComm'.
-      2: rewrite <- subst_pair, <- subst_fst, <- singleSubstComm'; tea.
-      all: rewrite <- subst_pair, <- subst_fst; irrelevance0; 
-        rewrite <- singleSubstComm'; try reflexivity; tea.
+    constructor; intros; rewrite 2!subst_pair.
+    instValid Vσσ'; instValid (liftSubstEq' VA Vσσ').
+    irrelevance0; [now rewrite subst_sig|].
+    eapply pairCongRed0; tea.
+    + irrelevance.
+    + rewrite <-subst_pair, subst_fst, up_subst_single'; irrelevance0; [now rewrite up_subst_single'|].
+      eapply (validTyEq (substSEq (reflValidTy VA) (reflValidTy VB) (symValidTmEq (pairFstValid0 VΓ VA VB Va Vb))) _ (lrefl Vσσ')).
+    + irrelevance.
+    Unshelve.
+    1:  rewrite <-subst_sig; now apply invLRΣ.
+    now rewrite up_subst_single'.
   Qed.
 
   Lemma sigEtaValid {Γ A B p p' l}
@@ -946,36 +763,17 @@ Section PairRed.
     (Vsndpp' : [Γ ||-v<l> tSnd p ≅ tSnd p' : _| VΓ | VBfst]) :
     [Γ ||-v<l> p ≅ p' : _ | VΓ | VΣ].
   Proof.
-    pose proof (Vfst' := fstValid VΓ VA VB Vp').
-    pose proof (VBfst' := substS VB Vfst').
-    pose proof (VBfsteq := substSEq (reflValidTy _ VA) VB (reflValidTy _ VB) Vfst Vfst' Vfstpp').
-    cbn in VBfsteq.
-    constructor; intros ?? wfΔ Vσ; instValid Vσ.
-    pose proof (RΣ0 := invLRΣ RVΣ).
-    pose (RΣ := LRSig' (normRedΣ0 RΣ0)).
-    fold subst_term in *.
-    assert (Rp : [Δ ||-<l> p[σ] : _ | RΣ]) by irrelevance.
-    assert (Rp' : [Δ ||-<l> p'[σ] : _ | RΣ]) by irrelevance.
-    destruct (fstRed RΣ0 RVA Rp) as [[Rfstp Rfsteq] Rfstnf].
-    destruct (fstRed RΣ0 RVA Rp') as [[Rfstp' Rfsteq'] Rfstnf'].
-    pose (Vfstpσ := consSubstS _ _ Vσ VA Rfstp).
-    pose (Vfstnfσ := consSubstS _ _ Vσ VA Rfstnf).
-    pose proof (Vfsteqσ := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VA Rfstp Rfsteq).
-    epose (Vfstpσ' := consSubstS _ _ Vσ VA Rfstp').
-    pose (Vfstnfσ' := consSubstS _ _ Vσ VA Rfstnf').
-    pose proof (Vfsteqσ' := consSubstSEq' _ _ Vσ (reflSubst _ _ Vσ) VA Rfstp' Rfsteq').
-    instAllValid Vfstpσ Vfstnfσ Vfsteqσ.
-    instAllValid Vfstpσ' Vfstnfσ' Vfsteqσ'.
-    irrelevance0.
-    1: now rewrite subst_sig.
-    unshelve eapply (sigEtaRed RΣ0 RVA _ _ Rp Rp') ; tea.
-    1,2: rewrite <- subst_fst,<- singleSubstComm'; tea.
-    + irrelevance0; rewrite <- subst_fst, <- singleSubstComm'; try reflexivity; tea.
-    + now rewrite up_subst_single.
-    + irrelevance0; rewrite up_subst_single; try reflexivity; tea.
-    + irrelevance0; rewrite up_subst_single; try reflexivity; tea.
-    + irrelevance0. 1: now rewrite <- subst_fst, <- singleSubstComm'. tea.
-  Qed. 
+    constructor; intros.
+    instValid Vσσ'.
+    irrelevance0; [now rewrite subst_sig|].
+    eapply sigEtaRed; try irrelevance.
+    + eapply lrefl; irrelevance.
+    + eapply urefl; irrelevance.
+    Unshelve.
+    2: rewrite <- subst_sig; now apply invLRΣ.
+    1: tea.
+    now rewrite subst_fst, up_subst_single'.
+  Qed.
 
 End PairRed.
 

--- a/theories/Substitution/Introductions/Sigma.v
+++ b/theories/Substitution/Introductions/Sigma.v
@@ -1,8 +1,8 @@
 From Coq Require Import ssrbool CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
-From LogRel.LogicalRelation Require Import Induction Escape Irrelevance Reflexivity Irrelevance Weakening Neutral Transitivity Reduction Application Universe EqRedRight SimpleArr NormalRed InstKripke.
-From LogRel.Substitution Require Import Irrelevance Properties Conversion SingleSubst Reflexivity Reduction SingleSubst.
+From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Irrelevance Weakening Neutral Transitivity Reduction Application Universe EqRedRight SimpleArr NormalRed InstKripke.
+From LogRel.Substitution Require Import Irrelevance Properties Conversion SingleSubst Reflexivity Reduction.
 From LogRel.Substitution.Introductions Require Import Universe Poly.
 
 

--- a/theories/Substitution/Introductions/SimpleArr.v
+++ b/theories/Substitution/Introductions/SimpleArr.v
@@ -2,7 +2,7 @@ From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening
   GenericTyping LogicalRelation Validity.
 From LogRel.LogicalRelation Require Import Escape Reflexivity Neutral Weakening Irrelevance.
-From LogRel.Substitution Require Import Irrelevance Properties Conversion.
+From LogRel.Substitution Require Import Irrelevance Properties Conversion Reflexivity.
 From LogRel.Substitution.Introductions Require Import Universe Pi Application Lambda Var.
 
 Set Universe Polymorphism.
@@ -56,56 +56,6 @@ Section SimpleArrValidity.
     2: eapply appValid; tea.
     now bsimpl.
   Unshelve. all: tea.
-  Qed.
-
-  Lemma simple_idValid {Γ A l}
-    (VΓ : [||-v Γ])
-    {VF : [Γ ||-v<l> A | VΓ]}
-    (VΠ : [Γ ||-v<l> arr A A | VΓ]) :
-    [Γ ||-v<l> idterm A : arr A A | _ | VΠ].
-  Proof.
-    eapply irrelevanceTm'.
-    2: unshelve eapply lamValid.
-    5: unshelve eapply var0Valid.
-    - now rewrite wk1_ren_on.
-    - tea.
-  Qed.
-
-  Lemma simple_compValid {Γ A B C f g l}
-    (VΓ : [||-v Γ])
-    {VA : [Γ ||-v<l> A | VΓ]}
-    (VB : [Γ ||-v<l> B | VΓ])
-    (VC : [Γ ||-v<l> C | VΓ])
-    (VAB : [Γ ||-v<l> arr A B | VΓ])
-    (VBC : [Γ ||-v<l> arr B C | VΓ])
-    (VAC : [Γ ||-v<l> arr A C | VΓ])
-    (Vf : [Γ ||-v<l> f : arr A B | _ | VAB])
-    (Vg : [Γ ||-v<l> g : arr B C | _ | VBC]) :
-    [Γ ||-v<l> comp A g f : arr A C | _ | VAC].
-  Proof.
-    eapply irrelevanceTm'.
-    2: unshelve eapply lamValid.
-    5: unshelve eapply simple_appValid.
-    9: unshelve eapply simple_appValid.
-    13: eapply var0Valid.
-    4: eapply wk1ValidTy; exact VC.
-    4: eapply wk1ValidTy; exact VB.
-    - now rewrite wk1_ren_on.
-    - eassumption.
-    - do 2 erewrite wk1_ren_on. rewrite<- arr_ren1.
-      erewrite<- wk1_ren_on.
-      now eapply wk1ValidTy.
-    - eapply irrelevanceTm'. 2: erewrite<- wk1_ren_on;now eapply wk1ValidTm.
-      rewrite wk1_ren_on. rewrite arr_ren1.
-      do 2 rewrite wk1_ren_on. reflexivity.
-    - do 2 erewrite wk1_ren_on. rewrite<- arr_ren1.
-      erewrite<- wk1_ren_on.
-      now eapply wk1ValidTy.
-    - eapply irrelevanceTm'. 2: erewrite<- wk1_ren_on;now eapply wk1ValidTm.
-      rewrite wk1_ren_on. rewrite arr_ren1.
-      do 2 rewrite wk1_ren_on. reflexivity.
-
-      Unshelve. all: tea.
   Qed.
 
 End SimpleArrValidity.

--- a/theories/Substitution/Introductions/Universe.v
+++ b/theories/Substitution/Introductions/Universe.v
@@ -23,7 +23,7 @@ Lemma univValid {A l l'} (VΓ : [||-v Γ])
 Proof.
   unshelve econstructor; intros.
   - instValid vσ. now eapply UnivEq.
-  - instAllValid vσ vσ' vσσ'; now eapply UnivEqEq.
+  - instValid  vσσ'; now eapply UnivEqEq.
 Qed.
 
 Lemma univEqValid {A B l l'} (VΓ : [||-v Γ])
@@ -32,7 +32,7 @@ Lemma univEqValid {A B l l'} (VΓ : [||-v Γ])
   (VAB : [Γ ||-v<l'> A ≅ B : U | VΓ | VU]) :
   [Γ ||-v<l> A ≅ B | VΓ | VA].
 Proof.
-  constructor; intros; instValid Vσ.
+  constructor; intros; instValid Vσσ'.
   now eapply UnivEqEq.
 Qed.
 

--- a/theories/Substitution/Introductions/Universe.v
+++ b/theories/Substitution/Introductions/Universe.v
@@ -11,8 +11,7 @@ Context `{GenericTypingProperties} {Γ : context}.
 Lemma UValid (VΓ : [||-v Γ]) : [Γ ||-v<one> U | VΓ].
 Proof.
   unshelve econstructor; intros.
-  - eapply LRU_; econstructor; tea; [constructor|].
-    cbn; eapply redtywf_refl; gen_typing.
+  - now eapply LRU_, redUOneCtx.
   - cbn; constructor; eapply redtywf_refl; gen_typing.
 Defined.
 

--- a/theories/Substitution/Introductions/Var.v
+++ b/theories/Substitution/Introductions/Var.v
@@ -10,22 +10,18 @@ Set Printing Primitive Projection Parameters.
 
 Section Var.
   Context `{GenericTypingProperties}.
-  
+
   Lemma var0Valid {Γ l A} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) :
     [Γ,, A ||-v<l> tRel 0 : _ | validSnoc VΓ VA | wk1ValidTy _ VA ].
   Proof.
-    constructor; intros; cbn.
-    + epose (validHead Vσ); irrelevance.
-    + epose (eqHead Vσσ'); irrelevance.
+    constructor; intros; cbn; epose (eqHead Vσσ'); irrelevance.
   Qed.
-  
+
   Lemma var0Valid' {Γ l A} (VΓ : [||-v Γ,,A]) (VA : [Γ,,A ||-v<l> A⟨↑⟩ | VΓ]) :
     [Γ,, A ||-v<l> tRel 0 : _ | VΓ | VA ].
   Proof.
     pose proof (invValiditySnoc VΓ) as [? [? [? ]]]; subst.
-    constructor; intros; cbn.
-    + epose (validHead Vσ); irrelevance.
-    + epose (eqHead Vσσ'); irrelevance.
+    constructor; intros; cbn; epose (eqHead Vσσ'); irrelevance.
   Qed.
 
   Lemma in_ctx_valid {Γ A n} (hin : in_ctx Γ n A) : forall (VΓ : [||-v Γ]), ∑ l, [Γ ||-v<l> A | VΓ].
@@ -48,11 +44,11 @@ Section Var.
     eapply irrelevanceTm'; tea.
     now rewrite wk1_ren_on.
   Qed.
-  
+
   Lemma var1Valid {Γ l A B} (VΓ : [||-v (Γ,, A) ,, B]) (VA : [_ ||-v<l> A⟨↑⟩⟨↑⟩ | VΓ]) :
     [(Γ,, A) ,, B ||-v<l> tRel 1 : _ | VΓ | VA ].
   Proof.
     eapply varnValid; do 2 constructor.
   Qed.
-  
+
 End Var.

--- a/theories/Substitution/Irrelevance.v
+++ b/theories/Substitution/Irrelevance.v
@@ -142,8 +142,8 @@ Proof.
   - intros ???? [??]. eapply VAext.
 Qed.
 
-Lemma irrelevanceTyEq {Γ l A B} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) (VA' : [Γ||-v<l> A | VΓ']) :
-  [Γ ||-v< l > A ≅ B | VΓ | VA] -> [Γ ||-v< l > A ≅ B | VΓ' | VA'].
+Lemma irrelevanceTyEq {Γ l l' A B} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) (VA' : [Γ||-v<l'> A | VΓ']) :
+  [Γ ||-v< l > A ≅ B | VΓ | VA] -> [Γ ||-v< l' > A ≅ B | VΓ' | VA'].
 Proof.
   intros [h]; constructor; intros.
   irrelevanceRefl.
@@ -157,17 +157,17 @@ Proof.
   intros ->; now eapply irrelevanceTyEq.
 Qed.
 
-Lemma symValidTyEq {Γ l A B} {VΓ : [||-v Γ]} {VA : [Γ ||-v<l> A | VΓ]} (VB : [Γ ||-v<l> B | VΓ]) :
-  [Γ ||-v<l> A ≅ B | VΓ | VA] -> [Γ ||-v<l> B ≅ A | VΓ | VB].
+Lemma symValidTyEq {Γ l l' A B} {VΓ : [||-v Γ]} {VA : [Γ ||-v<l> A | VΓ]} (VB : [Γ ||-v<l'> B | VΓ]) :
+  [Γ ||-v<l> A ≅ B | VΓ | VA] -> [Γ ||-v<l'> B ≅ A | VΓ | VB].
 Proof.
   intros; constructor; intros.
   eapply LRTyEqSym; now eapply validTyEq.
   Unshelve. 1:tea. now symmetry.
 Qed.
 
-Lemma transValidTyEq {Γ l A B C} {VΓ : [||-v Γ]}
-  {VA : [Γ ||-v<l> A | VΓ]} {VB : [Γ ||-v<l> B | VΓ]} :
-  [Γ ||-v<l> A ≅ B | VΓ | VA] -> [Γ ||-v<l> B ≅ C | VΓ | VB] -> [Γ ||-v<l> A ≅ C | VΓ | VA].
+Lemma transValidTyEq {Γ l l' A B C} {VΓ : [||-v Γ]}
+  {VA : [Γ ||-v<l> A | VΓ]} {VB : [Γ ||-v<l'> B | VΓ]} :
+  [Γ ||-v<l> A ≅ B | VΓ | VA] -> [Γ ||-v<l'> B ≅ C | VΓ | VB] -> [Γ ||-v<l> A ≅ C | VΓ | VA].
 Proof.
   constructor; intros; eapply LRTransEq; now eapply validTyEq.
   Unshelve. 1: tea. now eapply urefl.

--- a/theories/Substitution/Irrelevance.v
+++ b/theories/Substitution/Irrelevance.v
@@ -1,4 +1,5 @@
 
+From Coq Require Import CRelationClasses.
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
 From LogRel.LogicalRelation Require Import Irrelevance Reflexivity Transitivity.
@@ -8,42 +9,49 @@ Set Universe Polymorphism.
 Section Irrelevances.
 Context `{GenericTypingProperties}.
 
+Section VRIrrelevant.
+Universes u1 u2 u3 u4 v1 v2 v3 v4.
 
-Lemma VRirrelevant Γ {vsubst vsubst' veqsubst veqsubst'}
-  (vr : VR Γ vsubst veqsubst) (vr' : VR Γ vsubst' veqsubst') :
-  (forall Δ σ wfΔ wfΔ', vsubst Δ σ wfΔ <~> vsubst' Δ σ wfΔ') ×
-  (forall Δ σ σ' wfΔ wfΔ' vs vs', veqsubst Δ σ σ' wfΔ vs <~> veqsubst' Δ σ σ' wfΔ' vs').
+Lemma VRirrelevant Γ {veqsubst veqsubst'}
+  (vr : VR@{u1 u2 u3 u4} Γ veqsubst) (vr' : VR@{v1 v2 v3 v4} Γ  veqsubst') :
+  (forall Δ σ σ' wfΔ wfΔ', veqsubst Δ  wfΔ σ σ' <~> veqsubst' Δ wfΔ' σ σ').
 Proof.
-  revert vsubst' veqsubst' vr'.  pattern Γ, vsubst, veqsubst, vr.
-  apply VR_rect; clear Γ vsubst veqsubst vr.
-  - intros ?? h. inversion h. split; reflexivity.
-  - intros ?????? ih ?? h. inversion h.
-    specialize (ih _ _ VΓad0); destruct ih as [ih1 ih2].
-    split.
-    + intros. split; intros []; unshelve econstructor.
-      1,2: eapply ih1; eassumption.
-      1,2: irrelevance.
-    + intros; split; intros []; unshelve econstructor.
-      1,3: eapply ih2; eassumption.
-      1,2: irrelevance.
+  revert veqsubst' vr'.  pattern Γ, veqsubst, vr.
+  apply VR_rect; clear Γ veqsubst vr.
+  - intros ? h; inversion h; intros; split; intros; constructor.
+  - intros ?????? ih ? h; inversion h.
+    specialize (ih _ VΓad0).
+    intros; split; intros []; unshelve econstructor.
+    1,2: now eapply ih.
+    all: irrelevanceCum.
 Qed.
+
+Fail Fail Constraint u1 < v1.
+Fail Fail Constraint v1 < u1.
+Fail Fail Constraint u2 < v2.
+Fail Fail Constraint v2 < u2.
+Fail Fail Constraint u3 < v3.
+Fail Fail Constraint v3 < u3.
+Fail Fail Constraint u4 < v4.
+Fail Fail Constraint v4 < u4.
+
+End VRIrrelevant.
 
 Lemma irrelevanceSubst {Γ} (VΓ VΓ' : [||-v Γ]) {σ Δ} (wfΔ wfΔ' : [|- Δ]) :
   [Δ ||-v σ : Γ | VΓ | wfΔ] -> [Δ ||-v σ : Γ | VΓ' | wfΔ'].
 Proof.
-  apply (fst (VRirrelevant Γ VΓ.(VAd.adequate) VΓ'.(VAd.adequate))).
+  eapply VRirrelevant; eapply VAd.adequate.
 Qed.
 
-Lemma irrelevanceSubstEq {Γ} (VΓ VΓ' : [||-v Γ]) {σ σ' Δ} (wfΔ wfΔ' : [|- Δ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) (Vσ' : [Δ ||-v σ : Γ | VΓ' | wfΔ']) :
-  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] -> [Δ ||-v σ ≅ σ' : Γ | VΓ' | wfΔ' | Vσ'].
+Lemma irrelevanceSubstEq {Γ} (VΓ VΓ' : [||-v Γ]) {σ σ' Δ} (wfΔ wfΔ' : [|- Δ]) :
+  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ] -> [Δ ||-v σ ≅ σ' : Γ | VΓ' | wfΔ'].
 Proof.
-  apply (snd (VRirrelevant Γ VΓ.(VAd.adequate) VΓ'.(VAd.adequate))).
+  eapply VRirrelevant; eapply VAd.adequate.
 Qed.
 
 Set Printing Primitive Projection Parameters.
 
-Lemma reflSubst {Γ} (VΓ : [||-v Γ]) : forall {σ Δ} (wfΔ : [|- Δ])
+(* Lemma reflSubst {Γ} (VΓ : [||-v Γ]) : forall {σ Δ} (wfΔ : [|- Δ])
   (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]),
   [Δ ||-v σ ≅ σ : Γ | VΓ | wfΔ | Vσ].
 Proof.
@@ -51,56 +59,70 @@ Proof.
   - constructor.
   - intros * ih. unshelve econstructor.
     1: apply ih.
-    apply reflLRTmEq. exact (validHead Vσ).
-Qed.
+    exact (validHead Vσ).
+Qed. *)
 
-Lemma symmetrySubstEq {Γ} (VΓ VΓ' : [||-v Γ]) : forall {σ σ' Δ} (wfΔ wfΔ' : [|- Δ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) (Vσ' : [Δ ||-v σ' : Γ | VΓ' | wfΔ']),
-  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] -> [Δ ||-v σ' ≅ σ : Γ | VΓ' | wfΔ' | Vσ'].
+Unset Printing Notations.
+Lemma symmetrySubstEq@{u1 u2 u3 u4} {Γ}
+                     (VΓ VΓ' : VAdequate@{u3 u4} Γ VR@{u1 u2 u3 u4}) :
+  (* (VΓ VΓ' : [||-v Γ]) : *)
+  forall {σ σ' Δ} (wfΔ wfΔ' : [|- Δ]),
+  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ] -> [Δ ||-v σ' ≅ σ : Γ | VΓ' | wfΔ'].
 Proof.
   revert VΓ'; pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - intros VΓ'. rewrite (invValidityEmpty VΓ'). constructor.
   - intros * ih VΓ'. pose proof (x := invValiditySnoc VΓ').
     destruct x as [lA'[ VΓ'' [VA' ->]]].
-    intros ????? [tl hd] [tl' hd'] [tleq hdeq].
+    intros ????? [tleq hdeq].
     unshelve econstructor.
     1: now eapply ih.
-    eapply LRTmEqSym. cbn in *.
-    revert hdeq. apply LRTmEqRedConv.
-    eapply validTyExt. 2:eassumption.
-    eapply irrelevanceSubst; eassumption.
+    symmetry; revert hdeq; apply LRTmEqConv.
+    eapply validTyExt.
 Qed.
 
+#[global]
+Instance substEqSymmetric {Γ Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ]) :
+  Symmetric (VΓ.(VPack.eqSubst) Δ wfΔ).
+Proof. intros x y. eapply (symmetrySubstEq VΓ VΓ wfΔ wfΔ). Qed.
+
 Lemma transSubstEq {Γ} (VΓ : [||-v Γ]) :
-  forall {σ σ' σ'' Δ} (wfΔ : [|- Δ])
-    (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
-    (Vσ' : [Δ ||-v σ' : Γ | VΓ | wfΔ]),
-    [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
-    [Δ ||-v σ' ≅ σ'' : Γ | VΓ | wfΔ | Vσ'] ->
-    [Δ ||-v σ ≅ σ'' : Γ | VΓ | wfΔ | Vσ].
+  forall {σ σ' σ'' Δ} (wfΔ : [|- Δ]),
+    [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ] ->
+    [Δ ||-v σ' ≅ σ'' : Γ | VΓ | wfΔ ] ->
+    [Δ ||-v σ ≅ σ'' : Γ | VΓ | wfΔ ].
 Proof.
   pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - constructor.
   - intros * ih * [] []; unshelve econstructor.
-    1: now eapply ih.
-    eapply transEqTerm; tea.
-    eapply LRTmEqRedConv; tea.
+    1:  now eapply ih.
+    etransitivity; [irrelevance|].
+    eapply LRTmEqConv; tea.
     unshelve eapply LRTyEqSym; tea.
     2: unshelve eapply validTyExt.
-    7: eassumption.
+    5: eassumption.
     1: tea.
-    now eapply validTail.
 Qed.
+
+#[global]
+Instance substEqTransitive {Γ Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ]) :
+  Transitive (VΓ.(VPack.eqSubst) Δ wfΔ).
+Proof. intros x y z. eapply (transSubstEq VΓ wfΔ). Qed.
+
+#[global]
+Instance substEqPER {Γ Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ]) :
+  PER (VΓ.(VPack.eqSubst) Δ wfΔ).
+Proof. constructor; typeclasses eauto. Qed.
+
 
 Lemma irrelevanceTy {Γ} : forall (VΓ VΓ' : [||-v Γ]) {l A},
   [Γ ||-v<l> A | VΓ] -> [Γ ||-v<l> A | VΓ'].
 Proof.
   intros VΓ VΓ' l A [VA VAext]; unshelve econstructor; intros.
-  - unshelve eapply VA. 2: eapply irrelevanceSubst. all:eassumption.
-  - eapply VAext; [eapply irrelevanceSubst| eapply irrelevanceSubstEq]; eassumption.
+  - unshelve (eapply VA; now eapply irrelevanceSubstEq); tea.
+  - eapply VAext; eapply irrelevanceSubstEq; eassumption.
 Qed.
 
-Lemma irrelevanceTy' {Γ Γ' A A' l} (VΓ : [||-v Γ]) (VΓ' : [||-v Γ']) (VA : [Γ ||-v<l> A | VΓ]) : 
+Lemma irrelevanceTy' {Γ Γ' A A' l} (VΓ : [||-v Γ]) (VΓ' : [||-v Γ']) (VA : [Γ ||-v<l> A | VΓ]) :
   A = A' -> Γ = Γ' -> [Γ' ||-v<l> A' | VΓ'].
 Proof.
   intros eqA eqΓ; subst; now eapply irrelevanceTy.
@@ -113,17 +135,11 @@ Lemma irrelevanceLift {l A F G Γ} (VΓ : [||-v Γ])
   [Γ ,, G ||-v<l> A | validSnoc VΓ VG].
 Proof.
   intros [VA VAext]; unshelve econstructor.
-  - intros ??? [hd tl]. eapply VA.
+  - intros ???? [hd tl]. eapply VA.
     unshelve econstructor. 1: eassumption.
-    eapply LRTmRedConv. 2: eassumption.
-    eapply LRTyEqSym; unshelve eapply VFeqG; eassumption.
-  - intros ???? [??] [??] [??]. eapply VAext.
-    + unshelve econstructor. 1: eassumption.
-      eapply LRTmRedConv. 2: eassumption.
-      eapply LRTyEqSym; unshelve eapply VFeqG; eassumption.
-    + unshelve econstructor. 1: eassumption.
-      eapply LRTmEqRedConv. 2: eassumption.
-      eapply LRTyEqSym; unshelve eapply VFeqG; eassumption.
+    eapply LRTmEqConv. 2: eassumption.
+    eapply LRTyEqSym; unshelve eapply VFeqG; tea; now eapply lrefl.
+  - intros ???? [??]. eapply VAext.
 Qed.
 
 Lemma irrelevanceTyEq {Γ l A B} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) (VA' : [Γ||-v<l> A | VΓ']) :
@@ -132,7 +148,7 @@ Proof.
   intros [h]; constructor; intros.
   irrelevanceRefl.
   unshelve apply h. 1:eassumption.
-  eapply irrelevanceSubst; eassumption.
+  eapply irrelevanceSubstEq; eassumption.
 Qed.
 
 Lemma irrelevanceTyEq' {Γ l A A' B} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) (VA' : [Γ||-v<l> A' | VΓ']) : A = A' ->
@@ -146,7 +162,7 @@ Lemma symValidTyEq {Γ l A B} {VΓ : [||-v Γ]} {VA : [Γ ||-v<l> A | VΓ]} (VB 
 Proof.
   intros; constructor; intros.
   eapply LRTyEqSym; now eapply validTyEq.
-  Unshelve. all: tea.
+  Unshelve. 1:tea. now symmetry.
 Qed.
 
 Lemma transValidTyEq {Γ l A B C} {VΓ : [||-v Γ]}
@@ -154,20 +170,17 @@ Lemma transValidTyEq {Γ l A B C} {VΓ : [||-v Γ]}
   [Γ ||-v<l> A ≅ B | VΓ | VA] -> [Γ ||-v<l> B ≅ C | VΓ | VB] -> [Γ ||-v<l> A ≅ C | VΓ | VA].
 Proof.
   constructor; intros; eapply LRTransEq; now eapply validTyEq.
-  Unshelve. all: tea.
+  Unshelve. 1: tea. now eapply urefl.
 Qed.
+
 
 Lemma irrelevanceTm'' {Γ l l' t A} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) (VA' : [Γ||-v<l'> A | VΓ']) :
   [Γ ||-v<l> t : A | VΓ | VA] -> [Γ ||-v<l'> t : A | VΓ' | VA'].
 Proof.
-  intros [h1 h2]; unshelve econstructor.
-  - intros. irrelevanceRefl.
-    unshelve apply h1. 1:eassumption.
-    eapply irrelevanceSubst; eassumption.
-  - intros. irrelevanceRefl.
-    unshelve eapply h2. 1: eassumption.
-    1,2: eapply irrelevanceSubst; eassumption.
-    eapply irrelevanceSubstEq; eassumption.
+  intros [h2]; unshelve econstructor.
+  intros. irrelevanceRefl.
+  unshelve apply h2. 1:eassumption.
+  now eapply irrelevanceSubstEq.
 Qed.
 
 Lemma irrelevanceTm' {Γ l l' t A A'} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) (VA' : [Γ||-v<l'> A' | VΓ']) :
@@ -192,23 +205,13 @@ Lemma irrelevanceTmLift {l t A F G Γ} (VΓ : [||-v Γ])
   [Γ ,, F ||-v<l> t : A | validSnoc VΓ VF | VA] ->
   [Γ ,, G ||-v<l> t : A | validSnoc VΓ VG | VA'].
 Proof.
-  intros [Vt Vtext]; unshelve econstructor.
-  - intros ??? [hd tl]. irrelevanceRefl. 
-    unshelve eapply Vt; tea.
-    unshelve econstructor; tea.
-    eapply LRTmRedConv; tea.
-    eapply LRTyEqSym; unshelve eapply VFeqG; eassumption.
-  - intros ???? [??] [??] [??]. irrelevanceRefl. 
-    unshelve eapply Vtext; tea.
-    + unshelve econstructor; tea.
-      eapply LRTmRedConv; tea.
-      eapply LRTyEqSym; unshelve eapply VFeqG; eassumption.
-    + unshelve econstructor; tea.
-      eapply LRTmRedConv; tea.
-      eapply LRTyEqSym; unshelve eapply VFeqG; eassumption.
-    + unshelve econstructor; tea.
-      eapply LRTmEqRedConv; tea.
-      eapply LRTyEqSym; unshelve eapply VFeqG; eassumption.
+  intros [Vtext]; unshelve econstructor.
+  intros ???? [hd tl]. irrelevanceRefl.
+  unshelve eapply Vtext; tea.
+  unshelve econstructor; tea.
+  eapply LRTmEqConv; tea.
+  eapply LRTyEqSym; unshelve eapply VFeqG; tea.
+  now eapply lrefl.
 Qed.
 
 Lemma irrelevanceTmEq {Γ l t u A} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) (VA' : [Γ||-v<l> A | VΓ']) :
@@ -216,7 +219,7 @@ Lemma irrelevanceTmEq {Γ l t u A} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | 
 Proof.
   intros [h]; constructor; intros; irrelevanceRefl.
   unshelve apply h; tea.
-  eapply irrelevanceSubst; eassumption.
+  eapply irrelevanceSubstEq; eassumption.
 Qed.
 
 Lemma irrelevanceTmEq' {Γ l t u A A'} (VΓ VΓ' : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) (VA' : [Γ||-v<l> A' | VΓ']) :
@@ -229,44 +232,51 @@ Lemma symValidTmEq {Γ l t u A} {VΓ : [||-v Γ]} {VA : [Γ ||-v<l> A | VΓ]} :
   [Γ ||-v<l> t ≅ u : A| VΓ | VA] -> [Γ ||-v<l> u ≅ t : A | VΓ | VA].
 Proof.
   intros; constructor; intros.
-  eapply LRTmEqSym; now eapply validTmEq.
+  eapply LRTmEqSym; eapply LRTmEqConv.
+  2: now eapply validTmEq.
+  eapply validTyExt.
+  Unshelve. 1: tea. now symmetry.
 Qed.
 
 Lemma transValidTmEq {Γ l t u v A} {VΓ : [||-v Γ]}
   {VA : [Γ ||-v<l> A | VΓ]} :
-  [Γ ||-v<l> t ≅ u : A | VΓ | VA] -> 
-  [Γ ||-v<l> u ≅ v : A | VΓ | VA] -> 
+  [Γ ||-v<l> t ≅ u : A | VΓ | VA] ->
+  [Γ ||-v<l> u ≅ v : A | VΓ | VA] ->
   [Γ ||-v<l> t ≅ v : A | VΓ | VA].
 Proof.
-  constructor; intros; eapply transEqTerm; now eapply validTmEq.
+  constructor; intros; etransitivity.
+  1: now eapply validTmEq.
+  eapply LRTmEqConv.
+  2: now eapply validTmEq.
+  eapply LRTyEqSym; eapply validTyExt.
+  Unshelve. 1,6-8:tea. now eapply urefl.
 Qed.
 
-Lemma irrelevanceSubstExt {Γ} (VΓ : [||-v Γ]) {σ σ' Δ} (wfΔ : [|- Δ]) :
+(* Lemma irrelevanceSubstExt {Γ} (VΓ : [||-v Γ]) {σ σ' Δ} (wfΔ : [|- Δ]) :
   σ =1 σ' -> [Δ ||-v σ : Γ | VΓ | wfΔ] -> [Δ ||-v σ' : Γ | VΓ | wfΔ].
 Proof.
   revert σ σ'; pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - constructor.
   - intros ????? ih ?? eq.  unshelve econstructor.
-    + eapply ih. 2: now eapply validTail.
+    + eapply ih. 2: now eapply eqTail.
       now rewrite eq.
     + rewrite <- (eq var_zero).
-      pose proof (validHead X).
+      pose proof (eqHead X).
       irrelevance. now rewrite eq.
-Qed.
+Qed. *)
 
 Lemma irrelevanceSubstEqExt {Γ} (VΓ : [||-v Γ]) {σ1 σ1' σ2 σ2' Δ}
-  (wfΔ : [|- Δ]) (eq1 : σ1 =1 σ1') (eq2 : σ2 =1 σ2')
-  (Vσ1 : [Δ ||-v σ1 : Γ | VΓ | wfΔ]) :
-  [Δ ||-v σ1 ≅ σ2 : Γ | VΓ | wfΔ | Vσ1] ->
-  [Δ ||-v σ1' ≅ σ2' : Γ | VΓ | wfΔ | irrelevanceSubstExt VΓ wfΔ eq1 Vσ1].
+  (wfΔ : [|- Δ]) (eq1 : σ1 =1 σ1') (eq2 : σ2 =1 σ2') :
+  [Δ ||-v σ1 ≅ σ2 : Γ | VΓ | wfΔ ] ->
+  [Δ ||-v σ1' ≅ σ2' : Γ | VΓ | wfΔ ].
 Proof.
-  revert σ1 σ1' σ2 σ2' eq1 eq2 Vσ1; pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
+  revert σ1 σ1' σ2 σ2' eq1 eq2; pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - constructor.
-  - intros ????? ih ???? eq1 eq2 ? X. unshelve econstructor.
+  - intros ????? ih ???? eq1 eq2 X. unshelve econstructor.
     + eapply irrelevanceSubstEq.
       unshelve eapply ih.
-      6: now eapply eqTail.
-      all: now (rewrite eq1 + rewrite eq2).
+      5: now eapply eqTail.
+      all: now rewrite ?eq1, ?eq2.
     + rewrite <- (eq1 var_zero); rewrite <- (eq2 var_zero).
       pose proof (eqHead X).
       irrelevance.
@@ -279,7 +289,7 @@ Ltac irrValid :=
   match goal with
   | [_ : _ |- [||-v _]] => idtac
   | [_ : _ |- [ _ ||-v _ : _ | _ | _]] => eapply irrelevanceSubst
-  | [_ : _ |- [ _ ||-v _ ≅ _ : _ | _ | _ | _]] => eapply irrelevanceSubstEq
+  | [_ : _ |- [ _ ||-v _ ≅ _ : _ | _ | _ ]] => eapply irrelevanceSubstEq
   | [_ : _ |- [_ ||-v<_> _ | _]] => eapply irrelevanceTy
   | [_ : _ |- [_ ||-v<_> _ ≅ _ | _ | _]] => eapply irrelevanceTyEq
   | [_ : _ |- [_ ||-v<_> _ : _ | _ | _]] => eapply irrelevanceTm

--- a/theories/Substitution/Irrelevance.v
+++ b/theories/Substitution/Irrelevance.v
@@ -252,6 +252,16 @@ Proof.
   Unshelve. 1,6-8:tea. now eapply urefl.
 Qed.
 
+#[global]
+Instance validTmEqSymmetric {Γ l A} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) :
+  Symmetric (fun t u => [Γ ||-v<l> t ≅ u : _ | VΓ | VA]).
+Proof. intros x y; eapply symValidTmEq. Qed.
+
+#[global]
+Instance validTmEqTransitive {Γ l A} (VΓ : [||-v Γ]) (VA : [Γ ||-v<l> A | VΓ]) :
+  Transitive (fun t u => [Γ ||-v<l> t ≅ u : _ | VΓ | VA]).
+Proof. intros x y z. eapply transValidTmEq. Qed.
+
 (* Lemma irrelevanceSubstExt {Γ} (VΓ : [||-v Γ]) {σ σ' Δ} (wfΔ : [|- Δ]) :
   σ =1 σ' -> [Δ ||-v σ : Γ | VΓ | wfΔ] -> [Δ ||-v σ' : Γ | VΓ | wfΔ].
 Proof.

--- a/theories/Substitution/Properties.v
+++ b/theories/Substitution/Properties.v
@@ -46,14 +46,14 @@ Qed.
 
 Set Printing Primitive Projection Parameters.
 
-Lemma consSubstEqvalid {Γ σ σ' t l A Δ} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+Lemma consSubstEqvalid {Γ σ σ' t u l A Δ} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ])
   {VA : [Γ ||-v<l> A | VΓ]}
-  (Vt : [Γ ||-v<l> t : A | VΓ | VA]) :
-  [Δ ||-v (t[σ] .: σ) ≅  (t[σ'] .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ ].
+  (Vt : [Γ ||-v<l> t ≅ u : A | VΓ | VA]) :
+  [Δ ||-v (t[σ] .: σ) ≅  (u[σ'] .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ ].
 Proof.
   unshelve econstructor; intros; tea.
-  now apply validTmExt.
+  now apply validTmEq.
 Qed.
 
 Lemma wkSubstSEq {Γ} (VΓ : [||-v Γ]) :

--- a/theories/Substitution/Properties.v
+++ b/theories/Substitution/Properties.v
@@ -8,98 +8,58 @@ Set Universe Polymorphism.
 Section Properties.
 Context `{GenericTypingProperties}.
 
-
-Lemma wellformedSubst {Γ σ Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ]) :
-  [Δ ||-v σ : Γ | VΓ| wfΔ] -> [Δ |-s σ : Γ ].
+Definition validTyEqLeft {Γ A B l} (VΓ : [||-v Γ])
+  (VA : [Γ ||-v<l> A | VΓ])
+  (VB : [Γ ||-v<l> B | VΓ])
+  (VeqAB : [Γ ||-v<l> A ≅ B | VΓ | VA])
+  {Δ} (wfΔ : [|- Δ]) {σ σ'}
+  (Vσσ' : [VΓ | Δ ||-v σ ≅ σ' : Γ | wfΔ]) :
+  [validTy VA wfΔ Vσσ' | _ ||- _ ≅ B[σ]].
 Proof.
-  revert σ; pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
-  - intros. apply well_sempty.
-  - intros * ih σ [tl hd].
-    eapply well_scons.
-    + now apply ih.
-    + now escape.
+  eapply LRTransEq; [eapply validTyEq| eapply validTyExt]; tea.
+  Unshelve.
+  (* 6: now symmetry. *)
+   (* why is the instance not found here and found later in this file ? *)
+  6: now eapply symmetrySubstEq. all: tea.
 Qed.
 
-Lemma wellformedSubstEq {Γ σ σ' Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ]) (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) :
-  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] -> [Δ |-s σ ≅ σ' : Γ].
+
+Lemma wellformedSubstEq {Γ σ σ' Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ]) :
+  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ] -> [Δ |-s σ ≅ σ' : Γ].
 Proof.
-  revert σ σ' Vσ; pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
+  revert σ σ'; pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - intros. apply conv_sempty.
-  - intros * ih ??? [tl hd]. apply conv_scons.
+  - intros * ih ?? []. apply conv_scons.
     + now eapply ih.
     + now escape.
 Qed.
 
-Lemma consSubstS {Γ σ t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) (VA : [Γ ||-v<l> A | VΓ])
-  (Vt : [ Δ ||-<l> t : A[σ] | validTy VA wfΔ Vσ]) :
-  [Δ ||-v (t .: σ) : Γ ,, A | validSnoc VΓ VA | wfΔ].
-Proof.  unshelve econstructor; eassumption. Defined.
 
-
-Lemma consSubstSEq {Γ σ σ' t l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
-  (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ])
+Lemma consSubstEq {Γ σ σ' t u l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
+  (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ])
   (VA : [Γ ||-v<l> A | VΓ])
-  (Vt : [Δ ||-<l> t : A[σ] | validTy VA wfΔ Vσ]) :
-  [Δ ||-v (t .: σ) ≅  (t .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ | consSubstS VΓ wfΔ Vσ VA Vt].
-Proof.
-  unshelve econstructor.
-  1: eassumption.
-  eapply LRTmEqRefl; [apply (validTy VA wfΔ)| exact Vt].
-Qed.
-
-Lemma consSubstSEq' {Γ σ σ' t u l A Δ} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
-  (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ])
-  (VA : [Γ ||-v<l> A | VΓ])
-  (Vt : [Δ ||-<l> t : A[σ] | validTy VA wfΔ Vσ])
-  (Vtu : [Δ ||-<l> t ≅ u : A[σ] | validTy VA wfΔ Vσ]) :
-  [Δ ||-v (t .: σ) ≅  (u .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ | consSubstS VΓ wfΔ Vσ VA Vt].
+  (Vtu : [Δ ||-<l> t ≅ u : A[σ] | validTy VA wfΔ Vσσ']) :
+  [Δ ||-v (t .: σ) ≅  (u .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ ].
 Proof.
   unshelve econstructor; tea.
-Qed.  
-
-
-Lemma consSubstSvalid {Γ σ t l A Δ} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]) {VA : [Γ ||-v<l> A | VΓ]}
-  (Vt : [ Γ ||-v<l> t : A | VΓ | VA]) :
-  [Δ ||-v (t[σ] .: σ) : Γ ,, A | validSnoc VΓ VA | wfΔ].
-Proof. unshelve eapply consSubstS; tea; now eapply validTm. Defined.
+Qed.
 
 Set Printing Primitive Projection Parameters.
 
-Lemma consSubstSEqvalid {Γ σ σ' t l A Δ} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
-  (Vσ' : [Δ ||-v σ' : Γ | VΓ | wfΔ]) 
-  (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ])
+Lemma consSubstEqvalid {Γ σ σ' t l A Δ} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+  (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ])
   {VA : [Γ ||-v<l> A | VΓ]}
   (Vt : [Γ ||-v<l> t : A | VΓ | VA]) :
-  [Δ ||-v (t[σ] .: σ) ≅  (t[σ'] .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ | consSubstSvalid Vσ Vt].
+  [Δ ||-v (t[σ] .: σ) ≅  (t[σ'] .: σ') : Γ ,, A | validSnoc VΓ VA | wfΔ ].
 Proof.
   unshelve econstructor; intros; tea.
   now apply validTmExt.
 Qed.
 
-Lemma wkSubstS {Γ} (VΓ : [||-v Γ]) : 
-  forall {σ  Δ Δ'}  (wfΔ : [|- Δ]) (wfΔ' : [|- Δ']) (ρ : Δ' ≤ Δ),
-  [Δ ||-v σ : Γ | VΓ | wfΔ] -> [Δ' ||-v σ ⟨ ρ ⟩ : Γ | VΓ | wfΔ'].
-Proof.
-  pattern Γ, VΓ ; apply validity_rect; clear Γ VΓ.
-  - constructor.
-  - intros * ih * [tl hd]. unshelve econstructor.
-    + eapply ih; eassumption.
-    + eapply LRTmRedIrrelevant'.
-      2: eapply (wkTerm _ wfΔ') ; exact hd.
-      now asimpl.
-Defined.
-
-
 Lemma wkSubstSEq {Γ} (VΓ : [||-v Γ]) :
-  forall {σ σ' Δ Δ'}  (wfΔ : [|- Δ]) (wfΔ' : [|- Δ']) (ρ : Δ' ≤ Δ)
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ]),
-  [Δ  ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
-  [Δ' ||-v σ ⟨ ρ ⟩ ≅ σ' ⟨ ρ ⟩ : Γ | VΓ | wfΔ' | wkSubstS VΓ wfΔ wfΔ' ρ Vσ].
+  forall {σ σ' Δ Δ'}  (wfΔ : [|- Δ]) (wfΔ' : [|- Δ']) (ρ : Δ' ≤ Δ),
+  [Δ  ||-v σ ≅ σ' : Γ | VΓ | wfΔ ] ->
+  [Δ' ||-v σ ⟨ ρ ⟩ ≅ σ' ⟨ ρ ⟩ : Γ | VΓ | wfΔ' ].
 Proof.
   pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - constructor.
@@ -110,171 +70,86 @@ Proof.
       now asimpl.
 Qed.
 
-Lemma wk1SubstS {Γ σ Δ F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ]) (wfF : [Δ |- F]) :
-  [Δ ||-v σ : Γ | VΓ | wfΔ ] ->
-  [Δ ,, F ||-v σ ⟨ @wk1 Δ F ⟩ : Γ | VΓ | wfc_cons wfΔ wfF].
-Proof. eapply wkSubstS. Defined.
 
 Lemma wk1SubstSEq {Γ σ σ' Δ F} (VΓ : [||-v Γ])
-  (wfΔ : [|- Δ]) (wfF : [Δ |- F])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
-  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
+  (wfΔ : [|- Δ]) (wfF : [Δ |- F]) :
+  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ] ->
   let ρ := @wk1 Δ F in
-  [Δ ,, F ||-v σ ⟨ ρ ⟩ ≅ σ' ⟨ ρ ⟩ : Γ | VΓ | wfc_cons wfΔ wfF | wk1SubstS VΓ wfΔ wfF Vσ].
+  [Δ ,, F ||-v σ ⟨ ρ ⟩ ≅ σ' ⟨ ρ ⟩ : Γ | VΓ | wfc_cons wfΔ wfF ].
 Proof.
   intro vσσ'. eapply wkSubstSEq ; eassumption.
 Qed.
 
-Lemma consWkSubstS {Γ F Δ Ξ σ a l VΓ wfΔ } VF
-  (ρ : Ξ ≤ Δ) wfΞ {RF}:
-  [Δ ||-v σ : Γ | VΓ | wfΔ] ->
-  [Ξ ||-<l> a : F[σ]⟨ρ⟩ | RF] ->
-  [Ξ ||-v (a .: σ⟨ρ⟩) : Γ,, F | validSnoc (l:=l) VΓ VF | wfΞ].
-Proof.
-  intros. unshelve eapply consSubstS.  2: irrelevance.
-  now eapply wkSubstS.
-Qed.
-
 Lemma consWkSubstSEq' {Γ Δ Ξ A σ σ' a b l} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (VA : [Γ ||-v<l> A | VΓ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ])
-  (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ])
+  (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ])
   (ρ : Ξ ≤ Δ) wfΞ {RA}
   (Ra : [Ξ ||-<l> a : A[σ]⟨ρ⟩ | RA])
-  (Rab : [Ξ ||-<l> a ≅ b : A[σ]⟨ρ⟩ | RA]) 
-  (Vawkσ := consWkSubstS VA ρ wfΞ Vσ Ra) :
-  [Ξ ||-v (a .: σ⟨ρ⟩) ≅  (b .: σ'⟨ρ⟩) : Γ ,, A | validSnoc VΓ VA | wfΞ | Vawkσ].
+  (Rab : [Ξ ||-<l> a ≅ b : A[σ]⟨ρ⟩ | RA]) :
+  [Ξ ||-v (a .: σ⟨ρ⟩) ≅  (b .: σ'⟨ρ⟩) : Γ ,, A | validSnoc VΓ VA | wfΞ ].
 Proof.
-  unshelve eapply consSubstSEq'.
+  unshelve eapply consSubstEq.
   - unshelve eapply irrelevanceSubstEq.
-    4: now eapply wkSubstSEq.
+    3: now eapply wkSubstSEq.
     tea.
   - irrelevance0; tea. now bsimpl.
-Qed.  
-
-
-Lemma liftSubstS {Γ σ Δ lF F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
-  (VF : [Γ ||-v<lF> F | VΓ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
-  let VΓF := validSnoc VΓ VF in
-  let ρ := @wk1 Δ F[σ] in
-  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
-  [Δ ,, F[σ] ||-v (tRel 0 .: σ ⟨ ρ ⟩) : Γ ,, F | VΓF | wfΔF ].
-Proof.
-  intros; unshelve econstructor.
-  - now eapply wk1SubstS.
-  - eapply var0; unfold ρ; [now bsimpl|].
-    now eapply escape, VF.
-Defined.
-
-Lemma liftSubstSrealign {Γ σ σ' Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
-  (VF : [Γ ||-v<lF> F | VΓ])
-  {Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]} :
-  let VΓF := validSnoc VΓ VF in
-  let ρ := @wk1 Δ F[σ]  in
-  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
-  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
-  [Δ ||-v σ' : Γ | VΓ | wfΔ ] ->
-  [Δ ,, F[σ] ||-v (tRel 0 .: σ'⟨ρ⟩) : Γ ,, F | VΓF | wfΔF].
-Proof.
-  intros; unshelve econstructor.
-  + now eapply wk1SubstS.
-  + cbn.
-    assert [Δ,, F[σ] |-[ ta ] tRel 0 : F[S >> (tRel 0 .: σ'⟨ρ⟩)]].
-    { replace F[_ >> _] with F[σ']⟨S⟩ by (unfold ρ; now bsimpl).
-      eapply ty_conv. 1: apply (ty_var wfΔF (in_here _ _)).
-      cbn; renToWk. eapply convty_wk; tea.
-      eapply escapeEq;  unshelve eapply validTyExt; cycle 3; tea. }
-    apply neuTerm; tea.
-    - apply convneu_var; tea.
 Qed.
 
-Lemma liftSubstS' {Γ σ Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
-  (VF : [Γ ||-v<lF> F | VΓ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
-  let VΓF := validSnoc VΓ VF in
-  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
-  [Δ ,, F[σ] ||-v up_term_term σ : Γ ,, F | VΓF | wfΔF ].
-Proof.
-  eapply irrelevanceSubstExt.
-  2: eapply liftSubstS.
-  intros ?; now bsimpl.
-Qed.
 
-Lemma liftSubstSEq {Γ σ σ' Δ lF F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
+Lemma liftSubstEq {Γ σ σ' Δ lF F} (VΓ : [||-v Γ]) (wfΔ : [|- Δ])
   (VF : [Γ ||-v<lF> F | VΓ])
-  (Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]) :
+  (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ]) :
   let VΓF := validSnoc VΓ VF in
   let ρ := @wk1 Δ F[σ] in
-  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
-  let Vliftσ := liftSubstS VΓ wfΔ VF Vσ in
-  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
-  [Δ ,, F[σ] ||-v (tRel 0 .: σ ⟨ ρ ⟩) ≅ (tRel 0 .: σ' ⟨ ρ ⟩) : Γ ,, F | VΓF | wfΔF | Vliftσ].
+  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσσ')) in
+  [Δ ,, F[σ] ||-v (tRel 0 .: σ ⟨ ρ ⟩) ≅ (tRel 0 .: σ' ⟨ ρ ⟩) : Γ ,, F | VΓF | wfΔF ].
 Proof.
   intros; unshelve econstructor.
   + now apply wk1SubstSEq.
-  + apply reflLRTmEq; exact (validHead Vliftσ).
+  + cbn. eapply var0; unfold ρ; [now bsimpl|].
+    now eapply escape, VF.
 Qed.
 
-Lemma liftSubstSEq' {Γ σ σ' Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+Lemma liftSubstEq' {Γ σ σ' Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (VF : [Γ ||-v<lF> F | VΓ])
-  {Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]} :
+  {Vσ : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ]} :
   let VΓF := validSnoc VΓ VF in
   let ρ := wk_up F (@wk_id Γ) in
   let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
-  let Vliftσ := liftSubstS' VF Vσ in
-  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
-  [Δ ,, F[σ] ||-v up_term_term σ ≅ up_term_term σ' : Γ ,, F | VΓF | wfΔF | Vliftσ].
+  [Δ ,, F[σ] ||-v up_term_term σ ≅ up_term_term σ' : Γ ,, F | VΓF | wfΔF ].
 Proof.
   intros.
   eapply irrelevanceSubstEq.
   unshelve eapply irrelevanceSubstEqExt.
-  6: now eapply liftSubstSEq.
-  all: intros ?; now bsimpl.
-  Unshelve. all: tea.
+  5: unshelve eapply liftSubstEq.
+  6,8: tea.
+  1-2: intros ?; now bsimpl.
 Qed.
 
-Lemma liftSubstSrealign' {Γ σ σ' Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
-  (VF : [Γ ||-v<lF> F | VΓ])
-  {Vσ : [Δ ||-v σ : Γ | VΓ | wfΔ ]} :
-  let VΓF := validSnoc VΓ VF in
-  let ρ := wk_up F (@wk_id Γ) in
-  let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in
-  [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ | Vσ] ->
-  [Δ ||-v σ' : Γ | VΓ | wfΔ ] ->
-  [Δ ,, F[σ] ||-v up_term_term σ' : Γ ,, F | VΓF | wfΔF].
-Proof.
-  intros.
-  eapply irrelevanceSubstExt.
-  2: eapply liftSubstSrealign; tea.
-  intros ?; now bsimpl.
-Qed.
 
 Lemma wk1ValidTy {Γ lA A lF F} {VΓ : [||-v Γ]} (VF : [Γ ||-v<lF> F | VΓ]) :
-  [Γ ||-v<lA> A | VΓ] -> 
+  [Γ ||-v<lA> A | VΓ] ->
   [Γ ,, F ||-v<lA> A ⟨ @wk1 Γ F ⟩ | validSnoc VΓ VF ].
 Proof.
   assert (forall σ, (A ⟨@wk1 Γ F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren) ;
   intros [VA VAext]; unshelve econstructor.
-  - abstract (intros * [tl _]; rewrite h; exact (VA _ _ wfΔ tl)).
-  - intros * [tl _] [tleq _].
+  - abstract (intros * [tl _]; rewrite h; exact (VA _ wfΔ _ _ tl)).
+  - intros ???? [tleq ?].
     rewrite (h σ'); unshelve eapply LRTyEqSym.
-    2: eapply VA; eassumption.
-    rewrite (h σ).
-    eapply VAext. 1: exact (validTail vσ).
-    eapply symmetrySubstEq. eassumption.
+    2: eapply VA; now symmetry.
+    rewrite (h σ); eapply VAext.
 Qed.
 
-Lemma wk1ValidTyEq {Γ lA A B lF F} {VΓ : [||-v Γ]} (VF : [Γ ||-v<lF> F | VΓ]) 
+Lemma wk1ValidTyEq {Γ lA A B lF F} {VΓ : [||-v Γ]} (VF : [Γ ||-v<lF> F | VΓ])
   {VA : [Γ ||-v<lA> A | VΓ]} :
-  [Γ ||-v<lA> A ≅ B | VΓ | VA] -> 
+  [Γ ||-v<lA> A ≅ B | VΓ | VA] ->
   [Γ ,, F ||-v<lA> A ⟨ @wk1 Γ F ⟩ ≅ B ⟨ @wk1 Γ F ⟩ | validSnoc VΓ VF | wk1ValidTy VF VA].
 Proof.
   assert (forall A σ, (A ⟨@wk1 Γ F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren).
   intros []; constructor; intros.
   rewrite h. irrelevance0.
   1: symmetry; apply h.
-  unshelve intuition; tea; now eapply validTail.
+  unshelve intuition; tea; now eapply eqTail.
 Qed.
 
 Lemma wk1ValidTm {Γ lA t A lF F} {VΓ : [||-v Γ]}
@@ -285,8 +160,7 @@ Lemma wk1ValidTm {Γ lA t A lF F} {VΓ : [||-v Γ]}
 Proof.
   assert (forall A σ, (A ⟨@wk1 Γ F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren).
   constructor; intros; repeat rewrite h.
-  - instValid (validTail Vσ); irrelevance.
-  - instValidExt (validTail Vσ') (eqTail Vσσ'); irrelevance.
+  instValid (eqTail Vσσ'); irrelevance.
 Qed.
 
 Lemma wk1ValidTmEq {Γ lA t u A lF F} {VΓ : [||-v Γ]}
@@ -297,7 +171,7 @@ Lemma wk1ValidTmEq {Γ lA t u A lF F} {VΓ : [||-v Γ]}
 Proof.
   assert (forall A σ, (A ⟨@wk1 Γ F⟩)[σ] = A[↑ >> σ]) as h by (intros; asimpl; now rewrite wk1_ren).
   constructor; intros; repeat rewrite h.
-  instValid (validTail Vσ); irrelevance.
+  instValid (eqTail Vσσ'); irrelevance.
 Qed.
 
 
@@ -307,7 +181,7 @@ Lemma embValidTy@{u i j k l} {Γ l l' A}
     typeValidity@{u i j k l} Γ VΓ l' A (*[Γ ||-v<l'> A |VΓ]*).
 Proof.
   unshelve econstructor.
-  - intros ??? Vσ; destruct (validTy VA _  Vσ) as [pack]; exists pack.
+  - intros ???? Vσ; destruct (validTy VA _ Vσ) as [pack]; exists pack.
     eapply LR_embedding; tea.
   - intros; now eapply validTyExt.
 Defined.
@@ -328,94 +202,49 @@ Proof.
   pattern Γ, VΓ; apply validity_rect; clear Γ VΓ.
   - exists ε, eq_refl, wfc_nil; constructor.
   - intros * [Δ [e [wfΔ Vid]]].
-    exists (Δ,, A[tRel]); unshelve eexists. 
+    exists (Δ,, A[tRel]); unshelve eexists.
     1: asimpl; now rewrite e.
     unshelve eexists.
     + apply wfc_cons; tea.
       eapply escape.
       apply (validTy VA wfΔ Vid).
-    + eapply irrelevanceSubstExt.
-      2: eapply irrelevanceSubst; now unshelve eapply liftSubstS.
-      intros []; [| bsimpl]; reflexivity.
+    + eapply irrelevanceSubstEqExt.
+      3: eapply irrelevanceSubstEq.
+      3: unshelve eapply liftSubstEq; cycle 2; tea.
+      all:intros []; [| bsimpl]; reflexivity.
 Qed.
 
 Definition soundCtx {Γ} (VΓ : [||-v Γ]) : [|-Γ] := (soundCtxId VΓ).π1.
 
 Definition idSubstS {Γ} (VΓ : [||-v Γ]) : [Γ ||-v tRel : Γ | VΓ | _] := (soundCtxId VΓ).π2.
 
-Lemma reflIdSubstS {Γ} (VΓ : [||-v Γ]) : [Γ ||-v tRel ≅ tRel : Γ | VΓ | _ | idSubstS VΓ].
-Proof.  apply reflSubst. Qed.
-
-Lemma substS_wk {Γ Δ} (ρ : Δ ≤ Γ) :
+Lemma substEq_wk {Γ Δ} (ρ : Δ ≤ Γ) :
   forall (VΓ : [||-v Γ])
-  (VΔ : [||-v Δ]) 
-  {Ξ σ} (wfΞ : [|- Ξ]), [VΔ | Ξ ||-v σ : _ | wfΞ] -> [VΓ | Ξ ||-v ρ >> σ : _ | wfΞ].
+  (VΔ : [||-v Δ])
+  {Ξ σ σ'} (wfΞ : [|- Ξ]), [VΔ | Ξ ||-v σ ≅ σ' : _ | wfΞ] -> [VΓ | Ξ ||-v ρ >> σ ≅ ρ >> σ' : _ | wfΞ].
 Proof.
   destruct ρ as [? wwk]; induction wwk.
   + intros; rewrite (invValidityEmpty VΓ); constructor.
   + intros.
     pose proof (invValiditySnoc VΔ) as [? [? [? eq]]].
     rewrite eq in X; cbn in X; inversion X.
-    eapply irrelevanceSubstExt.
+    eapply irrelevanceSubstEqExt.
     1: rewrite <- (scons_eta' σ); reflexivity.
+    1: rewrite <- (scons_eta' σ'); reflexivity.
     cbn. asimpl.
     now eapply IHwwk.
   + intros.
     pose proof (invValiditySnoc VΔ) as [? [? [? eq]]].
     rewrite eq in X; cbn in X; inversion X.
-    eapply irrelevanceSubstExt.
+    eapply irrelevanceSubstEqExt.
     1:{ rewrite <- (scons_eta' σ); cbn; unfold up_ren; rewrite scons_comp'; cbn. reflexivity. }
+    1:{ rewrite <- (scons_eta' σ'); cbn; unfold up_ren; rewrite scons_comp'; cbn. reflexivity. }
     asimpl.
     pose proof (invValiditySnoc VΓ) as [? [? [? eq']]].
-    rewrite eq'.
-    unshelve eapply consSubstS.
+    rewrite eq'; unshelve econstructor.
     * now eapply IHwwk.
     * irrelevance.
 Defined.
-
-Lemma substSEq_wk {Γ Δ} (ρ : Δ ≤ Γ) :
-  forall (VΓ : [||-v Γ])
-  (VΔ : [||-v Δ]) 
-  Ξ σ σ' (wfΞ : [|- Ξ])
-  (Vσ : [VΔ | Ξ ||-v σ : _ | wfΞ]),
-  [VΔ | Ξ ||-v σ' : _ | wfΞ] -> 
-  [VΔ | Ξ ||-v σ ≅ σ' : _ | wfΞ | Vσ] -> 
-  [VΓ | Ξ ||-v ρ >> σ ≅ ρ >> σ' : _ | wfΞ | substS_wk ρ VΓ VΔ wfΞ Vσ].
-Proof.
-  destruct ρ as [? wwk]; induction wwk.
-  + intros; rewrite (invValidityEmpty VΓ); constructor.
-  + intros.
-    pose proof (invValiditySnoc VΔ) as [? [? [? eq]]].
-    revert Vσ X X0; rewrite eq; intros Vσ Vσ' Vσσ'.
-    cbn; asimpl; eapply irrelevanceSubstEq.
-    unshelve eapply IHwwk; tea.
-    1,2: now eapply validTail.
-    now eapply eqTail.
-    Unshelve. tea.
-+ intros ??????.
-  set (ρ0 := {| well_wk := _ |}); unfold ρ0.
-  pose proof (invValiditySnoc VΔ) as [? [VΓ0 [? eq]]].
-  pose proof (invValiditySnoc VΓ) as [? [VΔ0 [? eqΓ]]].
-  rewrite eq; intros Vσ Vσ' Vσσ'.
-  assert (subst_eq : forall τ : nat -> term, τ var_zero .: (ρ >> ↑ >> τ) =1 (0 .: ρ >> S) >> τ).
-  1:{ intros τ;  asimpl; reflexivity. }
-  pose proof (v := substS_wk ρ0 VΓ _ wfΞ Vσ).
-  cbn; asimpl ; eapply irrelevanceSubstEq; unshelve eapply irrelevanceSubstEqExt.
-  2,5: apply subst_eq.
-  - eapply irrelevanceSubstExt.
-    1: symmetry; apply subst_eq.
-    exact v.
-  - eapply irrelevanceSubstEq.
-    eapply consSubstSEq'.
-    * exact (IHwwk VΔ0 VΓ0 Ξ (↑ >> σ) (↑ >> σ') wfΞ (validTail Vσ) (validTail Vσ') (eqTail Vσσ')).
-    * irrelevance0. 
-      2: now eapply eqHead. 
-      now asimpl.
-    Unshelve. 2: tea.
-    rewrite eqΓ in v.
-    irrelevanceRefl.
-    eapply (validHead v).
-Qed.
 
 Lemma wkValidTy {l Γ Δ A} (ρ : Δ ≤ Γ)
   (VΓ : [||-v Γ])
@@ -427,12 +256,11 @@ Proof.
   unshelve econstructor.
   - intros; rewrite h.
     eapply validTy; tea.
-    now eapply substS_wk.
+    now eapply substEq_wk.
   - intros; irrelevance0; rewrite h; [reflexivity|].
-    eapply validTyExt.
-    1: now eapply substS_wk.
-    now eapply substSEq_wk.
-    Unshelve. 2,3: tea.
+    unshelve eapply validTyExt.
+    5: now eapply substEq_wk.
+    tea.
 Qed.
 
 Lemma wkValidTm {l Γ Δ A t} (ρ : Δ ≤ Γ)
@@ -444,16 +272,10 @@ Lemma wkValidTm {l Γ Δ A t} (ρ : Δ ≤ Γ)
 Proof.
   assert (hA : forall σ, A⟨ρ⟩[σ] = A[ρ >> σ]) by (intros; now asimpl).
   assert (ht : forall σ, t⟨ρ⟩[σ] = t[ρ >> σ]) by (intros; now asimpl).
-  unshelve econstructor.
-  - intros; rewrite ht.
-    irrelevance0; [symmetry; apply hA|].
-    eapply validTm, Vt.
-  - intros; do 2 rewrite ht.
-    irrelevance0; [symmetry; apply hA|].
-    eapply validTmExt; [apply Vt|now eapply substS_wk|].
-    now eapply substSEq_wk.
-    Unshelve. all: tea.
-    now eapply substS_wk.
+  econstructor; intros; rewrite 2!ht.
+  irrelevance0; [symmetry; apply hA|].
+  eapply validTmExt, Vt.
+  Unshelve. 1: tea. now eapply substEq_wk.
 Qed.
 
 Lemma wkValidTyEq {l Γ Δ A B} (ρ : Δ ≤ Γ)
@@ -467,7 +289,7 @@ Proof.
   unshelve econstructor; intros; irrelevance0; rewrite h; [reflexivity|].
   now eapply validTyEq.
   Unshelve. 1: tea.
-    now eapply substS_wk.
+  now eapply substEq_wk.
 Qed.
 
 

--- a/theories/Substitution/Properties.v
+++ b/theories/Substitution/Properties.v
@@ -80,11 +80,10 @@ Proof.
   intro vσσ'. eapply wkSubstSEq ; eassumption.
 Qed.
 
-Lemma consWkSubstSEq' {Γ Δ Ξ A σ σ' a b l} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
+Lemma consWkSubstEq {Γ Δ Ξ A σ σ' a b l} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (VA : [Γ ||-v<l> A | VΓ])
   (Vσσ' : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ])
   (ρ : Ξ ≤ Δ) wfΞ {RA}
-  (Ra : [Ξ ||-<l> a : A[σ]⟨ρ⟩ | RA])
   (Rab : [Ξ ||-<l> a ≅ b : A[σ]⟨ρ⟩ | RA]) :
   [Ξ ||-v (a .: σ⟨ρ⟩) ≅  (b .: σ'⟨ρ⟩) : Γ ,, A | validSnoc VΓ VA | wfΞ ].
 Proof.
@@ -112,7 +111,7 @@ Qed.
 
 Lemma liftSubstEq' {Γ σ σ' Δ lF F} {VΓ : [||-v Γ]} {wfΔ : [|- Δ]}
   (VF : [Γ ||-v<lF> F | VΓ])
-  {Vσ : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ]} :
+  (Vσ : [Δ ||-v σ ≅ σ' : Γ | VΓ | wfΔ ]) :
   let VΓF := validSnoc VΓ VF in
   let ρ := wk_up F (@wk_id Γ) in
   let wfΔF := wfc_cons wfΔ (escape (validTy VF wfΔ Vσ)) in

--- a/theories/Substitution/Properties.v
+++ b/theories/Substitution/Properties.v
@@ -291,6 +291,40 @@ Proof.
   now eapply substEq_wk.
 Qed.
 
+Lemma subst_rel t : t[tRel] = t.
+Proof. now bsimpl. Qed.
+
+Lemma validTyWf {Γ A l} (VΓ : [||-v Γ]) : [_ ||-v<l> A | VΓ ] -> [Γ |- A].
+Proof.
+  intros h; generalize (validTy h _ (idSubstS VΓ)); rewrite subst_rel.
+  eapply escape.
+Qed.
+
+Lemma validWf {Γ} (VΓ: [||-v Γ]) :  [|- Γ].
+Proof.
+  induction Γ, VΓ using validity_rect.
+  gen_typing.
+  eapply wfc_cons; tea; now eapply validTyWf.
+Qed.
+
+(* Lemma compSubstS {Γ} (VΓ : [||-v Γ])  :
+  forall Δ (VΔ : [||-v Δ])
+    {σ σ'} (Vσσ' : [_ ||-v σ ≅ σ' : _ | VΓ | validWf VΔ])
+    Ξ (wfΞ : [|- Ξ])
+    {τ τ'} (Vττ' : [_ ||-v τ ≅ τ' : _ | VΔ | wfΞ]),
+    [_ ||-v  σ >> subst_term τ ≅ σ' >> subst_term τ' : _ | VΓ | wfΞ].
+Proof.
+  induction Γ, VΓ using validity_rect.
+  1: intros; constructor.
+  intros ; unshelve econstructor.
+  - eapply irrelevanceSubstEqExt.
+    3:{ eapply IHVΓ; [eapply eqTail, Vσσ'|]; tea.  }
+    1,2: intros ?; reflexivity.
+  - cbn.  unfold funcomp. cbv. bsimpl. substify. asimpl.
+
+  intros Δ VΔ; induction Δ, VΔ using validity_rect. unshelve econstructor. *)
+
+
 
 
 

--- a/theories/Substitution/Reduction.v
+++ b/theories/Substitution/Reduction.v
@@ -9,14 +9,14 @@ Context `{GenericTypingProperties}.
 
 Set Printing Primitive Projection Parameters.
 
-Lemma redwfSubstValid {Γ A t u l}
+Lemma redSubstValid {Γ A t u l}
   (VΓ : [||-v Γ])
-  (red : [Γ ||-v t :⤳*: u : A | VΓ])
+  (red : [Γ ||-v t ⤳* u : A | VΓ])
   (VA : [Γ ||-v<l> A | VΓ])
   (Vu : [Γ ||-v<l> u : A | VΓ | VA]) :
   [Γ ||-v<l> t ≅ u : A | VΓ | VA].
 Proof.
-  constructor; intros. eapply redwfSubstTmEq.
+  constructor; intros. eapply redSubstLeftTmEq.
   1: now eapply validTmExt.
   now eapply validRed.
 Qed.

--- a/theories/Substitution/Reduction.v
+++ b/theories/Substitution/Reduction.v
@@ -14,25 +14,11 @@ Lemma redwfSubstValid {Γ A t u l}
   (red : [Γ ||-v t :⤳*: u : A | VΓ])
   (VA : [Γ ||-v<l> A | VΓ])
   (Vu : [Γ ||-v<l> u : A | VΓ | VA]) :
-  [Γ ||-v<l> t : A | VΓ | VA] × [Γ ||-v<l> t ≅ u : A | VΓ | VA].
+  [Γ ||-v<l> t ≅ u : A | VΓ | VA].
 Proof.
-  assert (Veq : [Γ ||-v<l> t ≅ u : A | VΓ | VA]).
-  {
-    constructor; intros; eapply redwfSubstTerm.
-    1: now eapply validTm.
-    now eapply validRed.
-  }
-  split; tea; constructor; intros.
-  - eapply redwfSubstTerm.
-    1: now eapply validTm.
-    now eapply validRed.
-  - eapply transEqTerm. 2: eapply transEqTerm.
-    + now eapply validTmEq.
-    + now eapply validTmExt.
-    + eapply LRTmEqSym. eapply LRTmEqRedConv.
-      1: eapply LRTyEqSym; now eapply validTyExt.
-      now eapply validTmEq.
-      Unshelve. all: tea.
+  constructor; intros. eapply redwfSubstTmEq.
+  1: now eapply validTmExt.
+  now eapply validRed.
 Qed.
-   
+
 End Reduction.

--- a/theories/Substitution/Reflexivity.v
+++ b/theories/Substitution/Reflexivity.v
@@ -1,6 +1,7 @@
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
-From LogRel.LogicalRelation Require Import Irrelevance Escape Reflexivity Weakening Neutral.
+From LogRel.LogicalRelation Require Import Irrelevance EqRedRight.
+From LogRel.Substitution Require Import Irrelevance Properties.
 
 Set Universe Polymorphism.
 
@@ -11,7 +12,21 @@ Lemma reflValidTy {Γ A l} (VΓ : [||-v Γ])
   (VA : [Γ ||-v<l> A | VΓ]) :
   [Γ ||-v<l> A ≅ A | VΓ | VA].
 Proof.
-  constructor; intros; apply reflLRTyEq.
+  constructor; intros; eapply validTyExt.
+Qed.
+Set Printing Primitive Projection Parameters.
+
+Lemma ureflValidTy {Γ A B l} (VΓ : [||-v Γ])
+  (VA : [Γ ||-v<l> A | VΓ])
+  (VAB : [Γ ||-v<l> A ≅ B | VΓ | VA]) :
+  [Γ ||-v<l> B | VΓ ].
+Proof.
+  unshelve econstructor; intros.
+  1: (unshelve now eapply LRTyEqRedRight, validTyEq); [tea| |now eapply lrefl].
+  eapply LRTransEq.
+  2: (unshelve now eapply validTyEq); cycle 2; tea.
+  eapply LRTyEqSym.
+  (unshelve now eapply validTyEq); tea; now eapply lrefl.
 Qed.
 
 Lemma reflValidTm {Γ t A l} (VΓ : [||-v Γ])
@@ -19,7 +34,29 @@ Lemma reflValidTm {Γ t A l} (VΓ : [||-v Γ])
   (Vt : [Γ ||-v<l> t : A | VΓ | VA]) :
   [Γ ||-v<l> t ≅ t : A | VΓ | VA].
 Proof.
-  constructor; intros; apply reflLRTmEq; now eapply validTm.
+  constructor; intros; now eapply validTmExt.
+Qed.
+
+Lemma lreflValidTm {Γ t u A l} (VΓ : [||-v Γ])
+  (VA : [Γ ||-v<l> A | VΓ])
+  (Vtu : [Γ ||-v<l> t ≅ u : A | VΓ | VA]) :
+  [Γ ||-v<l> t : A | VΓ | VA].
+Proof.
+  constructor; intros.
+  etransitivity; [now eapply validTmEq|symmetry].
+  eapply LRTmEqConv.
+  2: now eapply validTmEq.
+  eapply LRTyEqSym.
+  eapply validTyExt.
+  Unshelve. 1,6-8:tea. now eapply urefl.
+Qed.
+
+Lemma ureflValidTm {Γ t u A l} (VΓ : [||-v Γ])
+  (VA : [Γ ||-v<l> A | VΓ])
+  (Vtu : [Γ ||-v<l> t ≅ u : A | VΓ | VA]) :
+  [Γ ||-v<l> u : A | VΓ | VA].
+Proof.
+  eapply lreflValidTm; now eapply symValidTmEq.
 Qed.
 
 End Reflexivity.

--- a/theories/Substitution/Reflexivity.v
+++ b/theories/Substitution/Reflexivity.v
@@ -8,7 +8,7 @@ Set Universe Polymorphism.
 Section Reflexivity.
 Context `{GenericTypingProperties}.
 
-Lemma reflValidTy {Γ A l} (VΓ : [||-v Γ])
+Lemma reflValidTy {Γ A l} {VΓ : [||-v Γ]}
   (VA : [Γ ||-v<l> A | VΓ]) :
   [Γ ||-v<l> A ≅ A | VΓ | VA].
 Proof.
@@ -16,8 +16,8 @@ Proof.
 Qed.
 Set Printing Primitive Projection Parameters.
 
-Lemma ureflValidTy {Γ A B l} (VΓ : [||-v Γ])
-  (VA : [Γ ||-v<l> A | VΓ])
+Lemma ureflValidTy {Γ A B l} {VΓ : [||-v Γ]}
+  {VA : [Γ ||-v<l> A | VΓ]}
   (VAB : [Γ ||-v<l> A ≅ B | VΓ | VA]) :
   [Γ ||-v<l> B | VΓ ].
 Proof.
@@ -29,16 +29,15 @@ Proof.
   (unshelve now eapply validTyEq); tea; now eapply lrefl.
 Qed.
 
-Lemma reflValidTm {Γ t A l} (VΓ : [||-v Γ])
-  (VA : [Γ ||-v<l> A | VΓ])
+#[deprecated(note="Unneeded")]
+Lemma reflValidTm {Γ t A l} {VΓ : [||-v Γ]}
+  {VA : [Γ ||-v<l> A | VΓ]}
   (Vt : [Γ ||-v<l> t : A | VΓ | VA]) :
   [Γ ||-v<l> t ≅ t : A | VΓ | VA].
-Proof.
-  constructor; intros; now eapply validTmExt.
-Qed.
+Proof. exact Vt. Qed.
 
 Lemma lreflValidTm {Γ t u A l} (VΓ : [||-v Γ])
-  (VA : [Γ ||-v<l> A | VΓ])
+  {VA : [Γ ||-v<l> A | VΓ]}
   (Vtu : [Γ ||-v<l> t ≅ u : A | VΓ | VA]) :
   [Γ ||-v<l> t : A | VΓ | VA].
 Proof.
@@ -51,8 +50,9 @@ Proof.
   Unshelve. 1,6-8:tea. now eapply urefl.
 Qed.
 
-Lemma ureflValidTm {Γ t u A l} (VΓ : [||-v Γ])
-  (VA : [Γ ||-v<l> A | VΓ])
+Lemma ureflValidTm {Γ t u A l}
+  {VΓ : [||-v Γ]}
+  {VA : [Γ ||-v<l> A | VΓ]}
   (Vtu : [Γ ||-v<l> t ≅ u : A | VΓ | VA]) :
   [Γ ||-v<l> u : A | VΓ | VA].
 Proof.

--- a/theories/Substitution/SingleSubst.v
+++ b/theories/Substitution/SingleSubst.v
@@ -1,7 +1,7 @@
 From LogRel.AutoSubst Require Import core unscoped Ast Extra.
 From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakening GenericTyping LogicalRelation Validity.
 From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity NormalRed.
-From LogRel.Substitution Require Import Irrelevance Properties Conversion.
+From LogRel.Substitution Require Import Irrelevance Properties Conversion Reflexivity.
 
 Set Universe Polymorphism.
 
@@ -21,16 +21,16 @@ Lemma substS {Γ F G t l} {VΓ : [||-v Γ]}
   [Γ ||-v<l> G[t..] | VΓ].
 Proof.
   opector; intros; rewrite singleSubstComm.
-  - unshelve eapply validTy. 3,4:  tea.
-    now eapply consSubstSvalid.
+  - unshelve eapply validTy.
+    6: now eapply consSubstEqvalid.
+    tea.
   - irrelevance0. 1: symmetry; apply singleSubstComm.
-    eapply validTyExt.
-    1: eapply consSubstS; now  eapply validTm.
-    now eapply consSubstSEqvalid.
-    Unshelve. all: eassumption.
+    unshelve eapply validTyExt.
+    5: now eapply consSubstEqvalid.
+    tea.
 Qed.
 
-Lemma substSEq {Γ F F' G G' t t' l} {VΓ : [||-v Γ]} 
+Lemma substSEq {Γ F F' G G' t t' l} {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
   {VF' : [Γ ||-v<l> F' | VΓ]}
   (VFF' : [Γ ||-v<l> F ≅ F' | VΓ | VF])
@@ -47,21 +47,19 @@ Lemma substSEq {Γ F F' G G' t t' l} {VΓ : [||-v Γ]}
 Proof.
   constructor; intros.
   assert (VtF' : [Γ ||-v<l> t : F' | VΓ | VF']) by now eapply conv.
-  pose proof (consSubstSvalid Vσ Vt').
-  pose proof (consSubstSvalid Vσ VtF').
+  pose proof (consSubstEqvalid Vσσ' Vt').
+  pose proof (consSubstEqvalid Vσσ' VtF').
   rewrite singleSubstComm; irrelevance0.
   1: symmetry; apply singleSubstComm.
   eapply transEq.
   - unshelve now eapply validTyEq.
-    2: now eapply consSubstSvalid.
-  - eapply validTyExt; tea.
-    unshelve econstructor.
-    1: eapply reflSubst.
-    eapply validTmEq.
-    now eapply convEq.
-    Unshelve. all: tea.
+    3: now eapply consSubstEqvalid.
+  - unshelve (eapply validTyExt; tea).
+    3: tea.
+    1: tea.
+    unshelve eapply consSubstEq; [now eapply urefl|].
+     eapply validTmEq. now eapply convEq.
 Qed.
-
 
 
 
@@ -69,22 +67,19 @@ Lemma substSTm {Γ F G t f l} {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
   (VΓF := validSnoc VΓ VF)
   {VG : [Γ,, F ||-v<l> G | VΓF]}
-  (Vt : [Γ ||-v<l> t : F | VΓ | VF]) 
+  (Vt : [Γ ||-v<l> t : F | VΓ | VF])
   (Vf : [Γ ,, F ||-v<l> f : G | VΓF | VG])
   (VGt := substS VG Vt) :
   [Γ ||-v<l> f[t..] : G[t..] | VΓ | VGt].
 Proof.
-  constructor; intros; rewrite !singleSubstComm; irrelevance0. 
-  1,3: symmetry; apply singleSubstComm.
-  - now eapply validTm.
-  - eapply validTmExt; tea.
-    1: now apply consSubstSvalid.
-    now apply consSubstSEqvalid.
-    Unshelve. 1,3: eassumption.
-    now apply consSubstSvalid.
+  constructor; intros; rewrite !singleSubstComm; irrelevance0.
+  1: symmetry; apply singleSubstComm.
+  unshelve (eapply validTmExt; tea).
+  1: tea.
+  now apply consSubstEqvalid.
 Qed.
 
-Lemma substSTmEq {Γ F F' G G' t t' f f' l} (VΓ : [||-v Γ]) 
+Lemma substSTmEq {Γ F F' G G' t t' f f' l} (VΓ : [||-v Γ])
   (VF : [Γ ||-v<l> F | VΓ])
   (VF' : [Γ ||-v<l> F' | VΓ])
   (VFF' : [Γ ||-v<l> F ≅ F' | VΓ | VF])
@@ -95,34 +90,18 @@ Lemma substSTmEq {Γ F F' G G' t t' f f' l} (VΓ : [||-v Γ])
   (VGG' : [Γ ,, F ||-v<l> G ≅ G' | VΓF | VG])
   (Vt : [Γ ||-v<l> t : F | VΓ | VF])
   (Vt' : [Γ ||-v<l> t' : F' | VΓ | VF'])
-  (Vtt' : [Γ ||-v<l> t ≅ t' : F | VΓ | VF]) 
+  (Vtt' : [Γ ||-v<l> t ≅ t' : F | VΓ | VF])
   (Vf : [Γ ,, F ||-v<l> f : G | VΓF | VG])
   (Vf' : [Γ ,, F' ||-v<l> f' : G' | VΓF' | VG'])
   (Vff' : [Γ ,, F ||-v<l> f ≅ f' : G | VΓF | VG]) :
   [Γ ||-v<l> f[t..] ≅ f'[t'..] : G[t..] | VΓ | substS VG Vt].
 Proof.
-  constructor; intros; rewrite !singleSubstComm; irrelevance0. 
+  constructor; intros; rewrite !singleSubstComm; irrelevance0.
   1: symmetry; apply singleSubstComm.
-  eapply transEqTerm.
-  + unshelve now eapply validTmEq.
-    2: now eapply consSubstSvalid.
-  + assert (Vσt : [Δ ||-v (t[σ] .: σ) : _ | VΓF' | wfΔ])
-     by (eapply consSubstSvalid; tea; now eapply conv).
-    assert (Vσt' : [Δ ||-v (t'[σ] .: σ) : _ | VΓF' | wfΔ])
-     by (eapply consSubstSvalid; tea; now eapply conv).
-    assert (Vσtσt' : [Δ ||-v (t[σ] .: σ) ≅ (t'[σ] .: σ) : _ | VΓF' | wfΔ | Vσt]).
-    1:{
-      constructor.
-      - bsimpl; epose (reflSubst _  _ Vσ); now eapply irrelevanceSubstEq.
-      - bsimpl; eapply validTmEq. now eapply convEq.
-    }
-    eapply LRTmEqRedConv.
-    2: eapply (validTmExt Vf' _ Vσt Vσt' Vσtσt').
-    eapply LRTyEqSym. now eapply validTyEq.
-    Unshelve. 2: now eapply consSubstSvalid.
+  unshelve now eapply validTmEq.
+  1: tea.
+  now unshelve now eapply consSubstEq, validTmEq.
 Qed.
-
-(* Skipping a series of lemmas on single substitution of a weakened term *)
 
 
 Lemma liftSubstComm G t σ : G[t]⇑[σ] = G[t[σ] .: ↑ >> σ].
@@ -137,30 +116,26 @@ Lemma substLiftS {Γ F G t l} (VΓ : [||-v Γ])
   (Vt : [Γ,, F ||-v<l> t : F⟨@wk1 Γ F⟩ | VΓF | VF']) :
   [Γ ,, F ||-v<l> G[t]⇑ | VΓF].
 Proof.
-  assert (h : forall Δ σ (wfΔ: [|- Δ])
-    (vσ: [VΓF | Δ ||-v σ : Γ,, F | wfΔ]),
-    [VΓF | Δ ||-v (t[σ] .: ↑ >> σ) : _ | wfΔ ]).
+  assert (h : forall Δ σ σ' (wfΔ: [|- Δ])
+    (vσσ': [VΓF | Δ ||-v σ ≅ σ' : Γ,, F | wfΔ]),
+    [VΓF | Δ ||-v (t[σ] .: ↑ >> σ) ≅ (t[σ'] .: ↑ >> σ') : _ | wfΔ ]).
   1:{
     unshelve econstructor.
-    + asimpl; now eapply validTail.
-    + cbn. irrelevance0.
-      2: now eapply validTm.
-      now bsimpl.
-  }
-  opector; intros; rewrite liftSubstComm.
-  - unshelve eapply validTy; cycle 2; tea; now eapply h.
-  - irrelevance0.
-    2: unshelve eapply validTyExt.
-    8: now eapply h.
-    4: now eapply (h _ _  _ vσ).
-    1: now bsimpl.
-    1: tea.
-    constructor.
-    + asimpl; eapply irrelevanceSubstEq; now eapply eqTail.
+    + asimpl; now eapply eqTail.
     + cbn. irrelevance0.
       2: now eapply validTmExt.
       now bsimpl.
-      Unshelve. all:tea.
+  }
+  opector; intros; rewrite liftSubstComm.
+  - unshelve eapply validTy.
+    6: now eapply h.
+    tea.
+  - irrelevance0.
+    2: unshelve eapply validTyExt.
+    7: now eapply h.
+    2: tea.
+    now bsimpl.
+    Unshelve. all:tea.
 Qed.
 
 Lemma substLiftSEq {Γ F G G' t l} (VΓ : [||-v Γ])
@@ -174,10 +149,10 @@ Lemma substLiftSEq {Γ F G G' t l} (VΓ : [||-v Γ])
   [Γ ,, F ||-v<l> G[t]⇑ ≅ G'[t]⇑ | VΓF | substLiftS _ VF VG Vt].
 Proof.
   constructor; intros; rewrite liftSubstComm.
-  assert (Vσt : [Δ ||-v (t[σ] .: ↑ >> σ) : _ | VΓF | wfΔ ]). 1:{
+  assert (Vσt : [Δ ||-v (t[σ] .: ↑ >> σ) ≅ (t[σ'] .: ↑ >> σ') : _ | VΓF | wfΔ ]). 1:{
     unshelve econstructor.
-    + bsimpl. now eapply validTail.
-    + bsimpl. instValid Vσ. irrelevance.
+    + bsimpl. now eapply eqTail.
+    + cbn; instValid Vσσ'; irrelevance.
   }
   instValid Vσt. irrelevance.
 Qed.
@@ -189,25 +164,18 @@ Lemma substLiftSEq' {Γ F G G' t t' l} (VΓ : [||-v Γ])
   (VG' : [Γ,, F ||-v<l> G' | VΓF])
   (VGeq : [Γ,, F ||-v<l> G ≅ G' | VΓF | VG])
   (VF' := wk1ValidTy VF VF)
-  (Vt : [Γ,, F ||-v<l> t : F⟨@wk1 Γ F⟩ | VΓF | VF']) 
+  (Vt : [Γ,, F ||-v<l> t : F⟨@wk1 Γ F⟩ | VΓF | VF'])
   (Vt' : [Γ,, F ||-v<l> t' : F⟨@wk1 Γ F⟩ | VΓF | VF'])
   (Vtt' : [Γ,, F ||-v<l> t ≅ t' : F⟨@wk1 Γ F⟩ | VΓF | VF']) :
   [Γ ,, F ||-v<l> G[t]⇑ ≅ G'[t']⇑ | VΓF | substLiftS _ VF VG Vt].
 Proof.
-  eapply transValidTyEq.
-  1: eapply substLiftSEq; [| exact VGeq]; tea.
-  constructor; intros; irrelevance0; rewrite liftSubstComm ; [reflexivity|].
-  instValid Vσ.
-  eapply validTyExt.
-  + unshelve eapply consSubstS.
-    6: now eapply validTail.
-    3: exact VF. 
-    irrelevance.
-  + unshelve eapply consSubstSEq'.
-    1: now eapply validTail.
-    1,3: irrelevance.
-    eapply reflSubst.
-    Unshelve. 3: tea. now eapply substLiftS.
+  constructor; intros; rewrite liftSubstComm.
+  assert (Vσt : [Δ ||-v (t[σ] .: ↑ >> σ) ≅ (t'[σ'] .: ↑ >> σ') : _ | VΓF | wfΔ ]). 1:{
+    unshelve econstructor.
+    + bsimpl. now eapply eqTail.
+    + cbn; instValid Vσσ'; irrelevance.
+  }
+  instValid Vσt. irrelevance.
 Qed.
 
 
@@ -219,8 +187,8 @@ Lemma singleSubstPoly {Γ F G t l lF}
 Proof.
   replace G[t..] with G[t .: wk_id (Γ:=Γ) >> tRel] by now bsimpl.
   unshelve eapply (PolyRed.posRed RFG).
-  1: escape; gen_typing.
-  irrelevance0; tea.
+  2: escape; gen_typing.
+  2: irrelevance0; tea.
   now bsimpl.
 Qed.
 
@@ -244,44 +212,34 @@ Proof.
   eapply (ParamRedTy.polyRed (normRedΣ0 (invLRΣ ΠFG))).
 Qed.
 
+Lemma substId Γ t u : t[u..] = t[u .: wk_id (Γ:=Γ) >> tRel ].
+Proof. now bsimpl. Qed.
+
 Lemma singleSubstPoly2 {Γ F F' G G' t t' l lF lF'}
   {RFG : PolyRed Γ l F G}
   (RFGeq : PolyRedEq RFG F' G')
   {RF : [Γ ||-<lF> F]}
-  {RF' : [Γ ||-<lF'> F']}
-  (Rt : [Γ ||-<lF> t : F | RF]) 
-  (Rt' : [Γ ||-<lF'> t' : F' | RF']) 
   (Rteq : [Γ ||-<lF> t ≅ t' : F | RF])
   (RGt : [Γ ||-<lF> G[t..]])
   (RGt' : [Γ ||-<lF'> G'[t'..]]) :
   [Γ ||-<lF> G[t..] ≅ G'[t'..] | RGt ].
 Proof.
   assert (wfΓ : [|-Γ]) by (escape ; gen_typing).
-  assert [Γ ||-<l> t' : F⟨wk_id (Γ:=Γ)⟩ | PolyRed.shpRed RFG wk_id wfΓ].
-  {
-    eapply LRTmRedConv; tea.
-    eapply LRTyEqSym. 
-    replace F' with F'⟨wk_id (Γ := Γ)⟩ by now bsimpl.
-    eapply (PolyRedEq.shpRed RFGeq).
-  }
+  rewrite (substId Γ).
+  irrelevance0; [now rewrite (substId Γ)|].
   eapply transEq.
-  2: (replace G'[t'..] with G'[t' .: wk_id (Γ:=Γ) >> tRel] by now bsimpl); eapply (PolyRedEq.posRed RFGeq).
-  irrelevance0.
-  2: eapply (PolyRed.posExt RFG).
-  3: irrelevance0; tea; now bsimpl.
-  1: now bsimpl.
-  eassumption.
-  Unshelve. all: tea.
-  irrelevance0; tea; now bsimpl.
+  + unshelve eapply PolyRed.posExt.
+    2,4: tea.
+    2: irrelevance.
+  + unshelve eapply (PolyRedEq.posRed RFGeq).
+    2: tea.
+    2: irrelevance0; [| now eapply urefl]; now bsimpl.
 Qed.
 
 Lemma singleSubstΠ2 {Γ F F' G G' t t' l lF lF'}
   {ΠFG : [Γ ||-<l> tProd F G]}
   (ΠFGeq : [Γ ||-<l> tProd F G ≅ tProd F' G' | ΠFG])
   {RF : [Γ ||-<lF> F]}
-  {RF' : [Γ ||-<lF'> F']}
-  (Rt : [Γ ||-<lF> t : F | RF]) 
-  (Rt' : [Γ ||-<lF'> t' : F' | RF']) 
   (Rteq : [Γ ||-<lF> t ≅ t' : F | RF])
   (RGt : [Γ ||-<lF> G[t..]])
   (RGt' : [Γ ||-<lF'> G'[t'..]]) :
@@ -296,25 +254,25 @@ Proof.
   exact polyRed.
 Qed.
 
-Lemma substSΠaux {Γ F G t l} 
+Lemma substSΠaux {Γ F G t l}
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
   (VΠFG : [Γ ||-v<l> tProd F G | VΓ])
   (Vt : [Γ ||-v<l> t : F | VΓ | VF])
-  (Δ : context) (σ : nat -> term) 
-  (wfΔ : [ |-[ ta ] Δ]) (vσ : [VΓ | Δ ||-v σ : Γ | wfΔ]) :
+  (Δ : context) (σ σ' : nat -> term)
+  (wfΔ : [ |-[ ta ] Δ]) (vσ : [VΓ | Δ ||-v σ ≅ σ' : Γ | wfΔ]) :
   [Δ ||-< l > G[up_term_term σ][t[σ]..]].
 Proof.
   eapply singleSubstΠ1.
   eapply (validTy VΠFG); tea.
-  now eapply validTm.
-  Unshelve. all: eassumption.
+  unshelve now eapply validTmExt.
+  1: tea. now eapply lrefl.
 Qed.
 
 Lemma singleSubstComm' G t σ : G[t..][σ] = G[up_term_term σ][t[σ]..].
 Proof. now asimpl. Qed.
 
-Lemma substSΠ {Γ F G t l} 
+Lemma substSΠ {Γ F G t l}
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
   (VΠFG : [Γ ||-v<l> tProd F G | VΓ])
@@ -322,42 +280,41 @@ Lemma substSΠ {Γ F G t l}
   [Γ ||-v<l> G[t..] | VΓ].
 Proof.
   opector; intros.
-  - rewrite singleSubstComm'; now eapply substSΠaux.
+  - rewrite singleSubstComm'. now eapply substSΠaux.
   - rewrite singleSubstComm'.
     irrelevance0. 1: symmetry; apply singleSubstComm'.
     eapply singleSubstΠ2.
     1: eapply (validTyExt VΠFG).
-    1, 2: tea.
-    1, 2: now eapply validTm.
     1: now eapply validTmExt.
-    now eapply substSΠaux.
+    eapply substSΠaux; tea; now eapply urefl.
     Unshelve. all: tea.
     now eapply substSΠaux.
 Qed.
 
-Lemma substSΠeq {Γ F F' G G' t u l} 
+
+Lemma substSΠeq {Γ F F' G G' t u l}
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
   {VF' : [Γ ||-v<l> F' | VΓ]}
   {VΠFG : [Γ ||-v<l> tProd F G | VΓ]}
-  (VΠFG' : [Γ ||-v<l> tProd F' G' | VΓ])
   (VΠFGeq : [Γ ||-v<l> tProd F G ≅ tProd F' G' | VΓ | VΠFG])
-  (Vt : [Γ ||-v<l> t : F | VΓ | VF]) 
-  (Vu : [Γ ||-v<l> u : F' | VΓ | VF']) 
-  (Vtu : [Γ ||-v<l> t ≅ u : F | VΓ | VF]) 
+  (Vt : [Γ ||-v<l> t : F | VΓ | VF])
+  (Vu : [Γ ||-v<l> u : F' | VΓ | VF'])
+  (Vtu : [Γ ||-v<l> t ≅ u : F | VΓ | VF])
   (VGt := substSΠ VΠFG Vt) :
   [Γ ||-v<l> G[t..] ≅ G'[u..] | VΓ | VGt].
 Proof.
+  pose proof (ureflValidTy _ _ VΠFGeq).
   constructor; intros.
   rewrite singleSubstComm'.
   irrelevance0.
   1: symmetry; apply singleSubstComm'.
   eapply singleSubstΠ2.
   1: now eapply (validTyEq VΠFGeq).
-  3: now eapply validTmEq.
-  1,2: now eapply validTm.
-  now eapply substSΠaux.
+  1: now eapply validTmEq.
+  eapply substSΠaux; tea.
   Unshelve. all: tea.
+  1: now eapply urefl.
   now eapply substSΠaux.
 Qed.
 

--- a/theories/Substitution/SingleSubst.v
+++ b/theories/Substitution/SingleSubst.v
@@ -14,10 +14,10 @@ Lemma singleSubstComm G t σ : G[t..][σ] = G[t[σ] .: σ].
 Proof. now asimpl. Qed.
 
 
-Lemma substS {Γ F G t l} {VΓ : [||-v Γ]}
+Lemma substS {Γ F G t t' l} {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
   (VG : [Γ,, F ||-v<l> G | validSnoc VΓ VF])
-  (Vt : [Γ ||-v<l> t : F | VΓ | VF]) :
+  (Vt : [Γ ||-v<l> t ≅ t' : F | VΓ | VF]) :
   [Γ ||-v<l> G[t..] | VΓ].
 Proof.
   opector; intros; rewrite singleSubstComm.
@@ -26,42 +26,43 @@ Proof.
     tea.
   - irrelevance0. 1: symmetry; apply singleSubstComm.
     unshelve eapply validTyExt.
-    5: now eapply consSubstEqvalid.
+    5: now eapply consSubstEqvalid, lreflValidTm.
     tea.
 Qed.
 
 Lemma substSEq {Γ F F' G G' t t' l} {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
-  {VF' : [Γ ||-v<l> F' | VΓ]}
   (VFF' : [Γ ||-v<l> F ≅ F' | VΓ | VF])
   (VΓF := validSnoc VΓ VF)
-  (VΓF' := validSnoc VΓ VF')
   {VG : [Γ,, F ||-v<l> G | VΓF]}
-  (VG' : [Γ,, F' ||-v<l> G' | VΓF'])
   (VGG' : [Γ ,, F ||-v<l> G ≅ G' | VΓF | VG])
-  (Vt : [Γ ||-v<l> t : F | VΓ | VF])
-  (Vt' : [Γ ||-v<l> t' : F' | VΓ | VF'])
   (Vtt' : [Γ ||-v<l> t ≅ t' : F | VΓ | VF])
-  (VGt := substS VG Vt) :
+  (VGt := substS VG Vtt') :
   [Γ ||-v<l> G[t..] ≅ G'[t'..] | VΓ | VGt].
 Proof.
   constructor; intros.
-  assert (VtF' : [Γ ||-v<l> t : F' | VΓ | VF']) by now eapply conv.
-  pose proof (consSubstEqvalid Vσσ' Vt').
-  pose proof (consSubstEqvalid Vσσ' VtF').
   rewrite singleSubstComm; irrelevance0.
   1: symmetry; apply singleSubstComm.
-  eapply transEq.
-  - unshelve now eapply validTyEq.
-    3: now eapply consSubstEqvalid.
-  - unshelve (eapply validTyExt; tea).
-    3: tea.
-    1: tea.
-    unshelve eapply consSubstEq; [now eapply urefl|].
-     eapply validTmEq. now eapply convEq.
+  unshelve now eapply validTyEq.
+  2: now eapply consSubstEqvalid.
 Qed.
 
-
+Lemma substSTmEq {Γ F F' G G' t t' f f' l} (VΓ : [||-v Γ])
+  (VF : [Γ ||-v<l> F | VΓ])
+  (VFF' : [Γ ||-v<l> F ≅ F' | VΓ | VF])
+  (VΓF := validSnoc VΓ VF)
+  (VG : [Γ,, F ||-v<l> G | VΓF])
+  (VGG' : [Γ ,, F ||-v<l> G ≅ G' | VΓF | VG])
+  (Vtt' : [Γ ||-v<l> t ≅ t' : F | VΓ | VF])
+  (Vff' : [Γ ,, F ||-v<l> f ≅ f' : G | VΓF | VG]) :
+  [Γ ||-v<l> f[t..] ≅ f'[t'..] : G[t..] | VΓ | substS VG Vtt'].
+Proof.
+  constructor; intros; rewrite !singleSubstComm; irrelevance0.
+  1: symmetry; apply singleSubstComm.
+  unshelve now eapply validTmEq.
+  1: tea.
+  now unshelve now eapply consSubstEq, validTmEq.
+Qed.
 
 Lemma substSTm {Γ F G t f l} {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
@@ -71,42 +72,11 @@ Lemma substSTm {Γ F G t f l} {VΓ : [||-v Γ]}
   (Vf : [Γ ,, F ||-v<l> f : G | VΓF | VG])
   (VGt := substS VG Vt) :
   [Γ ||-v<l> f[t..] : G[t..] | VΓ | VGt].
-Proof.
-  constructor; intros; rewrite !singleSubstComm; irrelevance0.
-  1: symmetry; apply singleSubstComm.
-  unshelve (eapply validTmExt; tea).
-  1: tea.
-  now apply consSubstEqvalid.
-Qed.
-
-Lemma substSTmEq {Γ F F' G G' t t' f f' l} (VΓ : [||-v Γ])
-  (VF : [Γ ||-v<l> F | VΓ])
-  (VF' : [Γ ||-v<l> F' | VΓ])
-  (VFF' : [Γ ||-v<l> F ≅ F' | VΓ | VF])
-  (VΓF := validSnoc VΓ VF)
-  (VΓF' := validSnoc VΓ VF')
-  (VG : [Γ,, F ||-v<l> G | VΓF])
-  (VG' : [Γ,, F' ||-v<l> G' | VΓF'])
-  (VGG' : [Γ ,, F ||-v<l> G ≅ G' | VΓF | VG])
-  (Vt : [Γ ||-v<l> t : F | VΓ | VF])
-  (Vt' : [Γ ||-v<l> t' : F' | VΓ | VF'])
-  (Vtt' : [Γ ||-v<l> t ≅ t' : F | VΓ | VF])
-  (Vf : [Γ ,, F ||-v<l> f : G | VΓF | VG])
-  (Vf' : [Γ ,, F' ||-v<l> f' : G' | VΓF' | VG'])
-  (Vff' : [Γ ,, F ||-v<l> f ≅ f' : G | VΓF | VG]) :
-  [Γ ||-v<l> f[t..] ≅ f'[t'..] : G[t..] | VΓ | substS VG Vt].
-Proof.
-  constructor; intros; rewrite !singleSubstComm; irrelevance0.
-  1: symmetry; apply singleSubstComm.
-  unshelve now eapply validTmEq.
-  1: tea.
-  now unshelve now eapply consSubstEq, validTmEq.
-Qed.
+Proof. eapply substSTmEq; tea; now eapply reflValidTy. Qed.
 
 
 Lemma liftSubstComm G t σ : G[t]⇑[σ] = G[t[σ] .: ↑ >> σ].
 Proof. now bsimpl. Qed.
-
 
 Lemma substLiftS {Γ F G t l} (VΓ : [||-v Γ])
   (VF : [Γ ||-v<l> F | VΓ])
@@ -179,10 +149,10 @@ Proof.
 Qed.
 
 
-Lemma singleSubstPoly {Γ F G t l lF}
+Lemma singleSubstPoly {Γ F G t u l lF}
   (RFG : PolyRed Γ l F G)
   {RF : [Γ ||-<lF> F]}
-  (Rt : [Γ ||-<lF> t : F | RF]) :
+  (Rt : [Γ ||-<lF> t ≅ u : F | RF]) :
   [Γ ||-<l> G[t..]].
 Proof.
   replace G[t..] with G[t .: wk_id (Γ:=Γ) >> tRel] by now bsimpl.
@@ -192,20 +162,20 @@ Proof.
   now bsimpl.
 Qed.
 
-Lemma singleSubstΠ1 {Γ F G t l lF}
+Lemma singleSubstΠ1 {Γ F G t u l lF}
   (ΠFG : [Γ ||-<l> tProd F G])
   {RF : [Γ ||-<lF> F]}
-  (Rt : [Γ ||-<lF> t : F | RF]) :
+  (Rt : [Γ ||-<lF> t ≅ u : F | RF]) :
   [Γ ||-<l> G[t..]].
 Proof.
   eapply singleSubstPoly; tea.
   eapply (ParamRedTy.polyRed (normRedΠ0 (invLRΠ ΠFG))).
 Qed.
 
-Lemma singleSubstΣ1 {Γ F G t l lF}
+Lemma singleSubstΣ1 {Γ F G t u l lF}
   (ΠFG : [Γ ||-<l> tSig F G])
   {RF : [Γ ||-<lF> F]}
-  (Rt : [Γ ||-<lF> t : F | RF]) :
+  (Rt : [Γ ||-<lF> t ≅ u : F | RF]) :
   [Γ ||-<l> G[t..]].
 Proof.
   eapply singleSubstPoly; tea.
@@ -215,13 +185,12 @@ Qed.
 Lemma substId Γ t u : t[u..] = t[u .: wk_id (Γ:=Γ) >> tRel ].
 Proof. now bsimpl. Qed.
 
-Lemma singleSubstPoly2 {Γ F F' G G' t t' l lF lF'}
+Lemma singleSubstPoly2 {Γ F F' G G' t t' l lF}
   {RFG : PolyRed Γ l F G}
   (RFGeq : PolyRedEq RFG F' G')
   {RF : [Γ ||-<lF> F]}
   (Rteq : [Γ ||-<lF> t ≅ t' : F | RF])
-  (RGt : [Γ ||-<lF> G[t..]])
-  (RGt' : [Γ ||-<lF'> G'[t'..]]) :
+  (RGt : [Γ ||-<lF> G[t..]]) :
   [Γ ||-<lF> G[t..] ≅ G'[t'..] | RGt ].
 Proof.
   assert (wfΓ : [|-Γ]) by (escape ; gen_typing).
@@ -236,13 +205,34 @@ Proof.
     2: irrelevance0; [| now eapply urefl]; now bsimpl.
 Qed.
 
-Lemma singleSubstΠ2 {Γ F F' G G' t t' l lF lF'}
+Lemma singleSubstEqPoly {Γ F G t t' l lF}
+  {RFG : PolyRed Γ l F G}
+  {RF : [Γ ||-<lF> F]}
+  (Rteq : [Γ ||-<lF> t ≅ t' : F | RF])
+  (RGt : [Γ ||-<lF> G[t..]]) :
+  [Γ ||-<lF> G[t..] ≅ G[t'..] | RGt ].
+Proof.
+  eapply (singleSubstPoly2 (F':=F) (RFG:=RFG)); tea.
+  destruct RFG; econstructor; cbn; tea; intros; eapply reflLRTyEq.
+Qed.
+
+Lemma singleSubstEqΣ {Γ F G t t' l lF}
+  {RFG : [Γ ||-<l> tSig F G]}
+  {RF : [Γ ||-<lF> F]}
+  (Rteq : [Γ ||-<lF> t ≅ t' : F | RF])
+  (RGt : [Γ ||-<lF> G[t..]]) :
+  [Γ ||-<lF> G[t..] ≅ G[t'..] | RGt ].
+Proof.
+  unshelve (eapply singleSubstEqPoly; tea).
+  2: exact (normRedΣ0 (invLRΣ RFG)).
+Qed.
+
+Lemma singleSubstΠ2 {Γ F F' G G' t t' l lF}
   {ΠFG : [Γ ||-<l> tProd F G]}
   (ΠFGeq : [Γ ||-<l> tProd F G ≅ tProd F' G' | ΠFG])
   {RF : [Γ ||-<lF> F]}
   (Rteq : [Γ ||-<lF> t ≅ t' : F | RF])
-  (RGt : [Γ ||-<lF> G[t..]])
-  (RGt' : [Γ ||-<lF'> G'[t'..]]) :
+  (RGt : [Γ ||-<lF> G[t..]]) :
   [Γ ||-<lF> G[t..] ≅ G'[t'..] | RGt ].
 Proof.
   eapply singleSubstPoly2; tea.
@@ -254,19 +244,19 @@ Proof.
   exact polyRed.
 Qed.
 
-Lemma substSΠaux {Γ F G t l}
+Lemma substSΠaux {Γ F G t u l}
   {VΓ : [||-v Γ]}
   {VF : [Γ ||-v<l> F | VΓ]}
   (VΠFG : [Γ ||-v<l> tProd F G | VΓ])
-  (Vt : [Γ ||-v<l> t : F | VΓ | VF])
+  (Vt : [Γ ||-v<l> t ≅ u : F | VΓ | VF])
   (Δ : context) (σ σ' : nat -> term)
   (wfΔ : [ |-[ ta ] Δ]) (vσ : [VΓ | Δ ||-v σ ≅ σ' : Γ | wfΔ]) :
   [Δ ||-< l > G[up_term_term σ][t[σ]..]].
 Proof.
   eapply singleSubstΠ1.
   eapply (validTy VΠFG); tea.
-  unshelve now eapply validTmExt.
-  1: tea. now eapply lrefl.
+  unshelve now eapply validTmEq.
+  1,3: tea.
 Qed.
 
 Lemma singleSubstComm' G t σ : G[t..][σ] = G[up_term_term σ][t[σ]..].
@@ -286,7 +276,6 @@ Proof.
     eapply singleSubstΠ2.
     1: eapply (validTyExt VΠFG).
     1: now eapply validTmExt.
-    eapply substSΠaux; tea; now eapply urefl.
     Unshelve. all: tea.
     now eapply substSΠaux.
 Qed.
@@ -304,7 +293,7 @@ Lemma substSΠeq {Γ F F' G G' t u l}
   (VGt := substSΠ VΠFG Vt) :
   [Γ ||-v<l> G[t..] ≅ G'[u..] | VΓ | VGt].
 Proof.
-  pose proof (ureflValidTy _ _ VΠFGeq).
+  pose proof (ureflValidTy VΠFGeq).
   constructor; intros.
   rewrite singleSubstComm'.
   irrelevance0.
@@ -312,11 +301,8 @@ Proof.
   eapply singleSubstΠ2.
   1: now eapply (validTyEq VΠFGeq).
   1: now eapply validTmEq.
-  eapply substSΠaux; tea.
   Unshelve. all: tea.
-  1: now eapply urefl.
   now eapply substSΠaux.
 Qed.
-
 
 End SingleSubst.

--- a/theories/TypeConstructorsInj.v
+++ b/theories/TypeConstructorsInj.v
@@ -5,7 +5,7 @@ From LogRel Require Import Utils BasicAst Notations Context NormalForms Weakenin
   GenericTyping DeclarativeTyping DeclarativeInstance.
 From LogRel Require Import LogicalRelation Validity Fundamental DeclarativeSubst.
 From LogRel.LogicalRelation Require Import Escape Irrelevance Neutral Induction NormalRed.
-From LogRel.Substitution Require Import Escape Poly.
+From LogRel.Substitution Require Import Escape Poly Reflexivity.
 
 Set Printing Primitive Projection Parameters.
 
@@ -53,15 +53,15 @@ Section TypeConstructors.
     clearbody HTred.
     clear HT.
     eapply reducibleTy in HT'.
-    revert nfT T' nfT' HΓ HT' Hconv. 
-    revert HTred. 
+    revert nfT T' nfT' HΓ HT' Hconv.
+    revert HTred.
     generalize (eq_refl : one = one).
     generalize one at 1 3; intros l eql HTred; revert eql.
     pattern l, Γ, T, HTred; apply LR_rect_TyUr; clear l Γ T HTred.
     all: intros ? Γ T.
     - intros [] -> nfT T' nfT' HΓ HT' [].
       assert (T' = U) as HeqT' by (eapply redtywf_whnf ; gen_typing); subst.
-      assert (T = U) as HeqU by (eapply redtywf_whnf ; gen_typing). 
+      assert (T = U) as HeqU by (eapply redtywf_whnf ; gen_typing).
       destruct nfT ; inversion HeqU ; subst.
       2: now exfalso ; gen_typing.
       clear HeqU.
@@ -81,7 +81,7 @@ Section TypeConstructors.
       1-6: symmetry in ne'; apply convneu_whne in ne'; inversion ne'.
       cbn. gen_typing.
     - intros [dom cod red] _ _ -> nfT T' nfT' HΓ HT'[dom' cod' red']; cbn in *.
-      assert (T = tProd dom cod) as HeqT by (apply red_whnf ; gen_typing). 
+      assert (T = tProd dom cod) as HeqT by (apply red_whnf ; gen_typing).
       assert (T' = tProd dom' cod') as HeqT' by (apply red_whnf ; gen_typing).
       destruct nfT; cycle -1.
       1: subst ; exfalso ; gen_typing.
@@ -109,7 +109,7 @@ Section TypeConstructors.
         * exfalso; subst; inversion w.
       + exfalso; subst; inversion w.
     - intros [dom cod red] _ _ -> nfT T' nfT' HΓ HT' [dom' cod' red'].
-      assert (T = tSig dom cod) as HeqT by (apply red_whnf ; gen_typing). 
+      assert (T = tSig dom cod) as HeqT by (apply red_whnf ; gen_typing).
       assert (T' = tSig dom' cod') as HeqT' by (apply red_whnf ; gen_typing).
       destruct nfT; cycle -1.
       1: subst; inv_whne.
@@ -214,7 +214,7 @@ Section TypeConstructors.
     pose proof HT as HT'.
     unshelve eapply red_ty_complete in HT as (T''&[? nfT]).
     2: econstructor.
-    assert [Γ |- tProd A B ≅ T''] as Hconv by 
+    assert [Γ |- tProd A B ≅ T''] as Hconv by
       (etransitivity ; [eassumption|now eapply RedConvTyC]).
     unshelve eapply ty_conv_inj in Hconv.
     1: constructor.
@@ -242,7 +242,7 @@ Section TypeConstructors.
     pose proof HT as HT'.
     unshelve eapply red_ty_complete in HT as (T''&[? nfT]).
     2: econstructor.
-    assert [Γ |- tSig A B ≅ T''] as Hconv by 
+    assert [Γ |- tSig A B ≅ T''] as Hconv by
       (etransitivity ; [eassumption|now eapply RedConvTyC]).
     unshelve eapply ty_conv_inj in Hconv.
     1: constructor.
@@ -251,7 +251,7 @@ Section TypeConstructors.
     do 2 eexists ; split.
     all: eassumption.
   Qed.
-  
+
   Corollary red_ty_compl_sig_r Γ A B T :
     [Γ |- T ≅ tSig A B] ->
     ∑ A' B', [× [Γ |- T ⤳* tSig A' B'], [Γ |- A' ≅ A] & [Γ,, A' |- B ≅ B']].
@@ -277,7 +277,7 @@ Section TypeConstructors.
     pose proof HT as HT'.
     unshelve eapply red_ty_complete in HT as (T''&[? nfT]).
     2: econstructor.
-    assert [Γ |- tId A x y ≅ T''] as Hconv by 
+    assert [Γ |- tId A x y ≅ T''] as Hconv by
       (etransitivity ; [eassumption|now eapply RedConvTyC]).
     unshelve eapply ty_conv_inj in Hconv.
     1: constructor.
@@ -285,7 +285,7 @@ Section TypeConstructors.
     destruct nfT, Hconv.
     do 3 eexists ; split; eassumption.
   Qed.
-  
+
   Corollary red_ty_compl_id_r Γ A x y T :
     [Γ |- T ≅ tId A x y] ->
     ∑ A' x' y', [× [Γ |- T ⤳* tId A' x' y'], [Γ |- A' ≅ A], [Γ |- x ≅ x' : A] & [Γ |- y ≅ y' : A]].
@@ -322,7 +322,7 @@ Section Boundary.
       now eapply typing_wk.
   Qed.
 
-  Lemma scons2_well_subst {Γ A B} : 
+  Lemma scons2_well_subst {Γ A B} :
     (forall a b, [Γ |- a : A] -> [Γ |- b : B[a..]] -> [Γ |-s (b .: a ..) : (Γ ,, A),, B])
     × (forall a a' b b', [Γ |- a ≅ a' : A] -> [Γ |- b ≅ b' : B[a..]] -> [Γ |-s (b .: a..) ≅ (b' .: a'..) : (Γ ,, A),, B]).
   Proof.
@@ -350,7 +350,7 @@ Section Boundary.
   Lemma shift_subst_eq t a : t⟨↑⟩[a..] = t.
   Proof. now asimpl. Qed.
 
-  Lemma idElimMotiveCtx {Γ A x} : 
+  Lemma idElimMotiveCtx {Γ A x} :
     [Γ |- A] ->
     [Γ |- x : A] ->
     [|- (Γ,, A),, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0)].
@@ -359,7 +359,7 @@ Section Boundary.
     assert [|- Γ,, A] by now econstructor.
     econstructor; tea.
     econstructor.
-    1: now eapply wft_wk. 
+    1: now eapply wft_wk.
     1:  eapply ty_wk; tea; econstructor; tea.
     rewrite wk1_ren_on; now eapply ty_var0.
   Qed.
@@ -398,7 +398,9 @@ Section Boundary.
     - intros Γ A B H; apply Fundamental in H as [? VA VB _]; split.
       + now eapply escapeTy.
       + now eapply escapeTy.
-    - intros Γ A t u H; apply Fundamental in H as [? VA Vt Vu]; prod_splitter.
+    - intros Γ A t u H; apply Fundamental in H as [? VA Vtu].
+      pose proof (ureflValidTm Vtu).
+      prod_splitter.
       + now eapply escapeTy.
       + now eapply escapeTm.
       + now eapply escapeTm.
@@ -548,7 +550,7 @@ End Stability.
 
 (** ** Generation *)
 
-(** The generation lemma (the name comes from the PTS literature), gives a 
+(** The generation lemma (the name comes from the PTS literature), gives a
 stronger inversion principle on typing derivations, that give direct access
 to the last non-conversion rule, and bundle together all conversions.
 
@@ -580,7 +582,7 @@ Definition termGenData (Γ : context) (t T : term) : Type :=
     | tSnd p => ∑ A B, T = B[(tFst p)..] × [Γ |- p : tSig A B]
     | tId A x y => [× T = U, [Γ |- A : U], [Γ |- x : A] & [Γ |- y : A]]
     | tRefl A x => [× T = tId A x x, [Γ |- A] & [Γ |- x : A]]
-    | tIdElim A x P hr y e => 
+    | tIdElim A x P hr y e =>
       [× T = P[e .: y..], [Γ |- A], [Γ |- x : A], [Γ,, A,, tId A⟨@wk1 Γ A⟩ x⟨@wk1 Γ A⟩ (tRel 0) |- P], [Γ |- hr : P[tRefl A x .: x..]], [Γ |- y : A] & [Γ |- e : tId A x y]]
   end.
 
@@ -801,7 +803,7 @@ Proof.
   all: try now econstructor.
   all: try now cbn in Hconv.
 Qed.
-  
+
 Lemma type_isType Γ A :
   [Γ |-[de] A] ->
   whnf A ->

--- a/theories/Validity.v
+++ b/theories/Validity.v
@@ -268,14 +268,14 @@ Section Inductions.
     pattern Γ, VΓ. apply validity_rect.
     - reflexivity.
     - intros; do 3 eexists; reflexivity.
-  Qed.
+  Defined.
 
   Lemma invValidityEmpty (VΓ : [||-v ε]) : VΓ = validEmpty.
-  Proof. apply (invValidity VΓ). Qed.
+  Proof. apply (invValidity VΓ). Defined.
 
   Lemma invValiditySnoc {Γ A} (VΓ₀ : [||-v Γ ,, A ]) :
       ∑ l (VΓ : [||-v Γ]) (VA : [Γ ||-v< l > A | VΓ]), VΓ₀ = validSnoc VΓ VA.
-  Proof. apply (invValidity VΓ₀). Qed.
+  Proof. apply (invValidity VΓ₀). Defined.
 
 End Inductions.
 


### PR DESCRIPTION
This PR removes the term reducibility predicate `[ Γ ||- t : A | RA ]` and replaces it with reflexive instance of the reducible term conversion `[ Γ ||- t ≅ t : A | RA ]`. Since we can show quite early on that the latter relation is a PER, witnesses of `[ Γ ||- t ≅ u : A | RA ]` imply both `[ Γ ||- t ≅ t : A | RA ]` and `[ Γ ||- u ≅ u : A | RA ]`. Overall, removing this component does remove a lot of redundancies present in the proofs. 