### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Parts of the formalisation has been described in the following papers:
 - [*What does it take to certify conversion?*](https://arxiv.org/abs/2502.15500) focuses more on the verification of the properties of the algorithms, including the term-directed one.
 
 The project has also been used as a base for the following work:
+- [*Definitional Functoriality for Dependent (Sub)Types*](https://hal.science/hal-04160858v3), which extends the type system with lists and a definitionally functorial map operator (with applications to subtyping for dependent types);
 - [*“Upon This Quote I Will Build My Church Thesis”*](https://dl.acm.org/doi/10.1145/3661814.3662070), which extends the type system with primitives for quoting;
 - [*Continuity in Type Theory*, Chapter 4](https://theses.hal.science/tel-04617881v1), which extends the system with sheaf-like conditions to obtain continuity properties.
 
@@ -75,7 +76,7 @@ Proof.
 
 End Section.
 ```
-The names of the arguments printed when querying `About XXXInductionConcl` should make it clear 
+The names of the arguments printed when querying `About XXXInductionConcl` should make it clear
 to which mutually-defined relation each predicate corresponds.
 
 [Utils]: ./theories/Utils.v

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Utilities
 Syntax
 --------
 
-Primarily in the [Syntax]() folder, contains definitions related to the syntax of terms, independent of typing: contexts, untyped reduction, normal forms, weakenings… See also the [AutoSubst]() folder, which contains everything related to the [AutoSubst] tool.
+Primarily in the [Syntax](https://github.com/CoqHott/logrel-coq/tree/coq-8.20/theories/Syntax) folder, contains definitions related to the syntax of terms, independent of typing: contexts, untyped reduction, normal forms, weakenings… See also the [AutoSubst](https://github.com/CoqHott/logrel-coq/tree/coq-8.20/theories/AutoSubst) folder, which contains everything related to the [AutoSubst] tool.
 
 [Syntax.BasicAst] | Definitions preceding those of the AST of terms (for now, only sorts)
 [AutoSubst.Ast] | Abstract syntax tree, definitions of renamings, substitutions and many lemmas. Generated using the [AutoSubst] tool.
@@ -28,7 +28,7 @@ Primarily in the [Syntax]() folder, contains definitions related to the syntax o
 Basic typing-related definitions and properties
 -------
 
-Primarily in the [Typing]() folder. We gather the important properties of typing in [TypingProperties.PropertiesDefinition], then derive their consequences in a series of files. Finally, we show that these properties are consequences of the fundamental lemma of the (proper instantiations of the) logical relation in [TypingProperties.LogRelConsequences]. This file also contains derivations of important meta-theoretic properties such as canonicity, consistency…
+Primarily in the [Typing](https://github.com/CoqHott/logrel-coq/tree/coq-8.20/theories/Typing) folder. We gather the important properties of typing in [TypingProperties.PropertiesDefinition], then derive their consequences in a series of files. Finally, we show that these properties are consequences of the fundamental lemma of the (proper instantiations of the) logical relation in [TypingProperties.LogRelConsequences]. This file also contains derivations of important meta-theoretic properties such as canonicity, consistency…
 
 | File | Description |
 |---|----|
@@ -41,9 +41,9 @@ Primarily in the [Typing]() folder. We gather the important properties of typing
 Logical relation
 -----------
 
-The files in the [LogicalRelation.Definition]() folder give the definition of each of the cases of the logical relation, which are assembled in [LogicalRelation.Def]. Files in the [LogicalRelation]() folder derive general properties of the logical relation, and those in [LogicalRelation.Introductions]() derive the reducibility some term formers.
+The files in the [LogicalRelation.Definition](https://github.com/CoqHott/logrel-coq/tree/coq-8.20/theories/LogicalRelation/Definition) folder give the definition of each of the cases of the logical relation, which are assembled in [LogicalRelation.Def]. Files in the [LogicalRelation](https://github.com/CoqHott/logrel-coq/tree/coq-8.20/theories/LogicalRelation) folder derive general properties of the logical relation, and those in [LogicalRelation.Introductions](https://github.com/CoqHott/logrel-coq/tree/coq-8.20/theories/LogicalRelation/Introductions) derive the reducibility some term formers.
 
-However the logical relation as defined in [LogicalRelation.Def] is not a model of typing, only its closure under reducible substitution is. This is defined in [Validity.Validity], and the remaining properties are proven in the [LogRel.Validity]() folder.
+However the logical relation as defined in [LogicalRelation.Def] is not a model of typing, only its closure under reducible substitution is. This is defined in [Validity.Validity], and the remaining properties are proven in the [LogRel.Validity](https://github.com/CoqHott/logrel-coq/tree/coq-8.20/theories/Validity) folder.
 
 Finally, [Fundamental] derives the fundamental theorem of the logical relation. Note that only [TypingProperties.LogRelConsequences] directly uses this fundamental lemma. All other files only use the properties in [TypingProperties.PropertiesDefinition] instead.
 
@@ -63,22 +63,20 @@ The second big part of the formalisation explores algorithmic presentations of t
 
 | File | Description |
 |---|----|
-[AlgorithmicTyping] | Definition of type-directed conversion and algorithmic typing, as inductive predicates.
-[Algorithmic.UntypedConversion] | Alternative, fully term-directed conversion checking algorithm, as inductive predicate.
+[AlgorithmicJudgments] | Definition of type-directed and untyped conversion and algorithmic typing, as inductive predicates.
 [Algorithmic.Bundled] | Algorithmic judgments bundled with their pre-conditions, and tailored induction principles showing invariant preservation in the "algorithm".
 
 
 Implementations
 ----------------
 
-The various functions for conversion-checking and type-checking are defined and verified in the [Decidability]() folder.
+The various functions for conversion-checking and type-checking are defined and verified in the [Checkers]() folder.
 
 | File | Description |
 |---|----|
-[Decidability.Functions] | Definition of the conversion and type-checker.
-[Decidability.UntypedFunctions] | Implementation of untyped conversion.
-[Decidability.Decidability] | Type-checking is decidable.
-[Decidability.Execution] | Example executions of the type checker, in Coq.
+[Checkers.Functions] | Definition of the conversion and type-checker (both type-directed and term-directed).
+[Decidability] | Type-checking is decidable.
+[Checkers.Execution] | Example executions of the type checker, in Coq.
 
 Miscellaneous
 ----------------------
@@ -92,10 +90,11 @@ The [Misc]() folder contains files that are not strictly necessary for the devel
 
 
 [Utils]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Utils.html
+[PERTactics]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.PERTactics.html
 [Syntax.BasicAst]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Syntax.BasicAst.html
 [Context]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Context.html
 [AutoSubst.Extra]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.AutoSubst.Extra.html
-[AutoSubst.Ast]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.AutoSubst.Extra.html
+[AutoSubst.Ast]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.AutoSubst.Ast.html
 [Notations]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Notations.html
 [Syntax.NormalForms]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Syntax.NormalForms.html
 [Syntax.UntypedReduction]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Syntax.UntypedReduction.html
@@ -103,21 +102,19 @@ The [Misc]() folder contains files that are not strictly necessary for the devel
 [DeclarativeTyping]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.DeclarativeTyping.html
 [TypingProperties.DeclarativeInstance]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.TypingProperties.DeclarativeInstance.html
 [TypingProperties.PropertiesDefinition]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.TypingProperties.PropertiesDefinition.html
-[TypingProperties.LogRelConsequences]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.TypingProperties.LogConsequences.html
+[TypingProperties.LogRelConsequences]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.TypingProperties.LogRelConsequences.html
 
-[LogicalRelation.Def]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.LogicalRelation.Def.html
+[LogicalRelation.Def]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.LogicalRelation.Definition.Def.html
 [LogicalRelation.Induction]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.LogicalRelation.Induction.html
 [LogicalRelation.Escape]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.LogicalRelation.Escape.html
 [Validity.Validity]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Validity.Validity.html
 [Fundamental]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Fundamental.html
 
-[AlgorithmicTyping]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.AlgorithmicTyping.html
-[Algorithmic.UntypedConversion]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Algorithmic.UntypedConversion.html
+[AlgorithmicJudgments]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.AlgorithmicJudgments.html
 [Algorithmic.Bundled]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Algorithmic.Bundled.html
 
-[Decidability.Functions]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Decidability.Functions.html
-[Decidability.UntypedFunctions]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Algorithmic.Bundled.html
-[Decidability.Decidability]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Algorithmic.Decidability.html
-[Decidability.Execution]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Algorithmic.Execution.html
+[Checkers.Functions]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Checkers.Functions.html
+[Decidability]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Decidability.html
+[Checkers.Execution]: https://coqhott.github.io/logrel-coq/coqdoc/LogRel.Checkers.Execution.html
 
 [AutoSubst]: https://github.com/uds-psl/autosubst-ocaml


### PR DESCRIPTION
The links on the [documentation page](https://coqhott.github.io/logrel-coq/) are mostly wrong.
I (temporarily) hard-coded the links to the directories to redirect to the current main branch (`coq-8.20`) but it would be better to substitute the right branch version when generating the doc.