### PR TITLE
change pattern for push branches in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
-      - 'coq.*'
-      - 'rocq.*'
+      - 'coq-*'
+      - 'rocq-*'
 
 permissions:
   contents: read


### PR DESCRIPTION
The branches of the repo are following `coq-*` pattern rather than `coq.*`