### PR TITLE
Dependency clean-ups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,10 +80,10 @@ jobs:
         uses: actions/configure-pages@v3
       - name: Upload artifact
         if: github.ref_name == github.event.repository.default_branch
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'docs'
       - name: Deploy to GitHub Pages
         if: github.ref_name == github.event.repository.default_branch
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/theories/Fundamental.v
+++ b/theories/Fundamental.v
@@ -1,6 +1,6 @@
 (** * LogRel.Fundamental: declarative typing implies the logical relation for any generic instance. *)
 From LogRel Require Import Utils Syntax.All GenericTyping DeclarativeTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Escape Irrelevance Reflexivity Transitivity Universe Weakening Neutral Induction NormalRed.
+From LogRel.LogicalRelation Require Import Escape Irrelevance Reflexivity Transitivity Weakening Neutral Induction NormalRed.
 From LogRel.Validity Require Import Validity Irrelevance Properties Conversion Reflexivity SingleSubst Escape.
 From LogRel.Validity.Introductions Require Import Application Universe Pi Lambda Var Nat Empty SimpleArr Sigma Id.
 

--- a/theories/LogicalRelation/Introductions/Id.v
+++ b/theories/LogicalRelation/Introductions/Id.v
@@ -1,5 +1,5 @@
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Escape Irrelevance Weakening Neutral Reflexivity NormalRed Reduction Transitivity Universe EqRedRight.
+From LogRel.LogicalRelation Require Import Induction Escape Irrelevance Weakening Neutral Reflexivity NormalRed Reduction Transitivity EqRedRight Introductions.Universe.
 
 Set Universe Polymorphism.
 Set Printing Primitive Projection Parameters.

--- a/theories/LogicalRelation/Introductions/SimpleArr.v
+++ b/theories/LogicalRelation/Introductions/SimpleArr.v
@@ -1,6 +1,6 @@
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Irrelevance Weakening Neutral Escape Reflexivity NormalRed Reduction Transitivity Application.
-From LogRel.LogicalRelation.Introductions Require Import Poly Pi.
+From LogRel.LogicalRelation Require Import Induction Irrelevance Weakening Neutral Escape Reflexivity NormalRed Reduction Transitivity.
+From LogRel.LogicalRelation.Introductions Require Import Poly Pi Application.
 
 Set Universe Polymorphism.
 Set Printing Primitive Projection Parameters.

--- a/theories/Validity/Introductions/Application.v
+++ b/theories/Validity/Introductions/Application.v
@@ -1,5 +1,5 @@
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity Reduction Application.
+From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity Reduction Introductions.Application.
 From LogRel.Validity Require Import Validity Irrelevance Properties Conversion SingleSubst Reflexivity.
 
 Set Universe Polymorphism.

--- a/theories/Validity/Introductions/Empty.v
+++ b/theories/Validity/Introductions/Empty.v
@@ -1,6 +1,7 @@
 From Coq Require Import CRelationClasses.
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import  Induction  Escape Irrelevance Reflexivity Irrelevance Weakening Neutral Transitivity Reduction Application Universe EqRedRight SimpleArr.
+From LogRel.LogicalRelation Require Import  Induction  Escape Irrelevance Reflexivity Irrelevance Weakening Neutral Transitivity Reduction EqRedRight.
+From LogRel.LogicalRelation.Introductions Require Import Application Universe.
 From LogRel.Validity Require Import Validity Irrelevance Properties Conversion SingleSubst Reflexivity Reduction Universe Pi SimpleArr Var Application.
 
 Set Universe Polymorphism.

--- a/theories/Validity/Introductions/Id.v
+++ b/theories/Validity/Introductions/Id.v
@@ -1,5 +1,6 @@
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Irrelevance Weakening Neutral Transitivity Reduction Application Universe Id EqRedRight NormalRed InstKripke.
+From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Irrelevance Weakening Neutral Transitivity Reduction EqRedRight NormalRed InstKripke.
+From LogRel.LogicalRelation.Introductions Require Import Universe Id.
 From LogRel.Validity Require Import Validity Irrelevance Properties Conversion SingleSubst Reflexivity Reduction Universe Var Poly.
 
 Set Universe Polymorphism.

--- a/theories/Validity/Introductions/Lambda.v
+++ b/theories/Validity/Introductions/Lambda.v
@@ -1,5 +1,5 @@
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Neutral Weakening Irrelevance Application Reduction Transitivity NormalRed EqRedRight InstKripke.
+From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Neutral Weakening Irrelevance Introductions.Application Reduction Transitivity NormalRed EqRedRight InstKripke.
 From LogRel.Validity Require Import Validity Irrelevance Properties SingleSubst Reflexivity Conversion Reduction Pi Application Var.
 
 Set Universe Polymorphism.

--- a/theories/Validity/Introductions/Nat.v
+++ b/theories/Validity/Introductions/Nat.v
@@ -1,5 +1,6 @@
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction  Escape Irrelevance Reflexivity Irrelevance Weakening Neutral Transitivity Reduction Application Universe EqRedRight SimpleArr.
+From LogRel.LogicalRelation Require Import Induction  Escape Irrelevance Reflexivity Irrelevance Weakening Neutral Transitivity Reduction EqRedRight.
+From LogRel.LogicalRelation.Introductions Require Import Universe SimpleArr Application.
 From LogRel.Validity Require Import Validity Irrelevance Properties Conversion SingleSubst Reflexivity Reduction Universe Pi SimpleArr Var Application.
 
 Set Universe Polymorphism.

--- a/theories/Validity/Introductions/Sigma.v
+++ b/theories/Validity/Introductions/Sigma.v
@@ -1,7 +1,7 @@
 From Coq Require Import ssrbool CRelationClasses.
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Irrelevance Weakening Neutral Transitivity Reduction Application Universe EqRedRight SimpleArr NormalRed InstKripke.
-From LogRel.LogicalRelation.Introductions Require Import Poly.
+From LogRel.LogicalRelation Require Import Induction Escape Reflexivity Irrelevance Weakening Neutral Transitivity Reduction EqRedRight NormalRed InstKripke.
+From LogRel.LogicalRelation.Introductions Require Import Application Universe Poly.
 From LogRel.Validity Require Import Validity Irrelevance Properties Conversion SingleSubst Reflexivity Reduction Universe Poly.
 
 

--- a/theories/Validity/Introductions/SimpleArr.v
+++ b/theories/Validity/Introductions/SimpleArr.v
@@ -1,6 +1,6 @@
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
 From LogRel.LogicalRelation Require Import Escape Reflexivity Neutral Weakening Irrelevance.
-From LogRel.Validity Require Import Validity Irrelevance Properties Pi Application Lambda Var.
+From LogRel.Validity Require Import Validity Irrelevance Properties Pi Application Var.
 
 Set Universe Polymorphism.
 

--- a/theories/Validity/Introductions/Universe.v
+++ b/theories/Validity/Introductions/Universe.v
@@ -1,5 +1,5 @@
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity Reduction Universe.
+From LogRel.LogicalRelation Require Import Induction Irrelevance Escape Reflexivity Weakening Neutral Transitivity Introductions.Universe.
 From LogRel.Validity Require Import Validity Irrelevance Properties Conversion Reflexivity.
 
 Set Universe Polymorphism.

--- a/theories/Validity/Introductions/Var.v
+++ b/theories/Validity/Introductions/Var.v
@@ -1,6 +1,6 @@
 (** * LogRel.Introductions.Var : Validity of variables. *)
 From LogRel Require Import Utils Syntax.All GenericTyping LogicalRelation.
-From LogRel.LogicalRelation Require Import Escape Irrelevance Reflexivity Transitivity Universe Weakening Neutral Induction NormalRed.
+From LogRel.LogicalRelation Require Import Escape Irrelevance Reflexivity Transitivity Introductions.Universe Weakening Neutral Induction NormalRed.
 From LogRel.Validity Require Import Validity Irrelevance Properties Conversion Reflexivity SingleSubst Escape.
 
 Set Universe Polymorphism.


### PR DESCRIPTION
#66 broke the dependency graph. The root cause is that apparently `coqdep` is not smart enough to disambiguate that `From LogRel.LogicalRelation Require Import Universe.` creates a dependency of the current file on `LogicalRelation.Introductions.Universe`. Not sure whether this is something worth reporting on the Coq side… Anyway, this is fixed the dumb way by doing more qualified names in all imports.

I also took the liberty to clean-up some unnecessary dependencies, too. Maybe at some point we should run Jason's dependency minimisation script? Or even try to untangle a bit the big knot that is the dependency graph of the logical relation? I really have no clue of what's happening there.